### PR TITLE
auth: take the IBKey token sub-type from AUTH_START (ibx#279)

### DIFF
--- a/docs/book/src/api/python-reference.md
+++ b/docs/book/src/api/python-reference.md
@@ -46,7 +46,7 @@ def connect(host="cdc1.ibllc.com".to_string(), port=0, client_id=0, username="".
 | `paper` | `bool` | If `true`, connect to paper trading. If `false`, connect blocks on the live second-factor approval window (see method note). |
 | `core_id` | `usize or None` | CPU core affinity for the hot loop thread. Use a distinct value per engine when running several in one process. |
 | `ib_key_timeout_secs` | `int or None` | Live second-factor approval timeout in seconds (default ~18 min). Lower it to fail fast on unattended live logins; ignored for paper. |
-| `ib_key_token_sub_type` | `str or None` | Account-specific second-factor token sub-type (default `"2a"`); ignored for paper. |
+| `ib_key_token_sub_type` | `str or None` | Fallback second-factor token sub-type (default `"2a"`), used only when the server states none for the session; ignored for paper. |
 
 ---
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -899,11 +899,13 @@ pub struct GatewayConfig {
     /// server-side deadline). Set lower to fail fast for unattended logins.
     /// Only consulted on non-paper logins; paper logins skip the gate entirely.
     pub ib_key_timeout_secs: u64,
-    /// Account-specific second-factor token sub-type used in the SWCR_TOKEN
-    /// state=1 init body (`M.D` field). Default `"2a"` matches the captured
-    /// reference profile; other accounts may use a different value. Capture
-    /// the live value via ib-agent's `SWCR_TOKEN_SUBTYPE` hook if the default
-    /// doesn't trigger the IBKey push for your account.
+    /// Fallback second-factor token sub-type for the SWCR_TOKEN state=1 init
+    /// body (`M.D` field).
+    ///
+    /// `AUTH_START` states the sub-type for the session, and that value wins:
+    /// it is account- and session-specific, so a fixed setting can only ever
+    /// match the profile it came from. This is what gets used when the server
+    /// states none. Default `"2a"` matches the captured reference profile.
     pub ib_key_token_sub_type: String,
     /// If set, the IBKey gate uses the **Challenge/Response** path instead
     /// of waiting for a mobile push approval. After the server delivers
@@ -912,6 +914,26 @@ pub struct GatewayConfig {
     /// [`session::CodeProvider`] for the contract; `None` leaves behavior
     /// unchanged (push approval).
     pub code_provider: Option<session::CodeProvider>,
+}
+
+/// The second-factor sub-type `AUTH_START` states for the IBKey token.
+///
+/// Field 4 carries `<type>` or `<type>.<sub-type>`, and a comma-separated list
+/// when the account has more than one factor enabled — `4,5` was advertised for
+/// an account holding both an authenticator and IBKey. The list is split before
+/// the dot, so a sub-type on one entry cannot swallow the entries after it:
+/// reading `"5.2a,4"` as one pair yields `2a,4`, which is not a sub-type at all
+/// and is rejected by a server that would have accepted `2a`.
+///
+/// The sub-type returned is the one belonging to type `5`, since that is the
+/// token this gate sends. A sub-type stated against some other type is not
+/// IBKey's and is ignored.
+fn parse_auth_start_sub_type(auth_start: &str) -> Option<String> {
+    let field = auth_start.split(';').nth(4)?;
+    field.split(',').find_map(|entry| {
+        let (ty, sub) = entry.trim().split_once('.')?;
+        (ty.trim() == "5" && !sub.trim().is_empty()).then(|| sub.trim().to_string())
+    })
 }
 
 impl Gateway {
@@ -1016,7 +1038,7 @@ impl Gateway {
         session::send_secure(&mut tls, &mut channel, connect_req.as_bytes())?;
 
         // Receive AUTH_START (may get a redirect instead for paper accounts)
-        let _auth_start = match session::recv_secure(&mut tls, &mut channel) {
+        let auth_start = match session::recv_secure(&mut tls, &mut channel) {
             Ok(data) => data,
             Err(e) if e.to_string().starts_with("REDIRECT:") => {
                 let target = e.to_string().strip_prefix("REDIRECT:").unwrap().to_string();
@@ -1028,6 +1050,15 @@ impl Gateway {
             }
             Err(e) => return Err(e),
         };
+
+        // AUTH_START field 4 names the second-factor token type and its
+        // per-session subtype, e.g. "5.2i" = tokenType 5 (IBKey), subtype "2i".
+        // The subtype is account- and session-specific, so the compiled-in
+        // default only ever matches the profile it was captured from; every
+        // other account has its SWCR_TOKEN rejected and the socket closed
+        // before a challenge is issued (ibx#279).
+        let server_token_sub_type =
+            parse_auth_start_sub_type(&String::from_utf8_lossy(&auth_start));
 
         // Authentication
         log::info!("Starting auth for {}", config.username);
@@ -1062,9 +1093,20 @@ impl Gateway {
                     config.username, config.ib_key_timeout_secs,
                 );
             }
+            // The server's per-session value wins. `ib_key_token_sub_type` is
+            // the fallback for an AUTH_START that states none, not an override
+            // — a fixed value cannot be right for a session it predates.
+            let token_sub_type = server_token_sub_type
+                .as_deref()
+                .unwrap_or(&config.ib_key_token_sub_type);
+            log::info!(
+                "2FA gate: token sub-type {:?} ({})",
+                token_sub_type,
+                if server_token_sub_type.is_some() { "from AUTH_START" } else { "configured default" },
+            );
             match session::do_ib_key_2fa(
                 &mut tls,
-                &config.ib_key_token_sub_type,
+                token_sub_type,
                 deadline,
                 config.code_provider.as_ref(),
             )? {
@@ -1883,6 +1925,37 @@ pub use crate::config::{chrono_free_timestamp, days_to_ymd};
 
 #[cfg(test)]
 mod tests {
+
+    /// Field 4 selects the second factor and states its sub-type. The whole
+    /// field was read as one pair, so a list put the following entries inside
+    /// the sub-type: `"5.2a,4"` sent `2a,4`, which is not a sub-type — an
+    /// account that worked on the compiled-in `2a` would have had its token
+    /// rejected and the socket closed before any challenge (ibx#279).
+    #[test]
+    fn the_ib_key_sub_type_comes_from_the_ib_key_entry() {
+        use super::parse_auth_start_sub_type as parse;
+        let frame = |token: &str| format!("a;b;c;d;{token};f");
+
+        // The single-factor case this was written for.
+        assert_eq!(parse(&frame("5.2i")), Some("2i".into()));
+        assert_eq!(parse(&frame(" 5.2i ")), Some("2i".into()));
+
+        // A list must not fold the later entries into the sub-type.
+        assert_eq!(parse(&frame("5.2a,4")), Some("2a".into()));
+        assert_eq!(parse(&frame("4,5.2i")), Some("2i".into()));
+
+        // A sub-type stated against another factor is not IBKey's.
+        assert_eq!(parse(&frame("4.auth")), None);
+        assert_eq!(parse(&frame("4.auth,5.2i")), Some("2i".into()));
+
+        // Nothing to take: the configured value is used instead.
+        assert_eq!(parse(&frame("5")), None);
+        assert_eq!(parse(&frame("4,5")), None);
+        assert_eq!(parse(&frame("5.")), None);
+        assert_eq!(parse(&frame("")), None);
+        assert_eq!(parse("a;b;c"), None, "a short frame has no field 4");
+    }
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary

`AUTH_START` field 4 names the second-factor token type and its per-session sub-type — `"5.2i"` is type 5 (IBKey), sub-type `"2i"`. The main connect path received that payload and discarded it (`src/gateway.rs:1019`), then entered the gate with `config.ib_key_token_sub_type`, defaulting to the `"2a"` captured in ib-agent#123.

For any account whose sub-type is not `"2a"`, the server rejects the `SWCR_TOKEN` and closes the socket before issuing a challenge. No push is dispatched, so there is nothing for the user to approve, and the error reads like a protocol or account-configuration fault.

The sub-type now comes from the field the server just sent. `ib_key_token_sub_type` remains as an override for the case where `AUTH_START` carries none, and the gate logs which source it used.

Closes #279.

## Verified live

On an account with sub-type `2i`, before:

```
Auth complete
2FA gate: sent SWCR_TOKEN state=1 (40 bytes inner, 48 bytes framed)
Error: 2FA gate: server closed socket before issuing a challenge
```

After:

```
2FA gate: token sub-type "2i" (from AUTH_START)
2FA gate: awaiting approval (session_id=205 252, approval_url=...)
2FA gate: approved
Auth: trading farm route = ndc1.ibllc.com/usfarm
Auth: market-data farm route = ndc1.ibllc.com/ushmds/4000
```

The push arrived on the phone, approval completed, and the session went on to subscribe market data on three contracts. The same account authenticates normally through IB Gateway and ib_async, both of which take the sub-type from the auth response — which is what made a wrong constant, rather than a wrong frame layout, the likely explanation.

## Note on the code's own warning

`src/protocol/xyz.rs:131` already says the value is "computed server-side per session — for accounts matching the captured profile it's `2a`, but other accounts/SWCR configurations may differ", and suggests capturing the live value if the default does not trigger the push. The field carrying that value is in the message immediately preceding the gate, so the capture step is not needed.

## Prior art

#129 diagnosed this correctly and listed "Parse token subtype from AUTH_START" among its changes, with the same `"5.2i"` to `"2i"` derivation. It was closed when #111 landed, and the implementation that shipped used the captured constant instead. This restores the parse on top of the current code.

## Test plan

- [x] `cargo test --offline --lib` — 803 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.
- [x] Mutation check: dropping the type-5 ownership check fails `the_ib_key_sub_type_comes_from_the_ib_key_entry` by name.
- [ ] Not covered: the call site that uses the parse is inside `connect`, which needs a socket and a completed SRP exchange, so reverting it to an inline split still fails nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
