### PR TITLE
ccp: hydrate context from session-recovery push (ibx#191)

### DIFF
--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -536,16 +536,83 @@ impl CcpState {
         event_tx: &Option<Sender<Event>>,
         account_id: &str,
     ) {
-        let clord_id = parsed.get(&11).and_then(|s| {
-            let stripped = s.strip_prefix('C').unwrap_or(s);
-            // Strip versioned suffix (.0, .1, .2) from modify-chained ClOrdIDs
-            let base = stripped.split('.').next().unwrap_or(stripped);
-            base.parse::<u64>().ok()
-        }).unwrap_or(0);
+        // CCP recovery push format A (ib-agent#155, captured against live):
+        // 35=8 with 150=0/39=0, tag 11 carries `<permId>.0`, the originating
+        // orderId is in tag 6121. For these, prefer 6121 as the local key so
+        // cancel_order(<prior-session orderId>) finds the right ClOrdID.
+        // Format B (paper account, observed live): tag 11 carries the
+        // originating orderId directly with `.0` suffix, tags 6119/6121
+        // absent — the existing tag-11 split below already gives the right
+        // value. The unwrap_or_else fallback handles both.
+        let recovery_origin_order_id: Option<u64> = if parsed.get(&150).map(|s| s.as_str()) == Some("0")
+            && parsed.get(&39).map(|s| s.as_str()) == Some("0")
+            && parsed.contains_key(&6121)
+        {
+            parsed.get(&6121).and_then(|s| s.parse::<u64>().ok())
+        } else {
+            None
+        };
 
-        // Drop the gateway's echo of the mass-order-status wildcard request
-        // (ClOrdID="*"/"0"/absent → parses to 0). Real orders are assigned
-        // monotonic IDs via next_order_id and never collide with 0.
+        let clord_id = recovery_origin_order_id.unwrap_or_else(|| {
+            parsed.get(&11).and_then(|s| {
+                let stripped = s.strip_prefix('C').unwrap_or(s);
+                // Strip versioned suffix (.0, .1, .2) from modify-chained ClOrdIDs
+                let base = stripped.split('.').next().unwrap_or(stripped);
+                base.parse::<u64>().ok()
+            }).unwrap_or(0)
+        });
+
+        // Recovery insert: a 35=8 with status New/New (150=0/39=0) for an order
+        // that is NOT in this session's context is a cross-session recovery entry
+        // pushed by CCP on session establishment. Insert into context.open_orders
+        // so subsequent cancel/modify ACKs at ~line 668 can match via
+        // context.order(clord_id) and emit OrderUpdate events to the user. ibx#191.
+        let is_new_ack = parsed.get(&150).map(|s| s.as_str()) == Some("0")
+            && parsed.get(&39).map(|s| s.as_str()) == Some("0");
+        if is_new_ack && context.order(clord_id).is_none() {
+            let con_id: i64 = parsed.get(&6008).and_then(|s| s.parse().ok()).unwrap_or(0);
+            let side = match parsed.get(&54).map(|s| s.as_str()) {
+                Some("1") => Side::Buy,
+                Some("5") => Side::ShortSell,
+                _ => Side::Sell,
+            };
+            let qty: u32 = parsed.get(&38).and_then(|s| s.parse::<f64>().ok()).map(|q| q as u32).unwrap_or(0);
+            let limit_price_i64: i64 = parsed.get(&44)
+                .and_then(|s| s.parse::<f64>().ok())
+                .map(|p| (p * PRICE_SCALE as f64) as i64)
+                .unwrap_or(0);
+            let stop_price_i64: i64 = parsed.get(&99)
+                .and_then(|s| s.parse::<f64>().ok())
+                .map(|p| (p * PRICE_SCALE as f64) as i64)
+                .unwrap_or(0);
+            let ord_type_byte: u8 = parsed.get(&40).and_then(|s| s.bytes().next()).unwrap_or(b'2');
+            let tif_byte: u8 = parsed.get(&59).and_then(|s| s.bytes().next()).unwrap_or(b'1');
+            if con_id != 0 && qty > 0 {
+                let instrument = context.register_instrument(con_id);
+                if let Some(sym) = parsed.get(&55) {
+                    context.set_symbol(instrument, sym.clone());
+                }
+                context.insert_order(crate::types::Order {
+                    order_id: clord_id,
+                    instrument,
+                    side,
+                    price: limit_price_i64,
+                    qty,
+                    filled: 0,
+                    status: crate::types::OrderStatus::Submitted,
+                    ord_type: ord_type_byte,
+                    tif: tif_byte,
+                    stop_price: stop_price_i64,
+                });
+                log::info!("CCP recovery: inserted orderId={} sym={:?} side={:?} qty={} px={}",
+                    clord_id, parsed.get(&55), side, qty,
+                    limit_price_i64 as f64 / PRICE_SCALE as f64);
+            }
+        }
+
+        // Drop the sentinel/end-of-stream record (ClOrdID="*"/"0"/absent → parses
+        // to 0). Real orders are assigned monotonic IDs via next_order_id and
+        // never collide with 0. The recovery-push terminator (11='*') lands here.
         if clord_id == 0 {
             log::debug!("ExecReport: dropping sentinel record (ClOrdID=0/*) sym={:?} status={:?}",
                 parsed.get(&55), parsed.get(&39));
@@ -1361,21 +1428,11 @@ impl CcpState {
                 (6040, "6"), (6036, "1"), (6095, account_id), (6529, "AR.3"),
             ]);
 
-            // Mass order status request.
-            let result = conn.send_fix(&[
-                (fix::TAG_MSG_TYPE, "H"),
-                (fix::TAG_SENDING_TIME, &ts),
-                (11, "*"),
-                (54, "*"),
-                (55, "*"),
-            ]);
-            match result {
-                Ok(()) => {
-                    hb.last_ccp_sent = Instant::now();
-                    log::info!("CCP reconnected, sent account/position re-subscribe + order mass status request");
-                }
-                Err(e) => log::error!("CCP reconnected but mass status request failed: {}", e),
-            }
+            // Resting open orders are pushed unsolicited by CCP as 35=8 with
+            // 150=0/39=0 carrying originating clientId (6119) and orderId (6121),
+            // terminated by 11='*' sentinel. See ib-agent#155, ibx#191.
+            hb.last_ccp_sent = Instant::now();
+            log::info!("CCP reconnected, sent account/position re-subscribe");
         }
     }
 }

--- a/tests/ib_paper_compat/main.rs
+++ b/tests/ib_paper_compat/main.rs
@@ -430,3 +430,136 @@ fn query_error_phase_live() {
     let conns = ensure_ccp_alive(conns, &mut gw, &config);
     let _ = connection::phase_graceful_shutdown(conns);
 }
+
+/// ibx#191 PR A focused live entry — validates that after a full disconnect,
+/// a fresh `Gateway::connect` receives the CCP recovery push (35=8 with
+/// 150=0/39=0 per ib-agent#155) and that a subsequent
+/// `cancel_order(<prior_session_orderId>)` succeeds.
+///
+/// Two `Gateway::connect` calls in one process. Paper account skips the IBKey
+/// gate so this runs unattended. IB throttles back-to-back logins within ~60s,
+/// so the test waits 90s between sessions. Run:
+///   cargo test --test ib_paper_compat cross_session_recovery_phase_live -- --ignored --nocapture
+#[test]
+#[ignore]
+fn cross_session_recovery_phase_live() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let config = match get_config() {
+        Some(c) => c,
+        None => { println!("Skipping: IB credentials not set"); return; }
+    };
+
+    println!("=== ibx#191 PR A: cross-session recovery test ===\n");
+
+    // ─── Session A: place resting GTC LMT BUY 1 SPY @ $1 (far below market) ───
+    println!("Session A: connecting + placing resting LMT GTC BUY 1 SPY @ $1");
+    let (gw_a, farm_a, ccp_a, hmds_a) = Gateway::connect(&config)
+        .expect("Session A: Gateway::connect failed");
+    let account_id = gw_a.account_id.clone();
+    drop(gw_a); // gateway state not needed after sockets are out
+
+    let order_id = common::next_order_id();
+    println!("  orderId = {}", order_id);
+
+    let session_a_acked = {
+        let shared = std::sync::Arc::new(SharedState::new());
+        let (event_tx, event_rx) = crossbeam_channel::unbounded();
+        let (mut hot_loop, control_tx) = HotLoop::with_connections(
+            shared, Some(event_tx), account_id.clone(),
+            farm_a, ccp_a, hmds_a, None,
+        );
+        let inst_id = hot_loop.context_mut().register_instrument(756733);
+        hot_loop.context_mut().set_symbol(inst_id, "SPY".to_string());
+
+        control_tx.send(ControlCommand::Order(OrderRequest::SubmitLimitGtc {
+            order_id, instrument: inst_id, side: Side::Buy, qty: 1,
+            price: 1_00_000_000, outside_rth: true,
+        })).expect("Session A: send order failed");
+
+        let join = run_hot_loop(hot_loop);
+
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut acked = false;
+        let mut rejected = false;
+        while Instant::now() < deadline && !acked && !rejected {
+            if let Ok(Event::OrderUpdate(u)) = event_rx.recv_timeout(Duration::from_millis(100)) {
+                match u.status {
+                    OrderStatus::Submitted | OrderStatus::PreSubmitted => acked = true,
+                    OrderStatus::Rejected => rejected = true,
+                    _ => {}
+                }
+            }
+        }
+
+        let _ = control_tx.send(ControlCommand::Shutdown);
+        let _ = join.join();
+
+        if rejected {
+            panic!("Session A: order rejected — cleanup not possible automatically (check TWS for orderId={})", order_id);
+        }
+        acked
+    };
+    // Conns A dropped → TCP sockets close → CCP session ends.
+    assert!(session_a_acked, "Session A: LMT order never acked within 30s");
+    println!("  Session A: orderId={} acked + sockets closed", order_id);
+
+    // IB throttles back-to-back Gateway::connect calls ("Never received data
+    // start after auth" if too soon). Wait ~90s before attempting Session B.
+    let wait_secs = 90u64;
+    println!("  Waiting {}s before Session B to clear IB auth throttle...\n", wait_secs);
+    std::thread::sleep(Duration::from_secs(wait_secs));
+
+    // ─── Session B: fresh connect → expect 35=8 recovery push → cancel orderId ───
+    println!("Session B: fresh Gateway::connect → expect recovery push for orderId={}", order_id);
+    let (gw_b, farm_b, ccp_b, hmds_b) = Gateway::connect(&config)
+        .expect("Session B: Gateway::connect failed");
+    assert_eq!(account_id, gw_b.account_id, "Account ID changed between sessions");
+    drop(gw_b);
+
+    let shared = std::sync::Arc::new(SharedState::new());
+    let (event_tx, event_rx) = crossbeam_channel::unbounded();
+    let (mut hot_loop, control_tx) = HotLoop::with_connections(
+        shared, Some(event_tx), account_id.clone(),
+        farm_b, ccp_b, hmds_b, None,
+    );
+    let inst_id = hot_loop.context_mut().register_instrument(756733);
+    hot_loop.context_mut().set_symbol(inst_id, "SPY".to_string());
+
+    let join = run_hot_loop(hot_loop);
+
+    // CCP delivers the recovery push <1s after session establishment per ib-agent#155.
+    // Sleep a few seconds so handle_exec_report has time to populate last_clord.
+    std::thread::sleep(Duration::from_secs(3));
+
+    println!("  Session B: sending Cancel(orderId={})", order_id);
+    let cancel_sent = Instant::now();
+    control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id }))
+        .expect("Session B: send cancel failed");
+
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut cancelled = false;
+    let mut cancel_rejected = false;
+    while Instant::now() < deadline && !cancelled && !cancel_rejected {
+        if let Ok(Event::OrderUpdate(u)) = event_rx.recv_timeout(Duration::from_millis(100)) {
+            match u.status {
+                OrderStatus::Cancelled => cancelled = true,
+                OrderStatus::Rejected => cancel_rejected = true,
+                _ => {}
+            }
+        }
+    }
+    let cancel_ms = cancel_sent.elapsed().as_millis();
+
+    let _ = control_tx.send(ControlCommand::Shutdown);
+    let _ = join.join();
+
+    if cancel_rejected {
+        panic!("Session B: cancel rejected — recovery push did not populate last_clord for orderId={}", order_id);
+    }
+    assert!(cancelled,
+        "Session B: cancel not confirmed within 30s — recovery push likely not parsed correctly. Cleanup orderId={} via GUI.",
+        order_id);
+
+    println!("  Session B: cancel confirmed in {}ms", cancel_ms);
+    println!("\n  PASS — cross-session cancel works (ibx#191 PR A validated)\n");
+}


### PR DESCRIPTION
## Summary
- Insert CCP recovery-push entries (`35=8` with `150=0/39=0`) into `context.open_orders` so cross-session cancel/modify ACKs can emit `OrderUpdate` to user code.
- Use originating orderId from tag 6121 when present (ib-agent#155 format); fall back to the existing tag-11 `.0`-split which carries the same value in the alternate format observed on the paper account.
- Drop the non-iso `35=H` mass-status query on CCP reconnect — the official gateway doesn't send it; CCP's unsolicited push covers the same need.

## Why
Bug from ibx#191: after a process restart, `cancel_order(<prior-session orderId>)` would emit the correct FIX cancel to CCP and CCP would even reply with a successful Cancelled exec report — but the user's `event_rx` never saw it. The OrderUpdate emit at `ccp.rs:668` gates on `context.order(clord_id).copied()`, which was empty for cross-session orders. The recovery push parses fine; it just wasn't being persisted to the engine-internal context.

## Test plan
- [x] `cargo check --lib` clean
- [x] `cargo test --lib` — 693 pass, same pre-existing `auth::session::hw_info_two_calls_differ` RNG flake as main
- [x] Live paper-account validation: `tests/ib_paper_compat/main.rs::cross_session_recovery_phase_live` (added in this PR, `#[ignore]`). Places resting LMT GTC, fully disconnects, 90s wait, fresh `Gateway::connect`, sends cancel, asserts Cancelled. **Passed end-to-end in 117s; cancel confirmed in 210ms after CCP ack.**

## Out of scope (PR B, separate)
`cancel_order_by_perm_id` — the `permId → orderId` lookup is unblocked by this PR (recovery entries populate `RichOrderInfo.order.perm_id`), but the public API addition belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)