### PR TITLE
build: bump pyo3 0.24 -> 0.26 for Python 3.14 support (ibx#198)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,11 +883,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
- "cfg-if",
  "indoc",
  "inventory",
  "libc",
@@ -902,19 +901,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -922,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -934,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ env_logger = "0.11"
 mac_address = "1"
 
 # Python bindings (optional)
-pyo3 = { version = "0.24", features = ["extension-module", "multiple-pymethods"], optional = true }
+pyo3 = { version = "0.26", features = ["extension-module", "multiple-pymethods"], optional = true }
 
 [dev-dependencies]
 serde_json = "1"


### PR DESCRIPTION
Fixes #198.

`pyo3-ffi` 0.24 refuses CPython 3.14 at build time; pyo3 0.26 added 3.14 support. This bump compiles with no source changes:

- `cargo check --features python --lib` clean on this branch (CPython 3.14.5 interpreter)
- wheel builds via maturin, imports and runs on 3.14
- soak evidence: we run this exact change (on v0.5.1) against an IB paper account in a live trading service — login, account/positions reads, contract details, and the full order lifecycle (place/modify/cancel incl. algo orders) all exercised daily

No behavior change for ≤3.13 interpreters.

Co-authored with Claude (Anthropic).
