### PR TITLE
Add IBKey Challenge/Response 2FA code provider (#176)

### DIFF
--- a/bench/bench_harness.rs
+++ b/bench/bench_harness.rs
@@ -83,6 +83,7 @@ impl BenchSession {
             accept_invalid_certs: false,
             ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
             ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+            code_provider: None,
         };
 
         let connect_start = Instant::now();

--- a/examples/ex151_srp_fallback.rs
+++ b/examples/ex151_srp_fallback.rs
@@ -28,6 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     };
 
     println!("== Connecting to paper {} ...", host);

--- a/examples/ex176_live_2fa_code_provider.rs
+++ b/examples/ex176_live_2fa_code_provider.rs
@@ -1,0 +1,98 @@
+//! Verify issue #176: live login through the Challenge/Response variant of the
+//! second-factor approval gate. Instead of tapping Approve on the mobile push,
+//! the example reads the 8-character code from stdin and submits it.
+//!
+//! Run:
+//!   $env:RUST_LOG="info"; cargo run --release --example ex176_live_2fa_code_provider
+//!
+//! Requires `IB_LIVE_USERNAME` / `IB_LIVE_PASSWORD` in `.env` (auto-loaded).
+//! When the IBKey app shows the 8-char code, type it at the prompt.
+//!
+//! Note: one wrong code is terminal — the server skips AUTH_FINISH and tears
+//! the socket down (ib-agent#149). There is no retry loop.
+
+use std::env;
+use std::fs;
+use std::io::{self, BufRead, Write};
+use std::sync::Arc;
+use std::time::Instant;
+
+use ibx::auth::session::{self, CodeProvider, IbKeyChallenge};
+use ibx::gateway::{Gateway, GatewayConfig};
+use zeroize::Zeroizing;
+
+/// Minimal `.env` loader (KEY=VALUE per line, `#` comments, no quoting tricks).
+fn load_dotenv() {
+    if let Ok(text) = fs::read_to_string(".env") {
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') { continue; }
+            if let Some((k, v)) = line.split_once('=') {
+                let k = k.trim();
+                let v = v.trim().trim_matches('"').trim_matches('\'');
+                if env::var_os(k).is_none() {
+                    // SAFETY: single-threaded at startup, before any thread spawns.
+                    unsafe { env::set_var(k, v); }
+                }
+            }
+        }
+    }
+}
+
+/// Prompt the operator for the 8-character code displayed in the IBKey app.
+fn read_code_from_stdin(challenge: IbKeyChallenge) -> io::Result<String> {
+    println!();
+    println!("== IBKey Challenge/Response ==");
+    if !challenge.display_id.is_empty() {
+        println!("   display_id : {}", challenge.display_id);
+    }
+    if !challenge.avth_url.is_empty() {
+        println!("   avth_url   : {}", challenge.avth_url);
+    }
+    print!("Enter the 8-character code shown in the IBKey app: ");
+    io::stdout().flush()?;
+
+    let mut line = String::new();
+    io::stdin().lock().read_line(&mut line)?;
+    let code = line.trim().to_string();
+    if code.len() != 8 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("expected 8 characters, got {}", code.len()),
+        ));
+    }
+    Ok(code)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    load_dotenv();
+
+    let username = env::var("IB_LIVE_USERNAME")
+        .map_err(|_| "IB_LIVE_USERNAME not set (.env or shell)")?;
+    let password = env::var("IB_LIVE_PASSWORD")
+        .map_err(|_| "IB_LIVE_PASSWORD not set (.env or shell)")?;
+    let host = env::var("IB_HOST").unwrap_or_else(|_| "cdc1.ibllc.com".to_string());
+
+    let provider: CodeProvider = Arc::new(read_code_from_stdin);
+
+    let config = GatewayConfig {
+        username,
+        password: Zeroizing::new(password),
+        host: host.clone(),
+        paper: false,
+        accept_invalid_certs: false,
+        ib_key_timeout_secs: session::IB_KEY_DEFAULT_TIMEOUT_SECS,
+        ib_key_token_sub_type: session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: Some(provider),
+    };
+
+    println!("== Connecting LIVE ({}). Waiting for IBKey challenge...", host);
+    let t0 = Instant::now();
+    let (gw, _farm, _ccp, _hmds) = Gateway::connect(&config)?;
+    let elapsed = t0.elapsed().as_secs_f64();
+    println!();
+    println!("PASS — issue #176 verified: C/R login succeeded in {:.1}s (account_id={})",
+        elapsed, gw.account_id);
+    Ok(())
+}

--- a/examples/ex_parallel_farm_logon.rs
+++ b/examples/ex_parallel_farm_logon.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     };
 
     println!("== Initial Gateway::connect ({}, host={})", if live { "LIVE" } else { "PAPER" }, host);

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -113,6 +113,7 @@ impl EClient {
             accept_invalid_certs: false,
             ib_key_timeout_secs: crate::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
             ib_key_token_sub_type: crate::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+            code_provider: None,
         };
 
         let (gw, farm_conn, ccp_conn, hmds_conn) = Gateway::connect(&gw_config)?;

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -570,6 +570,32 @@ fn ib_key_err(kind: io::ErrorKind, msg: impl Into<String>) -> io::Error {
     io::Error::new(kind, msg.into())
 }
 
+/// Challenge details surfaced to a [`CodeProvider`] callback.
+///
+/// Populated from the server's `XYZ 775` state=2 reply: the per-session
+/// display id the user sees next to the 8-char code in the IBKey app, and
+/// the `clientam.com/ibkr/ibkey/seamless?S=…` URL also used by the web
+/// fallback. Either may be empty if the server omitted it in this run.
+#[derive(Debug, Clone, Default)]
+pub struct IbKeyChallenge {
+    pub display_id: String,
+    pub avth_url: String,
+}
+
+/// 8-character Challenge/Response code provider callback.
+///
+/// If supplied (via `GatewayConfig::code_provider`), the C/R variant of the
+/// IBKey gate is used instead of waiting for a mobile push approval: after
+/// the server delivers state=2, this callback is invoked once with the
+/// parsed challenge and the returned 8-character code is submitted as
+/// `XYZ 775` state=3. Per ib-agent#149, the server has no retry loop — one
+/// wrong code returns state=4 FAILED and the socket is torn down. The
+/// callback should pull the code from a deterministic source (stdin,
+/// secrets vault, etc.) or return an `io::Error` to abort the login.
+pub type CodeProvider = std::sync::Arc<
+    dyn Fn(IbKeyChallenge) -> io::Result<String> + Send + Sync,
+>;
+
 /// Compact hex dump for diagnostic logging.
 fn hex_dump(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect::<Vec<_>>().join(" ")
@@ -610,6 +636,7 @@ pub fn do_ib_key_2fa<S: Read + Write>(
     stream: &mut S,
     token_sub_type: &str,
     deadline: std::time::Instant,
+    code_provider: Option<&CodeProvider>,
 ) -> io::Result<IbKeyOutcome> {
     use std::time::Instant;
 
@@ -629,6 +656,7 @@ pub fn do_ib_key_2fa<S: Read + Write>(
     let mut session_id = String::new();
     let mut announced_wait = false;
     let mut saw_challenge = false;
+    let mut code_submitted = false;
 
     loop {
         if Instant::now() >= deadline {
@@ -677,8 +705,44 @@ pub fn do_ib_key_2fa<S: Read + Write>(
                     );
                     announced_wait = true;
                 }
+                // Challenge/Response branch: if a code_provider is configured,
+                // pull the 8-char code from the callback and submit state=3
+                // instead of waiting for a phone tap. Guarded so a repeated
+                // state=2 (server retransmission) doesn't double-submit.
+                if !code_submitted {
+                    if let Some(provider) = code_provider {
+                        let challenge_info = IbKeyChallenge {
+                            display_id: session_id.clone(),
+                            avth_url: approval_url.clone(),
+                        };
+                        let code = provider(challenge_info)?;
+                        let submission = xyz::xyz_build_swcr_token_code_submission(&code);
+                        let framed = xyz::xyz_wrap(&submission);
+                        stream.write_all(&framed)?;
+                        log::info!(
+                            "2FA gate: submitted SWCR_TOKEN state=3 code (len={}, {} bytes framed)",
+                            code.len(), framed.len(),
+                        );
+                        code_submitted = true;
+                    }
+                }
             }
-            RecvMsg::Xyz { msg_id, state, fields, .. } if msg_id == xyz::XYZ_MSG_TOKEN_AUTH && state == 5 => {
+            RecvMsg::Xyz { msg_id, state, fields, .. } if msg_id == xyz::XYZ_MSG_SWCR_TOKEN && state == 4 => {
+                // Challenge/Response result. Server responds PASSED → falls
+                // through to AUTH_FINISH (state=3); FAILED → server skips
+                // AUTH_FINISH and tears the socket down (no retry loop —
+                // ib-agent#149).
+                let result = fields.iter().rev().find(|s| !s.is_empty()).cloned().unwrap_or_default();
+                if result.eq_ignore_ascii_case("PASSED") {
+                    log::info!("2FA gate: C/R code accepted (state=4 PASSED)");
+                } else {
+                    return Err(ib_key_err(
+                        io::ErrorKind::PermissionDenied,
+                        format!("2FA gate: C/R code rejected (state=4 {})", result),
+                    ));
+                }
+            }
+            RecvMsg::Xyz { msg_id, state, fields, .. } if msg_id == xyz::XYZ_MSG_TOKEN_AUTH && (state == 3 || state == 5) => {
                 // Look for "PASSED" sentinel and the SOFT token (long hex string).
                 let mut passed = false;
                 let mut soft_token_hex = String::new();
@@ -1337,7 +1401,7 @@ mod tests {
         // no SWCR_TOKEN(state=2) preceded it, so this is the no-2FA fast path.
         let auth_finish = xyz::xyz_build(xyz::XYZ_MSG_TOKEN_AUTH, 5, "user", &["PASSED"]);
         let mut stream = ScriptedStream::new(frame_xyz(&auth_finish));
-        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline()).unwrap();
+        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), None).unwrap();
         assert_eq!(outcome, IbKeyOutcome::Skipped);
 
         // Verify we sent the SWCR_TOKEN init carrying the tokenSubType.
@@ -1365,7 +1429,7 @@ mod tests {
         incoming.extend_from_slice(&frame_xyz(&auth_finish));
         let mut stream = ScriptedStream::new(incoming);
 
-        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline()).unwrap();
+        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), None).unwrap();
         match outcome {
             IbKeyOutcome::Approved { approval_url, session_id, soft_token_hex } => {
                 assert_eq!(approval_url, "https://www.example.com/seamless?S=YWJjZA==");
@@ -1393,7 +1457,7 @@ mod tests {
         incoming.extend_from_slice(&frame_xyz(&auth_finish));
         let mut stream = ScriptedStream::new(incoming);
 
-        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline()).unwrap();
+        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), None).unwrap();
         assert!(matches!(outcome, IbKeyOutcome::Approved { .. }));
 
         // The captured write stream contains: SWCR_TOKEN init, then HEART_BEAT.
@@ -1428,7 +1492,7 @@ mod tests {
             "https://x.example/u",
         ]);
         let mut stream = ScriptedStream::new(frame_xyz(&challenge));
-        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline()).unwrap_err();
+        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
         assert!(err.to_string().contains("18 min server-side deadline"),
             "expected the long-deadline message; got {}", err);
@@ -1441,7 +1505,7 @@ mod tests {
         // the 18 min deadline (which would mislead users into "approve faster"
         // when the real fix is "your account doesn't use IBKey").
         let mut stream = ScriptedStream::new(Vec::new());
-        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline()).unwrap_err();
+        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
         let msg = err.to_string();
         assert!(msg.contains("before issuing a challenge"),
@@ -1455,8 +1519,112 @@ mod tests {
         // Server replies AUTH_FINISH state=5 but payload says FAILED — denial.
         let auth_finish = xyz::xyz_build(xyz::XYZ_MSG_TOKEN_AUTH, 5, "user", &["FAILED"]);
         let mut stream = ScriptedStream::new(frame_xyz(&auth_finish));
-        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline()).unwrap_err();
+        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), None).unwrap_err();
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
         assert!(err.to_string().contains("rejected"));
+    }
+
+    // ── do_ib_key_2fa — Challenge/Response (ib-agent#149) ───────────────
+
+    #[test]
+    fn ib_key_2fa_cr_submits_code_then_passes_on_auth_finish_state_3() {
+        // Replay of ib-agent#149 run A (success path). Captured fixtures:
+        //   state=2: sessionId="399 830", challenge=10a447bc…0c9dc714 (20B / 40 hex),
+        //            AVTH_URL=clientam.com/ibkr/ibkey/seamless?S=…
+        //   user types "02226534" from the IBKey app
+        //   state=4 PASSED  → AUTH_FINISH(771) state=3 PASSED  (note: push uses state=5)
+        const RUN_A_CHALLENGE_HEX: &str = "10a447bc4f269b5161a6133b0265cf590c9dc714";
+        const RUN_A_SESSION_ID: &str = "399 830";
+        const RUN_A_AVTH_URL: &str =
+            "https://www.clientam.com/ibkr/ibkey/seamless?S=eyJBVlRIX1VSTCI6Imh0dHBzOi8vemRjMS5pYmxsYy5jb206NDAwMS9zYS94RUI1c3hUVDcvSGpuTTlFQksifQ==";
+        const RUN_A_CODE: &str = "02226534";
+
+        let challenge = xyz::xyz_build(xyz::XYZ_MSG_SWCR_TOKEN, 2, "johnbegood", &[
+            RUN_A_CHALLENGE_HEX,
+            RUN_A_SESSION_ID,
+            RUN_A_AVTH_URL,
+        ]);
+        let state4_passed = xyz::xyz_build(xyz::XYZ_MSG_SWCR_TOKEN, 4, "johnbegood", &["PASSED"]);
+        let auth_finish = xyz::xyz_build(xyz::XYZ_MSG_TOKEN_AUTH, 3, "johnbegood", &["PASSED"]);
+        let mut incoming = frame_xyz(&challenge);
+        incoming.extend_from_slice(&frame_xyz(&state4_passed));
+        incoming.extend_from_slice(&frame_xyz(&auth_finish));
+        let mut stream = ScriptedStream::new(incoming);
+
+        let seen_challenge = std::sync::Arc::new(std::sync::Mutex::new(IbKeyChallenge::default()));
+        let seen_clone = seen_challenge.clone();
+        let provider: CodeProvider = std::sync::Arc::new(move |c: IbKeyChallenge| {
+            *seen_clone.lock().unwrap() = c;
+            Ok(RUN_A_CODE.to_string())
+        });
+
+        let outcome = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), Some(&provider)).unwrap();
+        match outcome {
+            IbKeyOutcome::Approved { approval_url, session_id, .. } => {
+                assert_eq!(session_id, RUN_A_SESSION_ID);
+                assert_eq!(approval_url, RUN_A_AVTH_URL);
+            }
+            other => panic!("expected Approved, got {:?}", other),
+        }
+
+        // Provider must have received the parsed display_id + avth_url.
+        let seen = seen_challenge.lock().unwrap().clone();
+        assert_eq!(seen.display_id, RUN_A_SESSION_ID);
+        assert_eq!(seen.avth_url, RUN_A_AVTH_URL);
+
+        // Walk written frames: 1st = SWCR_TOKEN state=1 init, 2nd = state=3 submission.
+        // The 2nd frame must be byte-for-byte the 40-byte capture from run A.
+        let mut frames: Vec<Vec<u8>> = Vec::new();
+        let mut offset = 0;
+        while offset + 8 <= stream.written.len() {
+            let len = u32::from_be_bytes(
+                stream.written[offset + 4..offset + 8].try_into().unwrap(),
+            ) as usize;
+            frames.push(stream.written[offset + 8..offset + 8 + len].to_vec());
+            offset += 8 + len;
+        }
+        assert!(frames.len() >= 2, "expected at least 2 frames (init + submission); got {}", frames.len());
+        let expected_state3 = xyz::xyz_build_swcr_token_code_submission(RUN_A_CODE);
+        assert_eq!(frames[1], expected_state3,
+            "state=3 submission must byte-match the ib-agent#149 run-A capture");
+    }
+
+    #[test]
+    fn ib_key_2fa_cr_code_rejected_on_state_4_failed() {
+        // Server: state=2 → state=4 FAILED. Server tears the socket down after
+        // (no AUTH_FINISH on the wire). Client must surface PermissionDenied
+        // immediately on FAILED, without waiting for further frames.
+        let challenge = xyz::xyz_build(xyz::XYZ_MSG_SWCR_TOKEN, 2, "user", &[
+            "e7429fde5b4c26f81fff956be6749908a8653558e7429fde5b4c26f81fff956b",
+            "399 830",
+            "https://x.example/u",
+        ]);
+        let state4_failed = xyz::xyz_build(xyz::XYZ_MSG_SWCR_TOKEN, 4, "user", &["FAILED"]);
+        let mut incoming = frame_xyz(&challenge);
+        incoming.extend_from_slice(&frame_xyz(&state4_failed));
+        let mut stream = ScriptedStream::new(incoming);
+
+        let provider: CodeProvider = std::sync::Arc::new(|_| Ok("99999999".to_string()));
+        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), Some(&provider)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("C/R code rejected"),
+            "expected C/R rejection message; got {}", err);
+    }
+
+    #[test]
+    fn ib_key_2fa_cr_provider_error_aborts_login() {
+        // Provider returns an error (e.g. user cancelled): the function must
+        // propagate it without sending state=3.
+        let challenge = xyz::xyz_build(xyz::XYZ_MSG_SWCR_TOKEN, 2, "user", &[
+            "e7429fde5b4c26f81fff956be6749908a8653558e7429fde5b4c26f81fff956b",
+            "399 830",
+            "https://x.example/u",
+        ]);
+        let mut stream = ScriptedStream::new(frame_xyz(&challenge));
+        let provider: CodeProvider = std::sync::Arc::new(|_| {
+            Err(io::Error::new(io::ErrorKind::Interrupted, "user cancelled"))
+        });
+        let err = do_ib_key_2fa(&mut stream, "2a", far_future_deadline(), Some(&provider)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Interrupted);
     }
 }

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -158,6 +158,7 @@ fn main() {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     };
 
     println!("========================================");

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -852,6 +852,13 @@ pub struct GatewayConfig {
     /// the live value via ib-agent's `SWCR_TOKEN_SUBTYPE` hook if the default
     /// doesn't trigger the IBKey push for your account.
     pub ib_key_token_sub_type: String,
+    /// If set, the IBKey gate uses the **Challenge/Response** path instead
+    /// of waiting for a mobile push approval. After the server delivers
+    /// state=2, the callback is invoked once with the challenge details
+    /// and the returned 8-character code is submitted as state=3. See
+    /// [`session::CodeProvider`] for the contract; `None` leaves behavior
+    /// unchanged (push approval).
+    pub code_provider: Option<session::CodeProvider>,
 }
 
 impl Gateway {
@@ -983,7 +990,12 @@ impl Gateway {
         if !config.paper {
             let deadline = std::time::Instant::now()
                 + std::time::Duration::from_secs(config.ib_key_timeout_secs);
-            match session::do_ib_key_2fa(&mut tls, &config.ib_key_token_sub_type, deadline)? {
+            match session::do_ib_key_2fa(
+                &mut tls,
+                &config.ib_key_token_sub_type,
+                deadline,
+                config.code_provider.as_ref(),
+            )? {
                 session::IbKeyOutcome::Skipped => {
                     log::info!("2FA gate: skipped (no second factor)");
                 }
@@ -2085,6 +2097,7 @@ mod tests {
             accept_invalid_certs: false,
             ib_key_timeout_secs: session::IB_KEY_DEFAULT_TIMEOUT_SECS,
             ib_key_token_sub_type: session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+            code_provider: None,
         };
         assert_eq!(config.username, "user");
         assert!(config.paper);

--- a/src/protocol/xyz.rs
+++ b/src/protocol/xyz.rs
@@ -148,6 +148,39 @@ pub fn xyz_build_swcr_token_init(token_sub_type: &str) -> Vec<u8> {
     buf
 }
 
+/// Build the Challenge/Response code submission (state=3).
+///
+/// Sent after the server's state=2 challenge when the user has chosen the
+/// 8-character response-code variant in the IBKey dialog (as opposed to
+/// tapping Approve on the push notification). The literal ASCII code goes
+/// in the `M.z` slot — no transformation client-side. Layout per
+/// ib-agent#149:
+///
+/// ```text
+/// Header (5 slots, 20 B):
+///   version (=20), msg_id (=775), literal 1, state (=3), str_len (=0)
+/// Body (3 length-prefixed strings):
+///   M.x  = ""        (username slot, empty in submission)
+///   M.z  = code      (8 ASCII chars, no padding when len % 4 == 0)
+///   M.A  = ""        (challenge-response slot, empty for IBKey C/R)
+/// ```
+///
+/// Note: state=3 carries 3 body strings, not 4 — the `M.D` token sub-type
+/// field present at state=1 is omitted here (verified against the 40-byte
+/// capture in ib-agent#149).
+pub fn xyz_build_swcr_token_code_submission(code: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&20u32.to_be_bytes());             // version
+    buf.extend_from_slice(&XYZ_MSG_SWCR_TOKEN.to_be_bytes());// msg_id 775
+    buf.extend_from_slice(&1u32.to_be_bytes());              // hardcoded 1
+    buf.extend_from_slice(&3u32.to_be_bytes());              // state = 3
+    buf.extend_from_slice(&0u32.to_be_bytes());              // str_len = 0
+    xyz_write_string(&mut buf, "");                          // M.x
+    xyz_write_string(&mut buf, code);                        // M.z = code
+    xyz_write_string(&mut buf, "");                          // M.A
+    buf
+}
+
 /// Parsed payload from an `XYZ_MSG_SWCR_TOKEN` state=2 reply.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SwcrTokenChallenge {
@@ -289,6 +322,41 @@ mod tests {
         assert_eq!(expected.len(), 40, "canonical inner payload is 40 bytes");
         let got = xyz_build_swcr_token_init("2a");
         assert_eq!(got, expected, "byte-for-byte match required");
+    }
+
+    #[test]
+    fn swcr_token_code_submission_matches_canonical_bytes() {
+        // Reference: deepentropy/ib-agent#149. The literal 40-byte inner XYZ
+        // payload one successful Challenge/Response login put on the wire,
+        // with code="02226534".
+        let expected: Vec<u8> = vec![
+            // 5-slot header
+            0x00, 0x00, 0x00, 0x14, // version = 20
+            0x00, 0x00, 0x03, 0x07, // msg_id = 775
+            0x00, 0x00, 0x00, 0x01, // hardcoded 1
+            0x00, 0x00, 0x00, 0x03, // state = 3
+            0x00, 0x00, 0x00, 0x00, // str_len = 0
+            // 3 string fields: x="", z=code, A=""
+            0x00, 0x00, 0x00, 0x00, // M.x.length = 0
+            0x00, 0x00, 0x00, 0x08, // M.z.length = 8
+            0x30, 0x32, 0x32, 0x32, 0x36, 0x35, 0x33, 0x34, // "02226534"
+            0x00, 0x00, 0x00, 0x00, // M.A.length = 0
+        ];
+        assert_eq!(expected.len(), 40, "canonical state=3 payload is 40 bytes");
+        let got = xyz_build_swcr_token_code_submission("02226534");
+        assert_eq!(got, expected, "byte-for-byte match required");
+    }
+
+    #[test]
+    fn swcr_token_code_submission_state_and_msg_id_parse() {
+        let payload = xyz_build_swcr_token_code_submission("02226534");
+        let (msg_id, _, state, fields) = xyz_parse_response(&payload).unwrap();
+        assert_eq!(msg_id, XYZ_MSG_SWCR_TOKEN);
+        assert_eq!(state, 3);
+        // The parser reads the 5th header slot (str_len=0) as fields[0], then
+        // M.x="" at fields[1], M.z=code at fields[2], M.A="" at fields[3].
+        assert!(fields.iter().any(|f| f == "02226534"),
+            "code must appear in parsed fields; got {:?}", fields);
     }
 
     #[test]

--- a/src/python/compat/client/mod.rs
+++ b/src/python/compat/client/mod.rs
@@ -121,6 +121,7 @@ impl EClient {
                 .unwrap_or(crate::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS),
             ib_key_token_sub_type: ib_key_token_sub_type
                 .unwrap_or_else(|| crate::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into()),
+            code_provider: None,
         };
 
         let result = py.allow_threads(|| Gateway::connect(&config));

--- a/tests/depth_wire_test.rs
+++ b/tests/depth_wire_test.rs
@@ -12,6 +12,7 @@ fn config() -> GatewayConfig {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     }
 }
 

--- a/tests/farm_reconnect_poc.rs
+++ b/tests/farm_reconnect_poc.rs
@@ -18,6 +18,7 @@ fn config() -> GatewayConfig {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     }
 }
 

--- a/tests/ib_paper_compat/common.rs
+++ b/tests/ib_paper_compat/common.rs
@@ -27,6 +27,7 @@ pub(super) fn get_config() -> Option<GatewayConfig> {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     })
 }
 

--- a/tests/ib_paper_compat/connection.rs
+++ b/tests/ib_paper_compat/connection.rs
@@ -246,6 +246,7 @@ pub(super) fn phase_auth_wrong_password(config: &GatewayConfig) {
         accept_invalid_certs: false,
         ib_key_timeout_secs: ibx::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
         ib_key_token_sub_type: ibx::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: None,
     };
 
     let start = Instant::now();


### PR DESCRIPTION
## Summary

- New `GatewayConfig.code_provider` callback opts into the 8-character Challenge/Response variant of the IBKey 2FA gate instead of waiting on a mobile push approval (`#111`).
- State=3 submission wire builder added, with a byte-canonical test against the 40-byte capture from `deepentropy/ib-agent#149`.
- C/R branch handles state=4 PASSED/FAILED inline; one wrong code is terminal per server contract (no retry loop).
- Closes `#176`.

## Test plan

- [x] `cargo test` — 3 new unit tests cover pass / FAILED-reject / provider-error-abort paths
- [x] Byte-canonical match against the ib-agent#149 wire capture
- [ ] Live verification on the live account (`examples/ex176_live_2fa_code_provider.rs` provides the recipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)