### PR TITLE
ccp: drop an order the gateway says it does not have, rather than restoring it (ibx#252)

### DIFF
--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -1144,27 +1144,36 @@ impl CcpState {
 
         let Some(oid) = orig_clord else { return };
 
+        // FIX CxlRejReason 1 = UnknownOrder: the gateway is saying the order
+        // does not exist on its side, so there is nothing to restore it to.
+        // Restoring it anyway left the engine asserting a phantom order was
+        // working while the cache row that would surface it was removed —
+        // opposite halves of the same state disagreeing (ibx#252). Every other
+        // reason (TooLate, OrderInProcess, ...) means the order really is still
+        // working, so the cancel is undone and a follow-up exec report
+        // reconciles.
+        let unknown_order = reason_code == 1;
+
         // Update local context only if we tracked the order in this session.
         let instrument = if let Some(order) = context.order(oid).copied() {
-            let restore_status = if order.filled > 0 {
-                crate::types::OrderStatus::PartiallyFilled
+            if unknown_order {
+                context.remove_order(oid);
             } else {
-                crate::types::OrderStatus::Submitted
-            };
-            // Deliberate regression (PendingCancel back to working) — the
-            // ibx#212 guard would rightly block it on the ordinary path.
-            context.set_order_status_forced(oid, restore_status);
+                let restore_status = if order.filled > 0 {
+                    crate::types::OrderStatus::PartiallyFilled
+                } else {
+                    crate::types::OrderStatus::Submitted
+                };
+                // Deliberate regression (PendingCancel back to working) — the
+                // ibx#212 guard would rightly block it on the ordinary path.
+                context.set_order_status_forced(oid, restore_status);
+            }
             order.instrument
         } else {
             0
         };
 
-        // FIX CxlRejReason 1 = UnknownOrder. The gateway is telling us the
-        // order it just listed in the mass-status burst doesn't exist on its
-        // side — drop the stale cache entry so subsequent req_open_orders
-        // stops returning it. Other reasons (TooLate, OrderInProcess, ...)
-        // leave the cache alone; a follow-up exec report will reconcile.
-        if reason_code == 1 {
+        if unknown_order {
             shared.orders.remove_order_info(oid);
         }
 
@@ -2175,6 +2184,39 @@ mod tests {
             m.insert(*tag, val.to_string());
         }
         m
+    }
+
+    fn cancel_reject_frame(reason_code: &str) -> std::collections::HashMap<u32, String> {
+        let mut m = std::collections::HashMap::new();
+        m.insert(41u32, "42".to_string());   // OrigClOrdID
+        m.insert(434u32, "1".to_string());   // CxlRejResponseTo = cancel request
+        m.insert(102u32, reason_code.to_string());
+        m.insert(58u32, "reject".to_string());
+        m
+    }
+
+    /// ibx#252: CxlRejReason 1 is the gateway saying the order does not exist.
+    /// Restoring it to working left the engine asserting a phantom order while
+    /// the cache row was dropped — the two halves disagreeing.
+    #[test]
+    fn cancel_reject_unknown_order_drops_the_order_rather_than_restoring_it() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        context.set_order_status_forced(42, crate::types::OrderStatus::PendingCancel);
+        ccp.handle_cancel_reject(&cancel_reject_frame("1"), &mut context, &shared, &None);
+        assert!(context.order(42).is_none(),
+            "an order the gateway does not have must not stay in the engine");
+    }
+
+    /// Every other reason means the order really is still working, so the
+    /// cancel is undone exactly as before.
+    #[test]
+    fn cancel_reject_too_late_restores_the_order_to_working() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        context.set_order_status_forced(42, crate::types::OrderStatus::PendingCancel);
+        ccp.handle_cancel_reject(&cancel_reject_frame("0"), &mut context, &shared, &None);
+        assert_eq!(context.order(42).map(|o| o.status),
+            Some(crate::types::OrderStatus::Submitted),
+            "a TooLate reject must leave the order working");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `handle_cancel_reject` (`src/engine/hot_loop/ccp.rs:1147-1170`) force-restored the order to `Submitted`/`PartiallyFilled` before reading the reject reason, and only afterwards removed the shared-cache row for `CxlRejReason 1`.
- For UnknownOrder that inverted the message being handled: the gateway says the order does not exist, and ibx responded by putting it back to working in the engine while deleting the row that would have made it visible. Engine and cache then assert opposite things.
- The reason is now read first. UnknownOrder removes the order from the engine as well as the cache; every other reason keeps today's restore, since those mean the order really is still working.
- Closes #252.

## Test

Two tests either side of the branch: `cancel_reject_unknown_order_drops_the_order_rather_than_restoring_it` and `cancel_reject_too_late_restores_the_order_to_working`. Reverting the branch fails the first and leaves the second passing, so it pins the distinction rather than the mechanism.

`cargo test --lib` — 804 pass. The two `config::expiry_tests` failures are present on `main` before this branch.

## Note

The ibx#212 bypass is untouched — PendingCancel back to working is still a regression the ordinary guard would rightly block, so the restore path keeps `set_order_status_forced` and its comment.

Related: #251 covers the wider case where an order the gateway no longer has is never reconciled at all after a reconnect. This PR only fixes the path where the gateway tells us explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
