### PR TITLE
Reconcile order_cache on cancel-reject (#160)

### DIFF
--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -865,32 +865,52 @@ impl CcpState {
         shared: &SharedState,
         event_tx: &Option<Sender<Event>>,
     ) {
-        let orig_clord = parsed.get(&41).and_then(|s| s.parse::<u64>().ok());
+        // Match handle_exec_report's tag-11 parsing: strip the gateway's
+        // "C" prefix and any ".0/.1/.2" modify-chain suffix.
+        let orig_clord = parsed.get(&41).and_then(|s| {
+            let stripped = s.strip_prefix('C').unwrap_or(s);
+            let base = stripped.split('.').next().unwrap_or(stripped);
+            base.parse::<u64>().ok()
+        });
         let reason = parsed.get(&58).map(|s| s.as_str()).unwrap_or("Cancel rejected");
         let reject_type: u8 = parsed.get(&434).and_then(|s| s.parse().ok()).unwrap_or(1);
         let reason_code: i32 = parsed.get(&102).and_then(|s| s.parse().ok()).unwrap_or(-1);
         log::warn!("CancelReject: origClOrd={:?} type={} code={} reason={}",
             orig_clord, reject_type, reason_code, reason);
 
-        if let Some(oid) = orig_clord {
-            if let Some(order) = context.order(oid).copied() {
-                let restore_status = if order.filled > 0 {
-                    crate::types::OrderStatus::PartiallyFilled
-                } else {
-                    crate::types::OrderStatus::Submitted
-                };
-                context.update_order_status(oid, restore_status);
-                let reject = crate::types::CancelReject {
-                    order_id: oid,
-                    instrument: order.instrument,
-                    reject_type,
-                    reason_code,
-                    timestamp_ns: context.now_ns(),
-                };
-                shared.orders.push_cancel_reject(reject);
-                emit(event_tx, Event::CancelReject(reject));
-            }
+        let Some(oid) = orig_clord else { return };
+
+        // Update local context only if we tracked the order in this session.
+        let instrument = if let Some(order) = context.order(oid).copied() {
+            let restore_status = if order.filled > 0 {
+                crate::types::OrderStatus::PartiallyFilled
+            } else {
+                crate::types::OrderStatus::Submitted
+            };
+            context.update_order_status(oid, restore_status);
+            order.instrument
+        } else {
+            0
+        };
+
+        // FIX CxlRejReason 1 = UnknownOrder. The gateway is telling us the
+        // order it just listed in the mass-status burst doesn't exist on its
+        // side — drop the stale cache entry so subsequent req_open_orders
+        // stops returning it. Other reasons (TooLate, OrderInProcess, ...)
+        // leave the cache alone; a follow-up exec report will reconcile.
+        if reason_code == 1 {
+            shared.orders.remove_order_info(oid);
         }
+
+        let reject = crate::types::CancelReject {
+            order_id: oid,
+            instrument,
+            reject_type,
+            reason_code,
+            timestamp_ns: context.now_ns(),
+        };
+        shared.orders.push_cancel_reject(reject);
+        emit(event_tx, Event::CancelReject(reject));
     }
 
     fn handle_news_bulletin(&mut self, parsed: &std::collections::HashMap<u32, String>, shared: &SharedState) {

--- a/tests/python/test_issue_160_cancel_reject.py
+++ b/tests/python/test_issue_160_cancel_reject.py
@@ -1,0 +1,167 @@
+"""IBX Test #160 second-half: cancel-reject reconciliation.
+
+Regression: when the gateway rejects a cancel for an order it had previously
+listed in the post-connect mass-status burst (CxlRejReason=1, "No such
+order"), IBX must:
+
+  - parse OrigClOrdID (tag 41) correctly despite the gateway's "C" prefix
+    and ".0/.1/.2" modify-chain suffix,
+  - surface the reject through wrapper.error (code 202),
+  - purge the stale entry from order_cache so subsequent req_open_orders
+    stops returning it.
+
+Pre-fix: tag 41 was parsed without the prefix/suffix strip → orig_clord
+was None → no reject pushed → silent. order_cache was untouched, so
+req_open_orders kept returning the stale entry forever.
+
+Run: pytest tests/python/test_issue_160_cancel_reject.py -v --timeout=120
+"""
+
+import os
+import threading
+import time
+
+import pytest
+from ibx import EClient, EWrapper
+
+
+pytestmark = pytest.mark.skipif(
+    not (os.environ.get("IB_USERNAME") and os.environ.get("IB_PASSWORD")),
+    reason="IB_USERNAME and IB_PASSWORD not set",
+)
+
+
+class CollectorWrapper(EWrapper):
+    def __init__(self):
+        super().__init__()
+        self.connected = threading.Event()
+        self.next_id = 0
+        self.open_orders_batch = []
+        self.got_open_order_end = threading.Event()
+        self.statuses = []
+        self.errors = []
+
+    def next_valid_id(self, order_id):
+        self.next_id = order_id
+        self.connected.set()
+
+    def managed_accounts(self, accounts_list):
+        pass
+
+    def connect_ack(self):
+        pass
+
+    def open_order(self, order_id, contract, order, order_state):
+        self.open_orders_batch.append((order_id, contract.symbol, order_state.status))
+
+    def open_order_end(self):
+        self.got_open_order_end.set()
+
+    def order_status(self, order_id, status, filled, remaining, avg_fill_price,
+                     perm_id, parent_id, last_fill_price, client_id, why_held, mkt_cap_price):
+        self.statuses.append((order_id, status))
+
+    def error(self, req_id, error_code, error_string, advanced_order_reject_json=""):
+        if error_code in (2104, 2106, 2158, 202):
+            # 202 IS the cancel-reject we may want; record it but also keep
+            # the noise filters in sync with the other tests.
+            if error_code == 202:
+                self.errors.append((req_id, error_code, error_string))
+            return
+        self.errors.append((req_id, error_code, error_string))
+
+
+class TestCancelRejectReconcile:
+    @pytest.fixture(autouse=True)
+    def setup_connection(self):
+        self.wrapper = CollectorWrapper()
+        self.client = EClient(self.wrapper)
+        self.client.connect(
+            username=os.environ["IB_USERNAME"],
+            password=os.environ["IB_PASSWORD"],
+            host=os.environ.get("IB_HOST", "cdc1.ibllc.com"),
+            paper=True,
+        )
+        self.thread = threading.Thread(target=self.client.run, daemon=True)
+        self.thread.start()
+        assert self.wrapper.connected.wait(timeout=15), "Connection failed"
+        # Drain post-connect CCP burst.
+        time.sleep(5.0)
+        yield
+        self.client.disconnect()
+        self.thread.join(timeout=5)
+
+    def _snapshot_open(self):
+        self.wrapper.open_orders_batch = []
+        self.wrapper.got_open_order_end.clear()
+        self.client.req_open_orders()
+        assert self.wrapper.got_open_order_end.wait(timeout=15), "open_order_end never fired"
+        return list(self.wrapper.open_orders_batch)
+
+    def test_cancel_reject_surfaces_and_purges_cache(self):
+        """Walk the open-orders snapshot, cancelling each order until one
+        produces a 202 cancel-reject error (the bug's signature path), then
+        assert the rejected order is absent from the next snapshot.
+
+        Pre-fix: handle_cancel_reject failed to parse tag 41 (C-prefix +
+        version suffix not stripped), so no 202 was ever emitted and the
+        cache was never purged on reject.
+        """
+        snap_before = self._snapshot_open()
+        if not snap_before:
+            pytest.skip("paper account has no open orders to test cancel against")
+
+        # Cap the candidate walk so a regression (no 202 ever emitted) fails
+        # within the test timeout instead of running through the whole snapshot.
+        rejected_id = None
+        for candidate_id, _, _ in snap_before[:10]:
+            self.wrapper.statuses = []
+            self.wrapper.errors = []
+            self.client.cancel_order(candidate_id, "")
+
+            # Wait briefly for resolution. The gateway responds within ~1s
+            # for stale-order rejects; some IDs simply don't respond, so we
+            # try the next candidate.
+            deadline = time.time() + 3
+            while time.time() < deadline:
+                if any(e[0] == candidate_id and e[1] == 202 for e in self.wrapper.errors):
+                    rejected_id = candidate_id
+                    break
+                if any(s[0] == candidate_id and s[1] in ("Cancelled", "ApiCancelled", "Inactive")
+                       for s in self.wrapper.statuses):
+                    # Genuine cancel ack — not the reject path we want to test.
+                    break
+                time.sleep(0.1)
+
+            if rejected_id is not None:
+                break
+
+        if rejected_id is None:
+            # Pre-fix this is the bug's signature: cancel-reject was silently
+            # swallowed for every candidate, no 202 ever emitted. Distinguish
+            # from "no stale entries" by asserting at least one of the
+            # candidates is still in the cache (i.e. the gateway responded
+            # but we ignored it).
+            still_present = [c for c, _, _ in snap_before[:10]
+                             if any(o[0] == c for o in self._snapshot_open())]
+            assert not still_present, (
+                f"cancelled {len(snap_before[:10])} candidates but received "
+                f"no 202 cancel-rejects; {len(still_present)} are still in "
+                f"req_open_orders. handle_cancel_reject is silently swallowing "
+                f"the gateway's reject. still-present sample: {still_present[:3]}"
+            )
+            pytest.skip(
+                "no 202 cancel-reject produced and no stale entries to test "
+                "against — paper account has only live orders that all cancelled "
+                "normally. Run scripts/.tmp/discriminator_issue_160.py to verify "
+                "the engine path manually if needed."
+            )
+
+        # Brief drain so any post-cancel CCP updates settle, then assert the
+        # rejected entry was removed from order_cache.
+        time.sleep(1.0)
+        snap_after = self._snapshot_open()
+        assert not any(o[0] == rejected_id for o in snap_after), (
+            f"order {rejected_id} got a 202 cancel-reject but is still "
+            f"present in req_open_orders — order_cache was not purged."
+        )


### PR DESCRIPTION
## Summary

Fixes the second half of #160. After #161 dropped the wildcard-echo sentinel, the discriminator (cancel an entry from `req_open_orders`, observe the engine + next snapshot) showed the gateway rejects cancels for orders it had just listed in its mass-status burst — `CxlRejReason=1` ("No such order") — and IBX was silently swallowing those rejects, leaving the stale entries in `order_cache` forever.

Two bugs in `handle_cancel_reject` (`src/engine/hot_loop/ccp.rs:870`):

1. Tag 41 (OrigClOrdID) was parsed without the `C`-prefix and `.0/.1/.2` modify-chain-suffix strip that `handle_exec_report` applies to tag 11. The gateway encodes 41 the same way, so `orig_clord` parsed to `None` for every reject. Engine log: `CancelReject: origClOrd=None type=1 code=1 reason=No such order`.
2. Even when `orig_clord` was `Some`, the handler short-circuited unless the order was tracked in the local `context`. Mass-status-burst orders surface via `order_cache` without entering `context`, so their rejects were never pushed to `shared.orders.cancel_rejects`, the dispatch loop had nothing to forward, and `wrapper.error` never fired.

## Fix

- Parse tag 41 with `strip_prefix('C')` + version-suffix strip — same logic as `handle_exec_report`.
- Always push the `CancelReject` (and emit `Event::CancelReject`) when `orig_clord` is `Some`, regardless of whether the order is in local `context`. The local `context.update_order_status` path stays gated as before.
- On `reason_code == 1` (UnknownOrder), call `shared.orders.remove_order_info(oid)` to drop the stale cache entry. Other reasons leave the cache alone; a follow-up exec report will reconcile via the existing whitelist filter.

Behavior change worth flagging: `req_open_orders` will continue to surface the gateway's view (stale entries included) until the user attempts a cancel, at which point IBX self-heals on the reject. The cache won't grow past what the burst delivered.

## Test plan

- [x] `cargo check --lib` — clean.
- [x] `pytest tests/python/test_issue_160_cancel_reject.py -v --timeout=120` — passes (rejects a stale entry, asserts purge in next snapshot).
- [x] `pytest tests/python/test_issue_160.py tests/python/test_issue_159.py -v --timeout=120` — both still pass.
- [x] Verified test fails without the fix (silent-swallow signature triggers the still-present assertion path).
- [x] Discriminator (`scripts/.tmp/discriminator_issue_160.py`) confirms tag 41 now parses (`origClOrd=Some(...)`) and `order_cache` shrinks by 1 per successful reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)