### PR TITLE
Pass typed objects to callbacks instead of dicts (#167)

### DIFF
--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -14,7 +14,7 @@ use crate::api::types::{
     CommissionAndFeesReport as ApiCommissionAndFeesReport,
 };
 use super::EClient;
-use super::super::contract::{Contract, ContractDescription, ContractDetails, BarData, CommissionAndFeesReport, DepthMktDataDescriptionPy, Order, OrderState};
+use super::super::contract::{Contract, ContractDescription, ContractDetails, BarData, CommissionAndFeesReport, DepthMktDataDescriptionPy, Execution, Order, OrderState};
 use super::super::tick_types::*;
 use super::super::super::types::PRICE_SCALE_F;
 
@@ -118,23 +118,26 @@ impl EClient {
 
             let acct_name = self.account();
             let c_py = Py::new(py, exec_contract)?.into_any();
-            let exec_dict = pyo3::types::PyDict::new(py);
-            exec_dict.set_item("execId", exec_id.as_str())?;
-            exec_dict.set_item("time", now_str.as_str())?;
-            exec_dict.set_item("acctNumber", acct_name.as_str())?;
-            exec_dict.set_item("exchange", exec_exchange.as_str())?;
-            exec_dict.set_item("side", side_str)?;
-            exec_dict.set_item("price", price)?;
-            exec_dict.set_item("shares", fill.qty as f64)?;
-            exec_dict.set_item("orderId", fill.order_id as i64)?;
-            exec_dict.set_item("cumQty", cum_qty)?;
-            exec_dict.set_item("avgPrice", avg_price)?;
-            exec_dict.set_item("permId", perm_id)?;
-            exec_dict.set_item("clientId", 0i64)?;
-            exec_dict.set_item("liquidation", 0i64)?;
-            exec_dict.set_item("lastLiquidity", 0i64)?;
-            exec_dict.set_item("pendingPriceRevision", false)?;
-            call_wrapper!(self.wrapper, py, "exec_details", (req_id, &c_py, exec_dict.as_any()));
+            let exec_obj = Execution {
+                exec_id: exec_id.clone(),
+                time: now_str.clone(),
+                acct_number: acct_name,
+                exchange: exec_exchange.clone(),
+                side: side_str.to_string(),
+                shares: fill.qty as f64,
+                price,
+                perm_id,
+                client_id: 0,
+                order_id: fill.order_id as i64,
+                liquidation: 0,
+                cum_qty,
+                avg_price,
+                last_liquidity: 0,
+                pending_price_revision: false,
+                ..Default::default()
+            };
+            let exec_py = Py::new(py, exec_obj)?.into_any();
+            call_wrapper!(self.wrapper, py, "exec_details", (req_id, &c_py, &exec_py));
 
             // Update open order tracking
             self.core.update_order_fill(fill.order_id, status, fill.qty as f64, fill.remaining as f64);

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -11,7 +11,7 @@ use crate::api::types::{
 use crate::client_core::ClientCore;
 use crate::types::*;
 use super::EClient;
-use super::super::contract::{Contract, Order, CommissionAndFeesReport};
+use super::super::contract::{Contract, Order, CommissionAndFeesReport, Execution};
 
 #[pymethods]
 impl EClient {
@@ -195,30 +195,32 @@ impl EClient {
                 ..Default::default()
             })?.into_any();
 
-            let exec_obj = pyo3::types::PyDict::new(py);
-            exec_obj.set_item("execId", se.execution.exec_id.as_str())?;
-            exec_obj.set_item("time", se.execution.time.as_str())?;
-            exec_obj.set_item("acctNumber", se.execution.acct_number.as_str())?;
-            exec_obj.set_item("exchange", se.execution.exchange.as_str())?;
-            exec_obj.set_item("side", se.execution.side.as_str())?;
-            exec_obj.set_item("shares", se.execution.shares)?;
-            exec_obj.set_item("price", se.execution.price)?;
-            exec_obj.set_item("permId", se.execution.perm_id)?;
-            exec_obj.set_item("clientId", se.execution.client_id)?;
-            exec_obj.set_item("orderId", se.execution.order_id)?;
-            exec_obj.set_item("liquidation", se.execution.liquidation as i64)?;
-            exec_obj.set_item("cumQty", se.execution.cum_qty)?;
-            exec_obj.set_item("avgPrice", se.execution.avg_price)?;
-            exec_obj.set_item("orderRef", "")?;
-            exec_obj.set_item("evRule", se.execution.ev_rule.as_str())?;
-            exec_obj.set_item("evMultiplier", se.execution.ev_multiplier)?;
-            exec_obj.set_item("modelCode", se.execution.model_code.as_str())?;
-            exec_obj.set_item("lastLiquidity", se.execution.last_liquidity as i64)?;
-            exec_obj.set_item("pendingPriceRevision", se.execution.pending_price_revision)?;
+            let exec_obj = Execution {
+                exec_id: se.execution.exec_id.clone(),
+                time: se.execution.time.clone(),
+                acct_number: se.execution.acct_number.clone(),
+                exchange: se.execution.exchange.clone(),
+                side: se.execution.side.clone(),
+                shares: se.execution.shares,
+                price: se.execution.price,
+                perm_id: se.execution.perm_id,
+                client_id: se.execution.client_id,
+                order_id: se.execution.order_id,
+                liquidation: se.execution.liquidation,
+                cum_qty: se.execution.cum_qty,
+                avg_price: se.execution.avg_price,
+                order_ref: String::new(),
+                ev_rule: se.execution.ev_rule.clone(),
+                ev_multiplier: se.execution.ev_multiplier,
+                model_code: se.execution.model_code.clone(),
+                last_liquidity: se.execution.last_liquidity,
+                pending_price_revision: se.execution.pending_price_revision,
+            };
+            let exec_py = Py::new(py, exec_obj)?.into_any();
 
             self.wrapper.call_method(
                 py, "exec_details",
-                (req_id, &c_py, exec_obj.as_any()),
+                (req_id, &c_py, &exec_py),
                 None,
             )?;
 

--- a/src/python/compat/client/stubs.rs
+++ b/src/python/compat/client/stubs.rs
@@ -3,7 +3,7 @@
 use pyo3::prelude::*;
 
 use super::EClient;
-use super::super::contract::Contract;
+use super::super::contract::{Contract, NewsProviderPy, SmartComponentPy, SoftDollarTierPy};
 
 #[pymethods]
 impl EClient {
@@ -132,14 +132,16 @@ impl EClient {
         let _ = bbo_exchange;
         let shared = self.shared_state()?;
         let sc = shared.reference.smart_components();
-        let components = pyo3::types::PyList::new(py, sc.iter().map(|c| {
-            let dict = pyo3::types::PyDict::new(py);
-            dict.set_item("bitNumber", c.bit_number).unwrap();
-            dict.set_item("exchange", &c.exchange).unwrap();
-            dict.set_item("exchangeLetter", &c.exchange_letter).unwrap();
-            dict
-        }))?;
-        self.wrapper.call_method1(py, "smart_components", (req_id, components.as_any()))?;
+        let map = pyo3::types::PyDict::new(py);
+        for c in sc.iter() {
+            let obj = SmartComponentPy {
+                bit_number: c.bit_number,
+                exchange: c.exchange.clone(),
+                exchange_letter: c.exchange_letter.clone(),
+            };
+            map.set_item(c.bit_number, Py::new(py, obj)?)?;
+        }
+        self.wrapper.call_method1(py, "smart_components", (req_id, map.as_any()))?;
         Ok(())
     }
 
@@ -148,12 +150,12 @@ impl EClient {
     fn req_news_providers(&self, py: Python<'_>) -> PyResult<()> {
         let shared = self.shared_state()?;
         let np = shared.reference.news_providers();
-        let py_list = pyo3::types::PyList::new(py, np.iter().map(|p| {
-            let dict = pyo3::types::PyDict::new(py);
-            dict.set_item("code", &p.code).unwrap();
-            dict.set_item("name", &p.name).unwrap();
-            dict
-        }))?;
+        let mut providers: Vec<Py<NewsProviderPy>> = Vec::with_capacity(np.len());
+        for p in np.iter() {
+            let obj = NewsProviderPy { code: p.code.clone(), name: p.name.clone() };
+            providers.push(Py::new(py, obj)?);
+        }
+        let py_list = pyo3::types::PyList::new(py, providers)?;
         self.wrapper.call_method1(py, "news_providers", (py_list.as_any(),))?;
         Ok(())
     }
@@ -163,13 +165,16 @@ impl EClient {
     fn req_soft_dollar_tiers(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let shared = self.shared_state()?;
         let tiers = shared.reference.soft_dollar_tiers();
-        let py_list = pyo3::types::PyList::new(py, tiers.iter().map(|t| {
-            let dict = pyo3::types::PyDict::new(py);
-            dict.set_item("name", &t.name).unwrap();
-            dict.set_item("val", &t.val).unwrap();
-            dict.set_item("displayName", &t.display_name).unwrap();
-            dict
-        }))?;
+        let mut objs: Vec<Py<SoftDollarTierPy>> = Vec::with_capacity(tiers.len());
+        for t in tiers.iter() {
+            let obj = SoftDollarTierPy {
+                name: t.name.clone(),
+                val: t.val.clone(),
+                display_name: t.display_name.clone(),
+            };
+            objs.push(Py::new(py, obj)?);
+        }
+        let py_list = pyo3::types::PyList::new(py, objs)?;
         self.wrapper.call_method1(py, "soft_dollar_tiers", (req_id, py_list.as_any()))?;
         Ok(())
     }

--- a/src/python/compat/contract.rs
+++ b/src/python/compat/contract.rs
@@ -2,7 +2,6 @@
 
 use pyo3::prelude::*;
 use pyo3::exceptions::PyRuntimeError;
-use pyo3::types::PyDict;
 
 use crate::types::*;
 use super::super::types::PRICE_SCALE_F;
@@ -1401,11 +1400,12 @@ impl Order {
     fn get_smart_combo_routing_params_alias(&self) -> Vec<TagValue> { self.smart_combo_routing_params.clone() }
     #[getter(softDollarTier)]
     fn get_soft_dollar_tier(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let dict = PyDict::new(py);
-        dict.set_item("name", &self.soft_dollar_tier_name)?;
-        dict.set_item("val", &self.soft_dollar_tier_val)?;
-        dict.set_item("displayName", &self.soft_dollar_tier_display_name)?;
-        Ok(dict.into())
+        let tier = SoftDollarTierPy {
+            name: self.soft_dollar_tier_name.clone(),
+            val: self.soft_dollar_tier_val.clone(),
+            display_name: self.soft_dollar_tier_display_name.clone(),
+        };
+        Ok(Py::new(py, tier)?.into_any().into())
     }
     #[getter(startingPrice)]
     fn get_starting_price_alias(&self) -> f64 { self.starting_price }
@@ -2066,6 +2066,120 @@ impl ContractDetails {
     }
 }
 
+// ── Execution ──
+
+/// ibapi-compatible Execution class (used in exec_details callback).
+#[pyclass]
+#[derive(Clone, Debug, Default)]
+pub struct Execution {
+    #[pyo3(get, set)]
+    pub exec_id: String,
+    #[pyo3(get, set)]
+    pub time: String,
+    #[pyo3(get, set)]
+    pub acct_number: String,
+    #[pyo3(get, set)]
+    pub exchange: String,
+    #[pyo3(get, set)]
+    pub side: String,
+    #[pyo3(get, set)]
+    pub shares: f64,
+    #[pyo3(get, set)]
+    pub price: f64,
+    #[pyo3(get, set)]
+    pub perm_id: i64,
+    #[pyo3(get, set)]
+    pub client_id: i64,
+    #[pyo3(get, set)]
+    pub order_id: i64,
+    #[pyo3(get, set)]
+    pub liquidation: i32,
+    #[pyo3(get, set)]
+    pub cum_qty: f64,
+    #[pyo3(get, set)]
+    pub avg_price: f64,
+    #[pyo3(get, set)]
+    pub order_ref: String,
+    #[pyo3(get, set)]
+    pub ev_rule: String,
+    #[pyo3(get, set)]
+    pub ev_multiplier: f64,
+    #[pyo3(get, set)]
+    pub model_code: String,
+    #[pyo3(get, set)]
+    pub last_liquidity: i32,
+    #[pyo3(get, set)]
+    pub pending_price_revision: bool,
+}
+
+#[pymethods]
+impl Execution {
+    #[new]
+    #[pyo3(signature = ())]
+    fn new() -> Self { Self::default() }
+}
+
+// ── SmartComponent ──
+
+/// ibapi-compatible SmartComponent class.
+#[pyclass(name = "SmartComponent")]
+#[derive(Clone, Debug, Default)]
+pub struct SmartComponentPy {
+    #[pyo3(get, set)]
+    pub bit_number: i32,
+    #[pyo3(get, set)]
+    pub exchange: String,
+    #[pyo3(get, set)]
+    pub exchange_letter: String,
+}
+
+#[pymethods]
+impl SmartComponentPy {
+    #[new]
+    #[pyo3(signature = ())]
+    fn new() -> Self { Self::default() }
+}
+
+// ── NewsProvider ──
+
+/// ibapi-compatible NewsProvider class.
+#[pyclass(name = "NewsProvider")]
+#[derive(Clone, Debug, Default)]
+pub struct NewsProviderPy {
+    #[pyo3(get, set)]
+    pub code: String,
+    #[pyo3(get, set)]
+    pub name: String,
+}
+
+#[pymethods]
+impl NewsProviderPy {
+    #[new]
+    #[pyo3(signature = ())]
+    fn new() -> Self { Self::default() }
+}
+
+// ── SoftDollarTier ──
+
+/// ibapi-compatible SoftDollarTier class.
+#[pyclass(name = "SoftDollarTier")]
+#[derive(Clone, Debug, Default)]
+pub struct SoftDollarTierPy {
+    #[pyo3(get, set)]
+    pub name: String,
+    #[pyo3(get, set)]
+    pub val: String,
+    #[pyo3(get, set)]
+    pub display_name: String,
+}
+
+#[pymethods]
+impl SoftDollarTierPy {
+    #[new]
+    #[pyo3(signature = ())]
+    fn new() -> Self { Self::default() }
+}
+
 // ── CommissionAndFeesReport ──
 
 /// ibapi-compatible CommissionAndFeesReport class.
@@ -2173,6 +2287,10 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ContractDetails>()?;
     m.add_class::<ContractDescription>()?;
     m.add_class::<CommissionAndFeesReport>()?;
+    m.add_class::<Execution>()?;
+    m.add_class::<SmartComponentPy>()?;
+    m.add_class::<NewsProviderPy>()?;
+    m.add_class::<SoftDollarTierPy>()?;
     m.add_class::<DepthMktDataDescriptionPy>()?;
     Ok(())
 }

--- a/tests/python/test_bridge_integration.py
+++ b/tests/python/test_bridge_integration.py
@@ -503,8 +503,8 @@ class TestFillDispatch:
         exec_events = [e for e in w.events if e[0] == "exec_details"]
         assert len(exec_events) == 1
         execution = exec_events[0][3]
-        assert execution["side"] == "SELL"
-        assert abs(execution["price"] - 200.0) < 0.01
+        assert execution.side == "SELL"
+        assert abs(execution.price - 200.0) < 0.01
 
     def test_short_sell(self):
         w, c = make_test_client()
@@ -514,7 +514,7 @@ class TestFillDispatch:
         c._test_dispatch_once()
 
         exec_events = [e for e in w.events if e[0] == "exec_details"]
-        assert exec_events[0][3]["side"] == "SSHORT"
+        assert exec_events[0][3].side == "SSHORT"
 
     def test_exec_details_has_required_keys(self):
         w, c = make_test_client()
@@ -525,11 +525,11 @@ class TestFillDispatch:
 
         exec_events = [e for e in w.events if e[0] == "exec_details"]
         execution = exec_events[0][3]
-        assert "execId" in execution
-        assert "side" in execution
-        assert "price" in execution
-        assert "shares" in execution
-        assert "time" in execution
+        assert hasattr(execution, "exec_id")
+        assert hasattr(execution, "side")
+        assert hasattr(execution, "price")
+        assert hasattr(execution, "shares")
+        assert hasattr(execution, "time")
 
 
 class TestOrderUpdateDispatch:
@@ -1023,7 +1023,7 @@ class TestScenarios:
 
         execs = [e for e in w.events if e[0] == "exec_details"]
         assert len(execs) == 1
-        assert execs[0][3]["side"] == "BUY"
+        assert execs[0][3].side == "BUY"
 
     def test_partial_fill_then_cancel(self):
         """Partial fill → cancel → verify statuses."""


### PR DESCRIPTION
## Summary

- `exec_details(req_id, contract, execution)` was delivering a `PyDict` for `execution`, breaking iso with the upstream API where `execution` is an object with attribute access. User code following upstream patterns hit `AttributeError`.
- Same dict-as-object shape mismatch existed in `smart_components`, `news_providers`, `soft_dollar_tiers`, and the `Order.softDollarTier` getter.
- Adds `Execution`, `SmartComponent`, `NewsProvider`, `SoftDollarTier` pyclasses and updates all six call sites to construct typed objects.
- `smart_components` additionally switches from `list[dict]` to `dict[int, SmartComponent]` keyed by `bit_number` to match the upstream `SmartComponentMap` shape.

## Sites fixed

| # | Location | Callback / API |
|---|----------|----------------|
| 1 | `client/dispatch.rs:121` | `exec_details` (live fill) |
| 2 | `client/orders.rs:198` | `exec_details` (`req_executions` replay) |
| 3 | `client/stubs.rs` | `smart_components` |
| 4 | `client/stubs.rs` | `news_providers` |
| 5 | `client/stubs.rs` | `soft_dollar_tiers` |
| 6 | `compat/contract.rs:1404` | `Order.softDollarTier` getter |

The remaining `PyDict` returns in `account.rs` and `market_data.rs` are intentional — explicit dict-returning fast-path accessors outside the upstream API surface.

## Test plan

- [x] `cargo build --release` — 0 errors
- [x] Offline tests directly exercising changed code: `TestFillDispatch` (5/5), fill+order-place scenarios (5/5), `req_executions_*` (3/3) — all PASS
- [x] Updated `test_bridge_integration.py` dict-style assertions to attribute access (`execution.side`, `hasattr(execution, "exec_id")`, etc.)
- [x] Verified the 23 pre-existing test failures are identical between `main` HEAD and this branch — none introduced
- [x] Live paper-account validation: premarket BUY/SELL roundtrip produced 4 `exec_details` calls (2 live + 2 replay), zero `AttributeError`, `type(execution).__name__ == "Execution"` confirmed

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)