### PR TITLE
Fix cancel/modify of orders recorded under legacy ClOrdID format (#179)

### DIFF
--- a/examples/ex179_wire_repro.rs
+++ b/examples/ex179_wire_repro.rs
@@ -1,0 +1,208 @@
+//! ibx#179 — place → restart → cancel wire capture.
+//!
+//! Run in two phases against the paper account, with `RUST_LOG=trace` to dump
+//! every outbound/inbound FIX message. Phase A places, persists state, exits.
+//! Phase B reads state, attempts cancel against the prior session's order_id,
+//! logs whatever CCP returns (cancel-ack, 35=3 reject, 35=j business reject).
+//!
+//! Phase A:
+//!   $env:RUST_LOG="trace"; $env:IB_USERNAME="..."; $env:IB_PASSWORD="..."
+//!   cargo run --release --example ex179_wire_repro -- place 2> .tmp/ex179_a.log
+//!
+//! Phase B (fresh process):
+//!   cargo run --release --example ex179_wire_repro -- cancel 2> .tmp/ex179_b.log
+//!
+//! State file: .tmp/ex179_state.txt (order_id=, perm_id=, status=).
+
+use std::env;
+use std::fs;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ibx::api::client::{Contract, EClient, EClientConfig, Order};
+use ibx::api::types::OrderState;
+use ibx::api::wrapper::Wrapper;
+
+const STATE_PATH: &str = ".tmp/ex179_state.txt";
+
+#[derive(Default)]
+struct State {
+    statuses: Vec<(i64, String, i64)>,
+    errors: Vec<(i64, i64, String)>,
+    open_orders: Vec<(i64, String, String)>,
+}
+
+struct W { state: Arc<Mutex<State>> }
+
+impl Wrapper for W {
+    fn order_status(
+        &mut self, order_id: i64, status: &str, _filled: f64, _remaining: f64,
+        _avg_fill: f64, perm_id: i64, _parent_id: i64, _last_fill: f64,
+        _client_id: i64, _why_held: &str, _mkt_cap_price: f64,
+    ) {
+        println!("[status] oid={order_id} perm={perm_id} status={status}");
+        self.state.lock().unwrap().statuses.push((order_id, status.into(), perm_id));
+    }
+    fn open_order(
+        &mut self, order_id: i64, contract: &Contract,
+        order: &Order, _state: &OrderState,
+    ) {
+        println!("[open_order] oid={order_id} sym={} action={} qty={}",
+                 contract.symbol, order.action, order.total_quantity);
+        self.state.lock().unwrap().open_orders.push((
+            order_id, contract.symbol.clone(), order.action.clone(),
+        ));
+    }
+    fn error(&mut self, req_id: i64, code: i64, msg: &str, _adv: &str) {
+        eprintln!("[error] req_id={req_id} code={code} msg={msg}");
+        self.state.lock().unwrap().errors.push((req_id, code, msg.into()));
+    }
+}
+
+fn pump<F: Fn(&State) -> bool>(c: &EClient, w: &mut W, s: &Arc<Mutex<State>>,
+                                t: Duration, done: F) -> bool {
+    let dl = Instant::now() + t;
+    while Instant::now() < dl {
+        c.process_msgs(w);
+        if done(&s.lock().unwrap()) { return true; }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    false
+}
+
+fn connect() -> Result<EClient, Box<dyn std::error::Error>> {
+    Ok(EClient::connect(&EClientConfig {
+        username: env::var("IB_USERNAME")?,
+        password: env::var("IB_PASSWORD")?,
+        host: env::var("IB_HOST").unwrap_or_else(|_| "cdc1.ibllc.com".into()),
+        paper: true,
+        core_id: None,
+    })?)
+}
+
+fn spy() -> Contract {
+    Contract {
+        con_id: 756733,
+        symbol: "SPY".into(),
+        sec_type: "STK".into(),
+        exchange: "SMART".into(),
+        currency: "USD".into(),
+        ..Default::default()
+    }
+}
+
+fn write_state(order_id: i64, perm_id: i64, status: &str) -> std::io::Result<()> {
+    fs::create_dir_all(".tmp")?;
+    fs::write(STATE_PATH, format!("order_id={order_id}\nperm_id={perm_id}\nstatus={status}\n"))
+}
+
+fn read_state() -> Result<(i64, i64, String), Box<dyn std::error::Error>> {
+    let text = fs::read_to_string(STATE_PATH)?;
+    let mut order_id = 0i64; let mut perm_id = 0i64; let mut status = String::new();
+    for line in text.lines() {
+        if let Some(v) = line.strip_prefix("order_id=") { order_id = v.parse()?; }
+        else if let Some(v) = line.strip_prefix("perm_id=") { perm_id = v.parse()?; }
+        else if let Some(v) = line.strip_prefix("status=") { status = v.into(); }
+    }
+    Ok((order_id, perm_id, status))
+}
+
+fn phase_place() -> Result<(), Box<dyn std::error::Error>> {
+    let client = connect()?;
+    let order_id = client.next_order_id();
+    let state = Arc::new(Mutex::new(State::default()));
+    let mut w = W { state: state.clone() };
+
+    let order = Order {
+        action: "BUY".into(), total_quantity: 1.0,
+        order_type: "LMT".into(), lmt_price: 1.00,
+        tif: "DAY".into(), outside_rth: true,
+        ..Default::default()
+    };
+
+    println!("=== PHASE A: place oid={order_id} BUY 1 SPY LMT 1.00 ===");
+    client.place_order(order_id, &spy(), &order)?;
+
+    let got = pump(&client, &mut w, &state, Duration::from_secs(15), |s| {
+        s.statuses.iter().any(|(id, st, _)| *id == order_id
+            && (st == "Submitted" || st == "PreSubmitted"))
+    });
+    if !got { eprintln!("WARN: never saw Submitted/PreSubmitted within 15s"); }
+
+    let snap = state.lock().unwrap();
+    let (final_status, perm) = snap.statuses.iter()
+        .filter(|(id, _, _)| *id == order_id)
+        .last()
+        .map(|(_, s, p)| (s.clone(), *p))
+        .unwrap_or_else(|| ("Unknown".into(), 0));
+    write_state(order_id, perm, &final_status)?;
+    println!("=== PHASE A: persisted oid={order_id} perm={perm} status={final_status} ===");
+    println!("=== Now disconnect, restart, run phase B ===");
+
+    client.disconnect();
+    Ok(())
+}
+
+fn phase_cancel() -> Result<(), Box<dyn std::error::Error>> {
+    let (order_id, perm_id, prior_status) = read_state()?;
+    println!("=== PHASE B: read oid={order_id} perm={perm_id} prior={prior_status} ===");
+
+    let client = connect()?;
+    let state = Arc::new(Mutex::new(State::default()));
+    let mut w = W { state: state.clone() };
+
+    // Drain any unsolicited inbound for 2s before cancelling — gives the
+    // gateway time to push openOrder/35=8 for prior-session orders if it does.
+    println!("=== PHASE B: draining inbound for 2s ===");
+    pump(&client, &mut w, &state, Duration::from_secs(2), |_| false);
+
+    println!("=== PHASE B: cancel oid={order_id} ===");
+    client.cancel_order(order_id, "")?;
+
+    pump(&client, &mut w, &state, Duration::from_secs(10), |s| {
+        s.statuses.iter().any(|(id, st, _)| *id == order_id && st == "Cancelled")
+            || s.errors.iter().any(|(rid, _, _)| *rid == order_id)
+    });
+
+    let snap = state.lock().unwrap();
+    println!("=== PHASE B: summary ===");
+    for (id, st, p) in &snap.statuses { println!("  status oid={id} perm={p} status={st}"); }
+    for (rid, c, m) in &snap.errors { println!("  error req={rid} code={c} msg={m}"); }
+    for (id, sym, act) in &snap.open_orders { println!("  open_order oid={id} sym={sym} act={act}"); }
+
+    client.disconnect();
+    Ok(())
+}
+
+fn load_dotenv() {
+    if let Ok(text) = fs::read_to_string(".env") {
+        for line in text.lines() {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') { continue; }
+            if let Some((k, v)) = line.split_once('=') {
+                let k = k.trim();
+                let v = v.trim().trim_matches('"').trim_matches('\'');
+                if env::var_os(k).is_none() {
+                    unsafe { env::set_var(k, v); }
+                }
+            }
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+    load_dotenv();
+
+    let mode = env::args().nth(1).unwrap_or_default();
+    match mode.as_str() {
+        "place" => phase_place(),
+        "cancel" => phase_cancel(),
+        _ => {
+            eprintln!("usage: ex179_wire_repro <place|cancel>");
+            eprintln!("state file: {}", Path::new(STATE_PATH).display());
+            std::process::exit(2);
+        }
+    }
+}

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -43,6 +43,10 @@ pub struct Context {
     next_order_id: OrderId,
     /// ClOrdID version counter per order for modify chaining (orderId.0 → .1 → .2).
     pub(crate) modify_versions: HashMap<OrderId, u32>,
+    /// Last ClOrdID the server reported (or we emitted) for each order, exactly as
+    /// it appeared on the wire. Used as the OrigClOrdID on cancel/modify so that
+    /// legacy orders recorded without a `.{ver}` suffix still match — see ibx#179.
+    pub(crate) last_clord: HashMap<OrderId, String>,
     /// Timestamp when the last farm socket recv returned data (for decode latency measurement).
     pub(crate) recv_at: Instant,
     /// Total hot loop iterations since start.
@@ -57,6 +61,7 @@ impl Context {
             open_orders: HashMap::with_capacity(128),
             pending_orders: OrderBuffer::new(),
             modify_versions: HashMap::new(),
+            last_clord: HashMap::new(),
             account: AccountState::default(),
             clock: Clock::new(),
             next_order_id: {

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -184,14 +184,26 @@ impl CcpState {
                     match frame {
                         Frame::FixComp(raw) => {
                             let (unsigned, _) = conn.unsign(&raw);
-                            msgs.extend(fixcomp::fixcomp_decompress(&unsigned));
+                            let inner = fixcomp::fixcomp_decompress(&unsigned);
+                            if log::log_enabled!(log::Level::Trace) {
+                                for m in &inner {
+                                    log::trace!("WIRE< ccp/comp {}", fix::fmt_pipe(m));
+                                }
+                            }
+                            msgs.extend(inner);
                         }
                         Frame::Fix(raw) => {
                             let (unsigned, _) = conn.unsign(&raw);
+                            if log::log_enabled!(log::Level::Trace) {
+                                log::trace!("WIRE< ccp/fix {}", fix::fmt_pipe(&unsigned));
+                            }
                             msgs.push(unsigned);
                         }
                         Frame::Binary(raw) => {
                             let (unsigned, _) = conn.unsign(&raw);
+                            if log::log_enabled!(log::Level::Trace) {
+                                log::trace!("WIRE< ccp/bin {}", fix::fmt_pipe(&unsigned));
+                            }
                             msgs.push(unsigned);
                         }
                     }
@@ -529,6 +541,16 @@ impl CcpState {
             log::debug!("ExecReport: dropping sentinel record (ClOrdID=0/*) sym={:?} status={:?}",
                 parsed.get(&55), parsed.get(&39));
             return;
+        }
+
+        // Record the ClOrdID exactly as the server reports it so subsequent
+        // cancel/modify can echo back the same string. Skip cancel-ack frames
+        // (tag 11 starts with 'C' there) — those carry the cancel request's
+        // own id, not the original order's. See ibx#179.
+        if let Some(raw_clord) = parsed.get(&11) {
+            if !raw_clord.starts_with('C') && raw_clord != "*" {
+                context.last_clord.insert(clord_id, raw_clord.clone());
+            }
         }
 
         // What-If response

--- a/src/engine/hot_loop/farm.rs
+++ b/src/engine/hot_loop/farm.rs
@@ -87,14 +87,25 @@ impl FarmState {
                     Frame::FixComp(raw) => {
                         let (unsigned, _valid) = conn.unsign(raw);
                         let inner = fixcomp::fixcomp_decompress(&unsigned);
+                        if log::log_enabled!(log::Level::Trace) {
+                            for m in &inner {
+                                log::trace!("WIRE< farm/comp {}", fix::fmt_pipe(m));
+                            }
+                        }
                         self.farm_msg_buf.extend(inner);
                     }
                     Frame::Binary(raw) => {
                         let (unsigned, _valid) = conn.unsign(raw);
+                        if log::log_enabled!(log::Level::Trace) {
+                            log::trace!("WIRE< farm/bin {}", fix::fmt_pipe(&unsigned));
+                        }
                         self.farm_msg_buf.push(unsigned);
                     }
                     Frame::Fix(raw) => {
                         let (unsigned, _valid) = conn.unsign(raw);
+                        if log::log_enabled!(log::Level::Trace) {
+                            log::trace!("WIRE< farm/fix {}", fix::fmt_pipe(&unsigned));
+                        }
                         self.farm_msg_buf.push(unsigned);
                     }
                 }

--- a/src/engine/hot_loop/hmds.rs
+++ b/src/engine/hot_loop/hmds.rs
@@ -94,14 +94,25 @@ impl HmdsState {
                         Frame::FixComp(raw) => {
                             let (unsigned, _valid) = conn.unsign(raw);
                             let inner = fixcomp::fixcomp_decompress(&unsigned);
+                            if log::log_enabled!(log::Level::Trace) {
+                                for m in &inner {
+                                    log::trace!("WIRE< hmds/comp {}", crate::protocol::fix::fmt_pipe(m));
+                                }
+                            }
                             msgs.extend(inner);
                         }
                         Frame::Binary(raw) => {
                             let (unsigned, _valid) = conn.unsign(raw);
+                            if log::log_enabled!(log::Level::Trace) {
+                                log::trace!("WIRE< hmds/bin {}", crate::protocol::fix::fmt_pipe(&unsigned));
+                            }
                             msgs.push(unsigned);
                         }
                         Frame::Fix(raw) => {
                             let (unsigned, _valid) = conn.unsign(raw);
+                            if log::log_enabled!(log::Level::Trace) {
+                                log::trace!("WIRE< hmds/fix {}", crate::protocol::fix::fmt_pipe(&unsigned));
+                            }
                             msgs.push(unsigned);
                         }
                     }

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -1440,10 +1440,18 @@ pub(crate) fn drain_and_send_orders(
                 conn.send_fix(&fields)
             }
             OrderRequest::Cancel { order_id } => {
-                // Tag 41 must reference the latest versioned ClOrdID
-                let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
+                // OrigClOrdID must match exactly what the server has on record.
+                // Prefer the string we last observed on the wire (see ibx#179 —
+                // legacy orders recorded without a `.{ver}` suffix won't match
+                // a computed `{id}.0`). Fall back to the versioned scheme when
+                // we have no observation yet (fresh-order place→immediate-cancel
+                // before the ack round-trip).
+                let orig_clord = context.last_clord.get(&order_id).cloned()
+                    .unwrap_or_else(|| {
+                        let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
+                        format!("{}.{}", order_id, ver)
+                    });
                 let clord_str = format!("C{}", order_id);
-                let orig_clord = format!("{}.{}", order_id, ver);
                 let now = chrono_free_timestamp();
                 conn.send_fix(&[
                     (fix::TAG_MSG_TYPE, fix::MSG_ORDER_CANCEL),
@@ -1460,9 +1468,12 @@ pub(crate) fn drain_and_send_orders(
                     .collect();
                 let mut last_result = Ok(());
                 for oid in open_ids {
-                    let ver = *context.modify_versions.get(&oid).unwrap_or(&0);
+                    let orig_clord = context.last_clord.get(&oid).cloned()
+                        .unwrap_or_else(|| {
+                            let ver = *context.modify_versions.get(&oid).unwrap_or(&0);
+                            format!("{}.{}", oid, ver)
+                        });
                     let clord_str = format!("C{}", oid);
-                    let orig_clord = format!("{}.{}", oid, ver);
                     let now = chrono_free_timestamp();
                     last_result = conn.send_fix(&[
                         (fix::TAG_MSG_TYPE, fix::MSG_ORDER_CANCEL),
@@ -1487,7 +1498,14 @@ pub(crate) fn drain_and_send_orders(
                 let new_ver = prev_ver + 1;
                 context.modify_versions.insert(order_id, new_ver);
                 let clord_str = format!("{}.{}", order_id, new_ver);
-                let orig_clord = format!("{}.{}", order_id, prev_ver);
+                // OrigClOrdID matches whatever the server last recorded for
+                // this order (which may pre-date the versioned scheme — ibx#179).
+                let orig_clord = context.last_clord.get(&order_id).cloned()
+                    .unwrap_or_else(|| format!("{}.{}", order_id, prev_ver));
+                // Pre-seed `last_clord` with what we're about to emit so a
+                // subsequent cancel before the modify-ack still references the
+                // right version.
+                context.last_clord.insert(order_id, clord_str.clone());
 
                 let qty_str = format_uint(qty as u64);
                 let price_str = format_price(price);

--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -252,6 +252,9 @@ impl Connection {
     pub fn send_fix(&mut self, fields: &[(u32, &str)]) -> io::Result<()> {
         let next_seq = self.seq + 1;
         let msg = fix::fix_build(fields, next_seq);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!("WIRE> seq={} {}", next_seq, fix::fmt_pipe(&msg));
+        }
         let (to_send, next_iv) = if self.sign_key.is_empty() {
             (msg, None)
         } else {
@@ -272,6 +275,9 @@ impl Connection {
     /// State (sign_iv) is committed only after `write_all` returns Ok.
     pub fn send_fixcomp(&mut self, fields: &[(u32, &str)]) -> io::Result<()> {
         let msg = fix::fix_build(fields, 0);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!("WIRE> comp {}", fix::fmt_pipe(&msg));
+        }
         let wrapped = fixcomp::fixcomp_build(&msg);
         let (to_send, next_iv) = if self.sign_key.is_empty() {
             (wrapped, None)

--- a/src/protocol/fix.rs
+++ b/src/protocol/fix.rs
@@ -54,6 +54,21 @@ pub const MSG_ORDER_CANCEL: &str = "F";
 pub const MSG_ORDER_REPLACE: &str = "G";
 pub const MSG_MARKET_DATA_REQ: &str = "V";
 
+/// Render a FIX byte buffer with SOH (0x01) shown as `|` and any other
+/// non-printable bytes escaped as `\xNN`. For trace-level wire diagnostics
+/// (ibx#179 capture); not used on hot paths.
+pub fn fmt_pipe(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() + 8);
+    for &b in bytes {
+        match b {
+            SOH => s.push('|'),
+            0x20..=0x7e => s.push(b as char),
+            _ => s.push_str(&format!("\\x{:02x}", b)),
+        }
+    }
+    s
+}
+
 /// Sum of all bytes mod 256, zero-padded to 3 digits.
 pub fn fix_checksum(data: &[u8]) -> String {
     let sum: u32 = data.iter().map(|&b| b as u32).sum();


### PR DESCRIPTION
## Summary

- Cancel/Modify of legacy-format orders failed with `202 r1 "No such order"` because the server records the OrigClOrdID as it appeared on the original place wire, but our cancel path rebuilt it as `{order_id}.{ver}` unconditionally. Pre-`7748e2d` orders live as bare `{order_id}` and couldn't be matched.
- Record the OrigClOrdID-equivalent string from each exec report into `Context::last_clord`; Cancel/CancelAll/Modify now echo the recorded string verbatim. Computed `{id}.{ver}` form remains as fallback for the place→immediate-cancel race.
- Pre-seed at modify-emit time so a cancel issued before the modify-ack still references the right version.
- Adds opt-in wire trace (`RUST_LOG=trace` → `WIRE>`/`WIRE<` per signed-boundary frame) and `examples/ex179_wire_repro.rs` (two-phase place→restart→cancel driver) — the harness used for the diagnosis.
- Closes `#179`.

## Test plan

- [x] `cargo test --lib` — no new regressions (685/686 pass; the 1 pre-existing failure is the flaky `auth::session::tests::hw_info_two_calls_differ`, unrelated)
- [x] Pre-fix run reproduced the exact reject from the issue on `1774896823000`; post-fix run cancelled cleanly
- [x] Sixteen further qty=1 legacy orphans cancelled via the same flow
- [x] Three qty=100 legacy orphans cancelled — full open-order pool on the paper account is now empty
- [x] Fresh in-session place → cancel still works (control case from phase A/B verified pre-fix; same wire post-fix since `last_clord` is populated by the place-ack within ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)