### PR TITLE
Drop sentinel echo from req_open_orders snapshot (#160)

### DIFF
--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -499,6 +499,15 @@ impl CcpState {
             base.parse::<u64>().ok()
         }).unwrap_or(0);
 
+        // Drop the gateway's echo of the mass-order-status wildcard request
+        // (ClOrdID="*"/"0"/absent → parses to 0). Real orders are assigned
+        // monotonic IDs via next_order_id and never collide with 0.
+        if clord_id == 0 {
+            log::debug!("ExecReport: dropping sentinel record (ClOrdID=0/*) sym={:?} status={:?}",
+                parsed.get(&55), parsed.get(&39));
+            return;
+        }
+
         // What-If response
         if parsed.get(&6091).map(|s| s.as_str()) == Some("1") {
             let init_margin_after = parsed.get(&6092).and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);

--- a/tests/python/test_issue_160.py
+++ b/tests/python/test_issue_160.py
@@ -1,0 +1,92 @@
+"""IBX Test #160: req_open_orders must not surface gateway sentinel records.
+
+Regression: the mass-order-status request sent on (re)connect uses ClOrdID="*",
+Symbol="*". The gateway's reply burst includes an echo of that wildcard with
+ClOrdID=0 / Symbol="*" / Qty=0 that was being parsed as if it were a real
+order, then surfaced through wrapper.open_order.
+
+Run: pytest tests/python/test_issue_160.py -v --timeout=60
+"""
+
+import os
+import threading
+import time
+
+import pytest
+from ibx import EClient, EWrapper
+
+
+pytestmark = pytest.mark.skipif(
+    not (os.environ.get("IB_USERNAME") and os.environ.get("IB_PASSWORD")),
+    reason="IB_USERNAME and IB_PASSWORD not set",
+)
+
+
+class CollectorWrapper(EWrapper):
+    def __init__(self):
+        super().__init__()
+        self.connected = threading.Event()
+        self.next_id = 0
+        self.open_orders_batch = []
+        self.got_open_order_end = threading.Event()
+
+    def next_valid_id(self, order_id):
+        self.next_id = order_id
+        self.connected.set()
+
+    def managed_accounts(self, accounts_list):
+        pass
+
+    def connect_ack(self):
+        pass
+
+    def open_order(self, order_id, contract, order, order_state):
+        self.open_orders_batch.append((order_id, contract.symbol, order_state.status))
+
+    def open_order_end(self):
+        self.got_open_order_end.set()
+
+    def error(self, req_id, error_code, error_string, advanced_order_reject_json=""):
+        if error_code not in (2104, 2106, 2158, 202):
+            print(f"  [error] oid={req_id} code={error_code}: {error_string}")
+
+
+class TestOpenOrdersNoSentinel:
+    @pytest.fixture(autouse=True)
+    def setup_connection(self):
+        self.wrapper = CollectorWrapper()
+        self.client = EClient(self.wrapper)
+        self.client.connect(
+            username=os.environ["IB_USERNAME"],
+            password=os.environ["IB_PASSWORD"],
+            host=os.environ.get("IB_HOST", "cdc1.ibllc.com"),
+            paper=True,
+        )
+        self.thread = threading.Thread(target=self.client.run, daemon=True)
+        self.thread.start()
+        assert self.wrapper.connected.wait(timeout=15), "Connection failed"
+        yield
+        self.client.disconnect()
+        self.thread.join(timeout=5)
+
+    def _snapshot_open(self):
+        self.wrapper.open_orders_batch = []
+        self.wrapper.got_open_order_end.clear()
+        self.client.req_open_orders()
+        assert self.wrapper.got_open_order_end.wait(timeout=15), "open_order_end never fired"
+        return list(self.wrapper.open_orders_batch)
+
+    def test_no_wildcard_sentinel_in_open_orders(self):
+        # Let the post-connect mass-status burst drain into order_cache.
+        time.sleep(5.0)
+
+        for snapshot in (self._snapshot_open(), self._snapshot_open()):
+            for order_id, symbol, status in snapshot:
+                assert order_id != 0, (
+                    f"sentinel ClOrdID=0 leaked into req_open_orders: "
+                    f"sym={symbol!r} status={status!r}"
+                )
+                assert symbol not in ("", "*"), (
+                    f"sentinel symbol {symbol!r} leaked into req_open_orders: "
+                    f"order_id={order_id} status={status!r}"
+                )


### PR DESCRIPTION
## Summary

Fixes the sentinel half of #160. The post-connect mass-order-status request sends `ClOrdID="*"` and the gateway's reply burst includes an echo with `ClOrdID=0 / Symbol="*" / Qty=0`. `handle_exec_report` parsed tag 11 with `unwrap_or(0)` then walked the rest of the function, writing the synthetic record into `order_cache` where it surfaced through `wrapper.open_order` as `id=0 sym="*" status="Submitted" qty=0`.

Real orders are assigned monotonic IDs via `next_order_id` and never collide with 0, so an early return on `clord_id == 0` drops only the echo.

**Out of scope** — the other half of #160 (the 31 "Submitted" SPY orders that TWS does not show) is left open. The issue's diagnosis of stale prior-session entries is incorrect (`order_cache` is in-memory, empty per connect), so the gateway is actively reporting those as `39=0` Submitted in this session — needs a raw FIX capture before any code change.

## Test plan

- [ ] `pytest tests/python/test_issue_160.py -v --timeout=60` against paper account — passes (no `order_id=0` / `symbol="*"` entries surface across two snapshots).
- [ ] `pytest tests/python/test_issue_159.py -v --timeout=120` — still passes (regression check on the closed-order filter).
- [ ] `cargo check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)