### PR TITLE
engine: stop gateway input panicking the hot loop (ibx#257, ibx#258)

### DIFF
--- a/src/control/contracts.rs
+++ b/src/control/contracts.rs
@@ -652,13 +652,12 @@ pub fn format_sessions_string(sessions: &[ScheduleSession]) -> String {
     for (i, s) in sessions.iter().enumerate() {
         if i > 0 { out.push(';'); }
         if s.start == s.end {
-            let date = if s.trade_date.len() >= 8 {
-                &s.trade_date[..8]
-            } else if s.start.len() >= 8 {
-                &s.start[..8]
-            } else {
-                s.start.as_str()
-            };
+            // get() rather than a length check plus a slice: it rejects a
+            // non-char boundary as well as a short field, so a lossily-decoded
+            // frame cannot panic here (ibx#258).
+            let date = s.trade_date.get(..8)
+                .or_else(|| s.start.get(..8))
+                .unwrap_or(s.start.as_str());
             out.push_str(date);
             out.push_str(":CLOSED");
         } else {
@@ -674,7 +673,11 @@ pub fn format_sessions_string(sessions: &[ScheduleSession]) -> String {
 /// Returns the input unchanged if the format does not match.
 fn trim_session_endpoint(s: &str) -> String {
     let bytes = s.as_bytes();
-    if bytes.len() >= 14 && bytes[8] == b'-' && bytes[11] == b':' {
+    // The reasoning below is in bytes, so it is only sound on ASCII. Frame
+    // bodies are decoded with from_utf8_lossy, and one invalid byte becomes a
+    // three-byte U+FFFD that can straddle a slice boundary — a panic on the
+    // hot loop rather than a bad value (ibx#258).
+    if s.is_ascii() && bytes.len() >= 14 && bytes[8] == b'-' && bytes[11] == b':' {
         let mut out = String::with_capacity(13);
         out.push_str(&s[..8]);
         out.push(':');
@@ -685,6 +688,54 @@ fn trim_session_endpoint(s: &str) -> String {
         s.to_string()
     }
 }
+#[cfg(test)]
+mod hot_loop_panic_tests {
+    use super::*;
+
+    /// ibx#258: frame bodies are decoded with from_utf8_lossy, so one invalid
+    /// byte becomes a three-byte U+FFFD that can straddle a byte-indexed slice
+    /// boundary. These must return a value, not abort the hot loop.
+    #[test]
+    fn session_endpoint_survives_a_lossily_decoded_field() {
+        // U+FFFD at bytes 12..15 — the old &s[12..14] cut inside it.
+        let lossy = format!("20260728-09:{}0", '\u{FFFD}');
+        assert!(!lossy.is_ascii());
+        let _ = trim_session_endpoint(&lossy);
+
+        let lossy2 = format!("2026072{}-09:30", '\u{FFFD}');
+        let _ = trim_session_endpoint(&lossy2);
+
+        // The ASCII form still trims exactly as before.
+        assert_eq!(trim_session_endpoint("20260728-09:30"), "20260728:0930");
+        assert_eq!(trim_session_endpoint("short"), "short");
+    }
+
+    /// The closed-session branch is the one that slices trade_date/start, and
+    /// it is only taken when start == end. The previous version of this test
+    /// set them differently, so it never reached the slice at all and passed
+    /// against the unfixed code too.
+    #[test]
+    fn sessions_string_survives_a_non_ascii_trade_date() {
+        let closed = format!("2026072{}", '\u{FFFD}');
+        let s = ScheduleSession {
+            trade_date: closed.clone(),
+            start: closed.clone(),
+            end: closed,
+        };
+        let out = format_sessions_string(&[s]);
+        assert!(!out.is_empty(), "a closed session must still render");
+
+        // A short trade_date falls back to start, and a short start to the
+        // whole string, without slicing past a boundary.
+        let short = ScheduleSession {
+            trade_date: "2026".to_string(),
+            start: "2026".to_string(),
+            end: "2026".to_string(),
+        };
+        let _ = format_sessions_string(&[short]);
+    }
+}
+
 
 // ─── Matching symbols search ───
 

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -890,6 +890,10 @@ impl Context {
 
     // ── Instrument management ──
 
+    pub fn try_register_instrument(&mut self, con_id: i64) -> Option<InstrumentId> {
+        self.market.try_register(con_id)
+    }
+
     pub fn register_instrument(&mut self, con_id: i64) -> InstrumentId {
         self.market.register(con_id)
     }

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -681,7 +681,10 @@ impl CcpState {
         // context.order(clord_id) and emit OrderUpdate events to the user. ibx#191.
         let is_new_ack = parsed.get(&150).map(|s| s.as_str()) == Some("0")
             && parsed.get(&39).map(|s| s.as_str()) == Some("0");
-        if is_new_ack && context.order(clord_id).is_none() {
+        // The sentinel is dropped further down, but this recovery insert runs
+        // first — without the guard, a `11='*'` terminator registers a conId
+        // and inserts the reserved order id 0 before being "discarded".
+        if is_new_ack && clord_id != 0 && context.order(clord_id).is_none() {
             let con_id: i64 = parsed.get(&6008).and_then(|s| s.parse().ok()).unwrap_or(0);
             let side = match parsed.get(&54).map(|s| s.as_str()) {
                 Some("1") => Side::Buy,
@@ -700,7 +703,22 @@ impl CcpState {
             let ord_type_byte: u8 = parsed.get(&40).and_then(|s| s.bytes().next()).unwrap_or(b'2');
             let tif_byte: u8 = parsed.get(&59).and_then(|s| s.bytes().next()).unwrap_or(b'1');
             if con_id != 0 && qty > 0 {
-                let instrument = context.register_instrument(con_id);
+                // Recovery is fed by gateway frames, so a full instrument
+                // table must degrade to a missing order rather than take the
+                // engine down (ibx#257). The reconnect burst replays every
+                // resting order, which is exactly when the table fills.
+                // Skipping only the insert keeps the order in last_clord and
+                // the rich-order cache, so req_open_orders still shows it —
+                // but it is NOT in the engine book, so a later fill or
+                // terminal status for it is dropped and no OrderUpdate
+                // reaches the caller (ibx#297). A missing order beats taking
+                // the engine down; it is not a complete answer.
+                match context.try_register_instrument(con_id) {
+                    None => log::warn!(
+                        "recovery: instrument table full, order clord={} con_id={} not tracked in the engine book",
+                        clord_id, con_id,
+                    ),
+                    Some(instrument) => {
                 if let Some(sym) = parsed.get(&55) {
                     context.set_symbol(instrument, sym.clone());
                 }
@@ -719,6 +737,8 @@ impl CcpState {
                 log::info!("CCP recovery: inserted orderId={} sym={:?} side={:?} qty={} px={}",
                     clord_id, parsed.get(&55), side, qty,
                     limit_price_i64 as f64 / PRICE_SCALE as f64);
+                    }
+                }
             }
         }
 
@@ -2077,6 +2097,30 @@ mod tests {
         (CcpState::new(), context, SharedState::new())
     }
 
+    /// The recovery-push terminator carries `11='*'`, which parses to the
+    /// reserved order id 0. It is dropped further down the handler, but the
+    /// recovery insert runs first — so without a guard there it registers the
+    /// frame's conId and inserts order 0 before the "discard".
+    #[test]
+    fn the_recovery_terminator_mutates_no_state_before_it_is_dropped() {
+        // A clean context: the shared fixture pre-registers its conId, which
+        // would mask exactly what this test is looking for.
+        let mut ccp = CcpState::new();
+        let mut context = Context::new();
+        let shared = SharedState::new();
+        let frame: std::collections::HashMap<u32, String> = [
+            (11u32, "*"), (150, "0"), (39, "0"), (6008, "265598"), (38, "1"), (54, "1"),
+        ].iter().map(|(k, v)| (*k, v.to_string())).collect();
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        assert!(context.order(0).is_none(), "the reserved order id must not be inserted");
+        assert!(
+            context.market.instrument_by_con_id(265598).is_none(),
+            "the terminator must not register an instrument",
+        );
+    }
+
     // ibx#205: a margin-reducing preview (close, cash-account sell) resolves to a
     // post-trade init margin of exactly 0, which the gateway sends as numeric "0"
     // (ib-agent#160). The old `> 0.0` guard dropped it and the caller timed out.
@@ -2166,6 +2210,42 @@ mod tests {
             42, instrument, Side::Buy, 1, 100 * PRICE_SCALE, b'2', b'0', 0,
         )); // starts at PendingSubmit
         (CcpState::new(), context, SharedState::new())
+    }
+
+    /// A recovery record arriving with the instrument table already full used
+    /// to take the engine down. A missing order beats a dead hot loop, and the
+    /// conversion to the fallible register is what makes that true — nothing
+    /// else in the suite fails if it is reverted.
+    #[test]
+    fn a_full_instrument_table_does_not_abort_the_recovery_path() {
+        let mut context = Context::new();
+        let mut ccp = CcpState::new();
+        let shared = SharedState::new();
+
+        // Fill every slot, so the next registration has nowhere to go.
+        for con_id in 1..=(crate::types::MAX_INSTRUMENTS as i64) {
+            assert!(context.try_register_instrument(con_id).is_some(), "slot {con_id}");
+        }
+        assert!(
+            context.try_register_instrument(999_999).is_none(),
+            "the table really is full",
+        );
+
+        let mut frame = std::collections::HashMap::new();
+        for (tag, val) in [
+            (11u32, "42"), (150, "0"), (39, "0"), (6008, "888888"),
+            (38, "100"), (55, "SPY"), (54, "1"),
+        ] {
+            frame.insert(tag, val.to_string());
+        }
+
+        // The point of the test: this must return rather than panic.
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        assert!(
+            context.order(42).is_none(),
+            "the order is not tracked, which is the acknowledged cost",
+        );
     }
 
     fn exec_report_frame(pairs: &[(u32, &str)]) -> std::collections::HashMap<u32, String> {

--- a/src/engine/hot_loop/hmds.rs
+++ b/src/engine/hot_loop/hmds.rs
@@ -195,7 +195,10 @@ impl HmdsState {
                     log::debug!(
                         "HMDS W xml head (len={}): {:?}",
                         xml_tag.len(),
-                        &xml_tag[..xml_tag.len().min(200)],
+                        // Byte-slicing a lossily decoded value panics when
+                        // byte 200 lands inside a multi-byte character, which
+                        // aborts the hot loop exactly when debug logging is on.
+                        xml_tag.get(..200).unwrap_or(xml_tag),
                     );
                     if let Some(resp) = crate::control::historical::parse_bar_response(xml_tag) {
                         if let Some(pos) = self.pending_historical.iter().position(|(qid, _, _)| resp.query_id.starts_with(qid.as_str())) {
@@ -1116,6 +1119,26 @@ impl HmdsState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The diagnostic log byte-sliced a lossily decoded value, so a tag whose
+    /// two-hundredth byte fell inside a multi-byte character aborted the hot
+    /// loop — and only when debug logging was on, which is to say only while
+    /// someone was diagnosing an incident.
+    #[test]
+    fn a_non_utf8_xml_tag_does_not_abort_the_hot_loop() {
+        // 199 ASCII bytes then one invalid byte: byte 200 is not a boundary.
+        let mut value = "a".repeat(199).into_bytes();
+        value.push(0xFF);
+        let lossy = String::from_utf8_lossy(&value).to_string();
+
+        // The slice the log performs, on the value the parser would hold.
+        let head = lossy.get(..200).unwrap_or(&lossy);
+        assert!(!head.is_empty(), "a head is produced rather than panicking");
+        assert!(
+            lossy.len() > 200 || head.len() <= lossy.len(),
+            "and it never exceeds the value it came from",
+        );
+    }
 
     fn make_query_error_msg(query_id: &str, error: &str) -> Vec<u8> {
         let xml = format!(


### PR DESCRIPTION
## Summary

Two panics reachable from gateway frames, both on the hot loop. A panic there is an engine-down, not a dropped message, which is what puts them together in one change.

**#257 — recovery registers through the panicking wrapper.** The session-recovery insert (`src/engine/hot_loop/ccp.rs:703`) called `context.register_instrument`, which resolves to `MarketState::register` — `try_register(..).expect("too many instruments")` (`market_state.rs:94-96`). #233 converted the client-facing path to `try_register` plus a rejection and left this caller on the old wrapper, and this is the one fed directly by inbound data: a reconnect replays every resting order across sessions, so an account holding orders on more than 256 distinct contracts aborted mid-recovery having taken out no subscriptions at all. It now uses a fallible `try_register_instrument` and drops the order with a warning.

**#258 — byte-guarded string slicing.** `trim_session_endpoint` (`src/control/contracts.rs:675`) checked byte positions and then sliced the `&str`. Frame bodies are decoded with `from_utf8_lossy` (`protocol/fix.rs:151`), so one invalid byte in tag 6841/6842 of a `6040=107` reply becomes a three-byte U+FFFD and `&s[12..14]` cuts inside it. The guard now requires `s.is_ascii()`, which is what makes reasoning in bytes sound rather than accidental. `format_sessions_string` had the same shape twice (`:656`, `:658`) and now uses `get(..8)`, which rejects a non-char boundary as well as a short field.

Closes #257 and #258.

## Test

`session_endpoint_survives_a_lossily_decoded_field` and `sessions_string_survives_a_non_ascii_trade_date` feed exactly the shape `from_utf8_lossy` produces. Removing the ASCII guard reproduces the original abort verbatim — `byte index 14 is not a char boundary; it is inside '\u{FFFD}' (bytes 12..15)` — so the test pins the panic rather than the phrasing of the fix.

## Note

`MarketState::register` now has no non-test callers. Leaving a panicking convenience wrapper in place is how this recurred after #233, so it is worth deleting or putting behind `#[cfg(test)]` — I left it alone here to keep the change to the defect.

## Test plan

- [x] `cargo test --offline --lib` — 807 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

