### PR TITLE
connection: do not chain the read IV off a frame that failed verification (ibx#275)

### DIFF
--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -282,7 +282,18 @@ impl Connection {
             return (msg.to_vec(), true);
         }
         let (undistorted, new_iv, valid) = fix::fix_unsign(msg, &self.read_key, &self.read_iv);
-        self.read_iv = new_iv;
+        if valid {
+            self.read_iv = new_iv;
+        } else {
+            // Do not chain off a frame that failed verification. The
+            // undistortion step XORs byte positions using this IV, so advancing
+            // it here desynchronised the read chain permanently and every later
+            // genuine frame arrived corrupted, with nothing surfaced (ibx#275).
+            log::warn!(
+                "inbound frame failed HMAC verification ({} bytes) — read IV not advanced",
+                msg.len(),
+            );
+        }
         (undistorted, valid)
     }
 
@@ -476,6 +487,33 @@ mod tests {
         assert_eq!(find_subsequence(b"hello world", b"world"), Some(6));
         assert_eq!(find_subsequence(b"hello world", b"xyz"), None);
         assert_eq!(find_subsequence(b"8=FIX.4.1\x01", b"8=FIX."), Some(0));
+    }
+
+    /// ibx#275: a frame that fails verification must not chain the read IV.
+    /// The undistortion step XORs byte positions using it, so advancing it on a
+    /// bad frame corrupted every genuine frame that followed.
+    #[test]
+    fn failed_verification_does_not_advance_the_read_iv() {
+        let key = vec![0xAAu8; 20];
+        let iv = vec![0x11u8; 16];
+        let mut conn = test_connection_with_buf(Vec::new());
+        conn.read_key = key.clone();
+        conn.read_iv = iv.clone();
+
+        // A properly signed frame, then the same frame with one payload byte
+        // flipped so the MAC no longer matches.
+        let (signed, _next_iv) = fix::fix_sign(&fix_build(&[(35, "0")], 1), &key, &iv);
+        let mut tampered = signed.clone();
+        let last = tampered.len() - 12;
+        tampered[last] ^= 0x01;
+
+        let (_out, valid) = conn.unsign(&tampered);
+        assert!(!valid, "tampering must be detected by the code that computes the flag");
+        assert_eq!(conn.read_iv, iv, "a rejected frame must not chain the IV");
+
+        // The genuine frame still verifies against the unadvanced IV.
+        let (_out, valid) = conn.unsign(&signed);
+        assert!(valid, "a genuine frame must still verify after a rejected one");
     }
 
     /// Helper: create a Connection with a dummy TCP stream for buffer tests.


### PR DESCRIPTION
## Summary

`Connection::unsign` (`src/protocol/connection.rs:285`) assigned `self.read_iv = new_iv` before knowing whether the frame verified. Since the undistortion step XORs byte positions using that IV (`fix.rs:338-344`), one frame that failed verification permanently desynchronised the read chain, and every genuine frame afterwards was silently corrupted before parsing.

The IV now advances only when verification succeeded, and a failure logs at warn.

Partially addresses #275.

## What this deliberately does not do

#275 has three legs. This PR fixes one:

1. ~~a failed verification advances the read IV~~ — fixed here
2. the validity flag is discarded at all thirteen call sites
3. `unsign` returns `(msg, true)` when the frame carries no `8349=` tag, so checking the flag would not be sufficient

Legs 2 and 3 both change what the client accepts from the gateway. If unsigned frames legitimately occur on a signed connection — which I cannot determine from the source — enforcing would break connectivity rather than harden it. That is a capture question and yours to answer, so I have left it rather than guess on a path where guessing wrong takes the client offline.

This leg needs no such judgement: chaining off a frame you have just decided not to trust is wrong under either answer, and today it corrupts the stream silently.

## Test

`failed_verification_does_not_advance_the_read_iv` signs a frame, flips a payload byte, and asserts the rejected frame leaves the IV untouched and that a genuine frame still verifies after it. Restoring the unconditional assignment fails it.

`cargo test --lib` — 803 pass. The two `config::expiry_tests` failures are present on `main` before this branch.

## Note

The warn log is the point as much as the IV fix: with the flag discarded everywhere, there is currently no way to know this is happening. Even before legs 2 and 3 are settled, a line in the log turns an invisible stream corruption into something diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
