### PR TITLE
order: percent-trail wire fix — emit 99/211/18 (ibx#192)

### DIFF
--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -522,6 +522,11 @@ pub(crate) fn drain_and_send_orders(
                 let side_str = fix_side(side);
                 let qty_str = format_uint(qty as u64);
                 let pct_str = trail_pct.to_string(); // basis points: 100 = 1%
+                // Per ib-agent#156 capture: percent-trail mirrors 99/211 as the
+                // percent in decimal form (1.00 for 1%), alongside 6268 in basis
+                // points and 18=a (ExecInst=TrailingStop). Without 99/211/18 the
+                // gateway rejects with "Invalid value in field # 18".
+                let pct_decimal = format!("{:.2}", trail_pct as f64 / 100.0);
                 let symbol = context.market.symbol(instrument).to_string();
                 let now = chrono_free_timestamp();
                 conn.send_fix(&[
@@ -534,6 +539,9 @@ pub(crate) fn drain_and_send_orders(
                     (54, side_str),
                     (38, &qty_str),
                     (40, "P"),              // OrdType = Trailing Stop
+                    (99, &pct_decimal),     // StopPx = percent as decimal
+                    (211, &pct_decimal),    // PegOffset = percent as decimal (mirror of 99)
+                    (18, "a"),              // ExecInst = TrailingStop
                     (6268, &pct_str),       // TrailingPercent (basis points)
                     (59, "0"),              // TIF = DAY
                     (60, &now),
@@ -552,6 +560,11 @@ pub(crate) fn drain_and_send_orders(
                 let side_str = fix_side(side);
                 let qty_str = format_uint(qty as u64);
                 let pct_str = trail_pct.to_string();
+                // Per ib-agent#156 capture: percent-trail mirrors 99/211 as the
+                // percent in decimal form (1.00 for 1%), alongside 6268 in basis
+                // points and 18=a (ExecInst=TrailingStop). Without 99/211/18 the
+                // gateway rejects with "Invalid value in field # 18".
+                let pct_decimal = format!("{:.2}", trail_pct as f64 / 100.0);
                 let symbol = context.market.symbol(instrument).to_string();
                 let now = chrono_free_timestamp();
                 let tif_byte = [tif];
@@ -576,6 +589,9 @@ pub(crate) fn drain_and_send_orders(
                     (54, side_str),
                     (38, &qty_str),
                     (40, "P"),              // OrdType = Trailing Stop
+                    (99, &pct_decimal),     // StopPx = percent as decimal
+                    (211, &pct_decimal),    // PegOffset = percent as decimal (mirror of 99)
+                    (18, "a"),              // ExecInst = TrailingStop
                     (6268, &pct_str),       // TrailingPercent (basis points)
                     (59, tif_str),
                     (60, &now),


### PR DESCRIPTION
## Summary
- `SubmitTrailingStopPct{,Ex}` previously omitted tags `99`, `211`, and `18=a`, causing the upstream CCP to reject every percent-based trailing-stop with `Invalid value in field # 18`. The amount-mode path already carried these tags; the percent-mode path was just out of sync.
- Per the ib-agent#156 capture: percent-mode mirrors the trail value in `99` and `211` as a 2-decimal string (`1.00` for 1 %), keeps `6268` as the basis-points form, and still needs `18=a` (ExecInst = TrailingStop). Patch adds exactly those three tags to both builders.
- Unit tests under `src/api/client/tests.rs` assert on the `OrderRequest` enum payload, not on wire bytes, which is why CI stayed green on the regression — the bug was wire-only.

Closes ibx#192.

## Test plan
- [x] `cargo build --lib` — clean.
- [x] `cargo test --lib place_order_trailing trail_order_with_trailing_percent` — 4 passed.
- [x] Live paper validation against `cdc1.ibllc.com`:
  - Phase 36 (Trailing Stop Percent Order, SPY) — **PASS** (previously failed with the rejection above).
  - Phase 37 (OCA Group, SPY) — **PASS**.
  - Phase 19 (amount-based Trailing Stop, SPY) — **PASS** (no regression on the path that was already correct).
- [ ] Follow-up not in this PR: paper-compat phase covering `SubmitTrailingStopPctEx` as a bracket child; wiring tag 58 (rejection reason) through `Wrapper::error()` so future wire-only rejects aren't silent (issue's step 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)