### PR TITLE
fix: parse good_till_date and emit correct GTD 126/432 expire encoding (ibx#199)

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -413,8 +413,8 @@ impl Order {
             min_qty: self.min_qty.max(0) as u32,
             hidden: self.hidden,
             outside_rth: self.outside_rth,
-            good_after: 0,
-            good_till: 0,
+            good_after: crate::config::ib_datetime_to_unix(&self.good_after_time),
+            good_till: crate::config::ib_datetime_to_unix(&self.good_till_date),
             oca_group: self.oca_group.parse().unwrap_or(0),
             oca_group_str: if self.oca_group.parse::<u64>().is_err() && !self.oca_group.is_empty() {
                 self.oca_group.clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,6 +108,47 @@ pub fn unix_to_ib_datetime(secs: i64) -> String {
     )
 }
 
+/// Convert (year, month, day) to days since Unix epoch. Inverse of `days_to_ymd`.
+pub fn ymd_to_days(y: u64, m: u64, d: u64) -> u64 {
+    // Algorithm from Howard Hinnant (days_from_civil)
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = y / 400;
+    let yoe = y - era * 400;
+    let mp = if m > 2 { m - 3 } else { m + 9 };
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// Parse an ibapi-style datetime string to unix seconds, treated as UTC.
+/// Accepts "YYYYMMDD HH:MM:SS", "YYYYMMDD-HH:MM:SS", or bare "YYYYMMDD".
+/// Anything after the seconds field (e.g. a timezone suffix) is ignored.
+/// Returns 0 for empty or unparseable input.
+pub fn ib_datetime_to_unix(s: &str) -> i64 {
+    let s = s.trim();
+    if s.len() < 8 || !s.is_char_boundary(8) {
+        return 0;
+    }
+    let (date, rest) = s.split_at(8);
+    let y = match date[0..4].parse::<u64>() { Ok(v) => v, Err(_) => return 0 };
+    let m = match date[4..6].parse::<u64>() { Ok(v) => v, Err(_) => return 0 };
+    let d = match date[6..8].parse::<u64>() { Ok(v) => v, Err(_) => return 0 };
+    if y < 1970 || !(1..=12).contains(&m) || !(1..=31).contains(&d) {
+        return 0;
+    }
+    let mut secs = (ymd_to_days(y, m, d) * 86400) as i64;
+    let time = rest.trim_start_matches(|c| c == ' ' || c == '-');
+    if time.len() >= 8 && time.is_char_boundary(8) {
+        let hh = time[0..2].parse::<i64>().unwrap_or(0);
+        let mm = time[3..5].parse::<i64>().unwrap_or(0);
+        let ss = time[6..8].parse::<i64>().unwrap_or(0);
+        if (0..24).contains(&hh) && (0..60).contains(&mm) && (0..60).contains(&ss) {
+            secs += hh * 3600 + mm * 60 + ss;
+        }
+    }
+    secs
+}
+
 /// Convert days since Unix epoch to (year, month, day).
 pub fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     // Algorithm from Howard Hinnant
@@ -122,4 +163,49 @@ pub fn days_to_ymd(days: u64) -> (u64, u64, u64) {
     let m = if mp < 10 { mp + 3 } else { mp - 9 };
     let y = if m <= 2 { y + 1 } else { y };
     (y, m, d)
+}
+
+#[cfg(test)]
+mod gtd_datetime_tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_with_unix_to_ib_datetime() {
+        for secs in [0i64, 86399, 1781199865, 4102444800] {
+            let s = unix_to_ib_datetime(secs);
+            assert_eq!(ib_datetime_to_unix(&s), secs, "round-trip failed for {s}");
+        }
+    }
+
+    #[test]
+    fn accepts_dash_and_space_separators() {
+        assert_eq!(
+            ib_datetime_to_unix("20260611-17:44:25"),
+            ib_datetime_to_unix("20260611 17:44:25"),
+        );
+        assert!(ib_datetime_to_unix("20260611-17:44:25") > 0);
+    }
+
+    #[test]
+    fn bare_date_is_midnight_utc() {
+        let secs = ib_datetime_to_unix("20260611");
+        assert_eq!(secs % 86400, 0);
+        assert_eq!(unix_to_ib_datetime(secs), "20260611 00:00:00");
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert_eq!(ib_datetime_to_unix(""), 0);
+        assert_eq!(ib_datetime_to_unix("tomorrow"), 0);
+        assert_eq!(ib_datetime_to_unix("2026061"), 0);
+        assert_eq!(ib_datetime_to_unix("20261311"), 0);
+    }
+
+    #[test]
+    fn ignores_timezone_suffix() {
+        assert_eq!(
+            ib_datetime_to_unix("20260611 17:44:25 UTC"),
+            ib_datetime_to_unix("20260611 17:44:25"),
+        );
+    }
 }

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -143,8 +143,17 @@ pub(crate) fn drain_and_send_orders(
                 let now = chrono_free_timestamp();
                 let display_str = format_uint(attrs.display_size as u64);
                 let min_qty_str = format_uint(attrs.min_qty as u64);
-                let gat_str = if attrs.good_after > 0 { unix_to_ib_datetime(attrs.good_after) } else { String::new() };
-                let gtd_str = if attrs.good_till > 0 { unix_to_ib_datetime(attrs.good_till) } else { String::new() };
+                // 126 (ExpireTime) / 168 (EffectiveTime) are FIX UTCTimestamps:
+                // "YYYYMMDD-HH:MM:SS" — the gateway rejects the space-separated
+                // form with "Invalid value in field # 126" (and then, treating
+                // 126 as absent, demands 432).
+                let gat_str = if attrs.good_after > 0 { unix_to_ib_datetime(attrs.good_after).replace(' ', "-") } else { String::new() };
+                let gtd_str = if attrs.good_till > 0 { unix_to_ib_datetime(attrs.good_till).replace(' ', "-") } else { String::new() };
+                // GTD wire encoding (verified against the paper gateway):
+                // time-precise GTD → 126 alone; date-only GTD (midnight UTC)
+                // → 432 ("YYYYMMDD") alone. Sending both gets the order
+                // rejected with "Invalid value in field # 432".
+                let gtd_date_str = if attrs.good_till > 0 && attrs.good_till % 86400 == 0 { gtd_str[..8].to_string() } else { String::new() };
                 let oca_str = if !attrs.oca_group_str.is_empty() {
                     attrs.oca_group_str.clone()
                 } else if attrs.oca_group > 0 {
@@ -190,7 +199,11 @@ pub(crate) fn drain_and_send_orders(
                     fields.push((168, &gat_str));
                 }
                 if attrs.good_till > 0 {
-                    fields.push((126, &gtd_str));
+                    if !gtd_date_str.is_empty() {
+                        fields.push((432, &gtd_date_str));
+                    } else {
+                        fields.push((126, &gtd_str));
+                    }
                 }
                 if !oca_str.is_empty() {
                     fields.push((583, &oca_str));


### PR DESCRIPTION
Fixes #199.

Two changes, matching the analysis in the issue:

**1. `Order::attrs()` now parses `good_till_date` / `good_after_time`** (src/api/types.rs) instead of hardcoding 0. New `config::ib_datetime_to_unix()` is the inverse of the existing `unix_to_ib_datetime()`: accepts `YYYYMMDD HH:MM:SS`, `YYYYMMDD-HH:MM:SS`, or bare `YYYYMMDD` (treated as UTC; anything after the seconds field, e.g. a tz suffix, is ignored — documented). Includes `ymd_to_days()` (Hinnant days_from_civil, inverse of the existing `days_to_ymd`) and round-trip + garbage-rejection unit tests.

**2. GTD wire encoding** (src/engine/hot_loop/order_builder.rs), per the empirically verified gateway dialect:
- time-precise GTD → tag **126 alone**, `YYYYMMDD-HH:MM:SS` (dash — the space-separated form is rejected as `Invalid value in field # 126`)
- date-only GTD (midnight) → tag **432 alone**, `YYYYMMDD`
- never both (432+126 together → `Invalid value in field # 432`)
- 168 (EffectiveTime / `good_after_time`) switched to the same dash format for consistency

**Validation on an IB paper account:** GTD LMT now acks (`PreSubmitted`), rests, and the gateway broker-side cancels at the requested timestamp — verified with a now+75s expiry, `Cancelled` arriving on schedule with no client-side cancel. DAY/GTC/IOC paths unchanged. `cargo test --lib config` green on this branch.

Co-authored with Claude (Anthropic).
