### PR TITLE
auth: support the authenticator-code second factor (ibx#282)

### DIFF
--- a/docs/book/src/api/python-reference.md
+++ b/docs/book/src/api/python-reference.md
@@ -46,7 +46,7 @@ def connect(host="cdc1.ibllc.com".to_string(), port=0, client_id=0, username="".
 | `paper` | `bool` | If `true`, connect to paper trading. If `false`, connect blocks on the live second-factor approval window (see method note). |
 | `core_id` | `usize or None` | CPU core affinity for the hot loop thread. Use a distinct value per engine when running several in one process. |
 | `ib_key_timeout_secs` | `int or None` | Live second-factor approval timeout in seconds (default ~18 min). Lower it to fail fast on unattended live logins; ignored for paper. |
-| `ib_key_token_sub_type` | `str or None` | Account-specific second-factor token sub-type (default `"2a"`); ignored for paper. |
+| `ib_key_token_sub_type` | `str or None` | Fallback second-factor token sub-type (default `"2a"`), used only when the server states none for the session; ignored for paper. |
 
 ---
 

--- a/examples/account_whatif.rs
+++ b/examples/account_whatif.rs
@@ -86,6 +86,7 @@ fn connect() -> Result<EClient, Box<dyn std::error::Error>> {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     })?)
 }
 

--- a/examples/ex111_live_2fa_aapl.rs
+++ b/examples/ex111_live_2fa_aapl.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("== Connecting LIVE ({}). Approve the second-factor push on your phone when it arrives.", host);
     let t0 = Instant::now();
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: false, core_id: None,
+        username, password, host, paper: false, core_id: None, code_provider: None,
     })?;
     println!("== Connected in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/examples/ex134_ccp_grace.rs
+++ b/examples/ex134_ccp_grace.rs
@@ -53,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("== ex134_ccp_grace: connecting to paper ({})...", host);
     let t0 = Instant::now();
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
     println!("== Connected in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/examples/ex136_trail_adaptive.rs
+++ b/examples/ex136_trail_adaptive.rs
@@ -123,7 +123,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("== Connecting to paper ({})...", host);
     let t0 = Instant::now();
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
     println!("== Connected in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/examples/ex138_lit_rel_opg.rs
+++ b/examples/ex138_lit_rel_opg.rs
@@ -122,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("== Connecting to paper ({})...", host);
     let t0 = Instant::now();
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
     println!("== Connected in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/examples/ex146_per_request_mode.rs
+++ b/examples/ex146_per_request_mode.rs
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let duration: u64 = env::var("DURATION_SECS").unwrap_or_else(|_| "20".to_string()).parse()?;
 
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
 
     let contract = Contract { con_id, symbol: symbol.clone(), sec_type: "STK".into(), exchange: "SMART".into(), currency: "USD".into(), ..Default::default() };

--- a/examples/ex150_misc_urls.rs
+++ b/examples/ex150_misc_urls.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let host = env::var("IB_HOST").unwrap_or_else(|_| "cdc1.ibllc.com".to_string());
 
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
 
     println!("ccp_session_id: {:?}", client.ccp_session_id());

--- a/examples/ex176_live_2fa_code_provider.rs
+++ b/examples/ex176_live_2fa_code_provider.rs
@@ -1,12 +1,14 @@
-//! Verify issue #176: live login through the Challenge/Response variant of the
-//! second-factor approval gate. Instead of tapping Approve on the mobile push,
-//! the example reads the 8-character code from stdin and submits it.
+//! Verify issue #176: live login through a typed second-factor code rather than
+//! a mobile push. Serves both factors — the 8-character IBKey
+//! Challenge/Response code, and an authenticator app's code — reading whichever
+//! the account uses from stdin.
 //!
 //! Run:
 //!   $env:RUST_LOG="info"; cargo run --release --example ex176_live_2fa_code_provider
 //!
 //! Requires `IB_LIVE_USERNAME` / `IB_LIVE_PASSWORD` in `.env` (auto-loaded).
-//! When the IBKey app shows the 8-char code, type it at the prompt.
+//! Type the code at the prompt. Authenticator codes expire in ~30s, so read a
+//! fresh one when asked rather than ahead of time.
 //!
 //! Note: one wrong code is terminal — the server skips AUTH_FINISH and tears
 //! the socket down (ib-agent#149). There is no retry loop.
@@ -17,7 +19,7 @@ use std::io::{self, BufRead, Write};
 use std::sync::Arc;
 use std::time::Instant;
 
-use ibx::auth::session::{self, CodeProvider, IbKeyChallenge};
+use ibx::auth::session::{self, CodeProvider, IbKeyChallenge, SecondFactor};
 use ibx::gateway::{Gateway, GatewayConfig};
 use zeroize::Zeroizing;
 
@@ -39,27 +41,46 @@ fn load_dotenv() {
     }
 }
 
-/// Prompt the operator for the 8-character code displayed in the IBKey app.
+/// Prompt the operator for whichever code this account's factor calls for.
 fn read_code_from_stdin(challenge: IbKeyChallenge) -> io::Result<String> {
     println!();
-    println!("== IBKey Challenge/Response ==");
+    let (banner, prompt, want) = match challenge.factor {
+        SecondFactor::IbKeyChallengeResponse => (
+            "== IBKey Challenge/Response ==",
+            "Enter the 8-character code shown in the IBKey app: ",
+            Some(8),
+        ),
+        // Length is not fixed across authenticator configurations, so take
+        // what the operator types rather than rejecting a valid code.
+        SecondFactor::AuthenticatorCode => (
+            "== Authenticator code ==",
+            "Enter the current code from your authenticator app: ",
+            None,
+        ),
+    };
+    println!("{}", banner);
     if !challenge.display_id.is_empty() {
         println!("   display_id : {}", challenge.display_id);
     }
     if !challenge.avth_url.is_empty() {
         println!("   avth_url   : {}", challenge.avth_url);
     }
-    print!("Enter the 8-character code shown in the IBKey app: ");
+    print!("{}", prompt);
     io::stdout().flush()?;
 
     let mut line = String::new();
     io::stdin().lock().read_line(&mut line)?;
     let code = line.trim().to_string();
-    if code.len() != 8 {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidInput,
-            format!("expected 8 characters, got {}", code.len()),
-        ));
+    if code.is_empty() {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "no code entered"));
+    }
+    if let Some(n) = want {
+        if code.len() != n {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("expected {} characters, got {}", n, code.len()),
+            ));
+        }
     }
     Ok(code)
 }
@@ -87,12 +108,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         code_provider: Some(provider),
     };
 
-    println!("== Connecting LIVE ({}). Waiting for IBKey challenge...", host);
+    println!("== Connecting LIVE ({}). Waiting for the second-factor challenge...", host);
     let t0 = Instant::now();
     let (gw, _farm, _ccp, _hmds) = Gateway::connect(&config)?;
     let elapsed = t0.elapsed().as_secs_f64();
     println!();
-    println!("PASS — issue #176 verified: C/R login succeeded in {:.1}s (account_id={})",
+    println!("PASS — issue #176 verified: second-factor login succeeded in {:.1}s (account_id={})",
         elapsed, gw.account_id);
     Ok(())
 }

--- a/examples/ex179_wire_repro.rs
+++ b/examples/ex179_wire_repro.rs
@@ -78,6 +78,7 @@ fn connect() -> Result<EClient, Box<dyn std::error::Error>> {
         host: env::var("IB_HOST").unwrap_or_else(|_| "cdc1.ibllc.com".into()),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?)
 }
 

--- a/examples/ex_axti_contract_details.rs
+++ b/examples/ex_axti_contract_details.rs
@@ -54,7 +54,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("== Connecting to paper ({})...", host);
     let t0 = Instant::now();
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
     println!("== Connected in {:.1}s", t0.elapsed().as_secs_f64());
 

--- a/examples/hello_bar_data.rs
+++ b/examples/hello_bar_data.rs
@@ -39,6 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let state = Arc::new(Mutex::new(State::default()));

--- a/examples/hello_contract_details.rs
+++ b/examples/hello_contract_details.rs
@@ -39,6 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let state = Arc::new(Mutex::new(State::default()));

--- a/examples/hello_limit_order.rs
+++ b/examples/hello_limit_order.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let order_id = client.next_order_id();

--- a/examples/hello_login.rs
+++ b/examples/hello_login.rs
@@ -25,6 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let mut wrapper = LoginWrapper::default();

--- a/examples/hello_login_live.rs
+++ b/examples/hello_login_live.rs
@@ -29,6 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: env::var("IB_HOST").unwrap_or_else(|_| "cdc1.ibllc.com".into()),
         paper: false,
         core_id: None,
+        code_provider: None,
     })?;
 
     let mut wrapper = LoginWrapper::default();

--- a/examples/hello_pnl.rs
+++ b/examples/hello_pnl.rs
@@ -34,6 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let account = client.account_id.clone();

--- a/examples/hello_scanner.rs
+++ b/examples/hello_scanner.rs
@@ -44,6 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let state = Arc::new(Mutex::new(State::default()));

--- a/examples/hello_stop_order.rs
+++ b/examples/hello_stop_order.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let order_id = client.next_order_id();

--- a/examples/hello_tick_data.rs
+++ b/examples/hello_tick_data.rs
@@ -47,6 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         host: "cdc1.ibllc.com".into(),
         paper: true,
         core_id: None,
+        code_provider: None,
     })?;
 
     let state = Arc::new(Mutex::new(State::default()));

--- a/examples/l2_aapl_tsla.rs
+++ b/examples/l2_aapl_tsla.rs
@@ -157,6 +157,7 @@ fn main() {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     }).expect("Failed to connect");
     println!("Connected.");
 

--- a/examples/l2_two_tickers.rs
+++ b/examples/l2_two_tickers.rs
@@ -157,6 +157,7 @@ fn main() {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     }).expect("Failed to connect");
     println!("Connected.");
 

--- a/examples/margin_reject_tsla.rs
+++ b/examples/margin_reject_tsla.rs
@@ -96,6 +96,7 @@ fn connect() -> Result<EClient, Box<dyn std::error::Error>> {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     })?)
 }
 

--- a/examples/premarket_lifecycle.rs
+++ b/examples/premarket_lifecycle.rs
@@ -90,6 +90,7 @@ fn connect() -> Result<EClient, Box<dyn std::error::Error>> {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     })?)
 }
 

--- a/examples/premarket_marketable_axti.rs
+++ b/examples/premarket_marketable_axti.rs
@@ -97,6 +97,7 @@ fn connect() -> Result<EClient, Box<dyn std::error::Error>> {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     })?)
 }
 

--- a/examples/seed_spy_position.rs
+++ b/examples/seed_spy_position.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("== Connecting to paper ({})...", host);
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
     println!("== Connected.");
 

--- a/examples/validate_154.rs
+++ b/examples/validate_154.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("== Connecting fresh to paper ({})", host);
     let client = EClient::connect(&EClientConfig {
-        username, password, host, paper: true, core_id: None,
+        username, password, host, paper: true, core_id: None, code_provider: None,
     })?;
     println!("== Connected.");
 

--- a/scripts/gen_api_docs.py
+++ b/scripts/gen_api_docs.py
@@ -87,7 +87,7 @@ PARAM_DOCS: dict[str, str] = {
     "manual_order_cancel_time": "Manual cancel time (empty for immediate).",
     "config": "Connection configuration (username, password, host, paper, core_id).",
     "ib_key_timeout_secs": "Live second-factor approval timeout in seconds (default ~18 min). Lower it to fail fast on unattended live logins; ignored for paper.",
-    "ib_key_token_sub_type": "Account-specific second-factor token sub-type (default `\"2a\"`); ignored for paper.",
+    "ib_key_token_sub_type": "Fallback second-factor token sub-type (default `\"2a\"`), used only when the server states none for the session; ignored for paper.",
     "host": "Server hostname.",
     "port": "Port number (unused — ibx connects directly).",
     "client_id": "Client ID (unused — single-client engine).",

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -20,6 +20,7 @@
 //!     host: "your_ib_host".into(),
 //!     paper: true,
 //!     core_id: None,
+//!     code_provider: None,
 //! }).unwrap();
 //!
 //! client.req_mkt_data(1, &Contract { con_id: 756733, symbol: "SPY".into(), ..Default::default() },
@@ -95,6 +96,11 @@ pub struct EClientConfig {
     /// CPU core to pin this engine's hot loop to. `None` = no pinning. When
     /// running multiple engines, use a **distinct** core per engine.
     pub core_id: Option<usize>,
+    /// Supplies the second-factor code. Required for accounts whose factor is
+    /// an authenticator code — those have no push to fall back to, and connect
+    /// fails without it. For IBKey accounts it selects Challenge/Response over
+    /// waiting for a mobile push, so `None` is fine there (ibx#208, ibx#282).
+    pub code_provider: Option<crate::auth::session::CodeProvider>,
 }
 
 /// ibapi-compatible EClient. Matches C++ `EClientSocket` method signatures.
@@ -139,6 +145,25 @@ impl Drop for EClient {
     }
 }
 
+/// The gateway's view of an [`EClientConfig`].
+///
+/// Extracted so the forwarding is checkable without opening a socket: the
+/// second-factor provider reaching the gateway is the whole of what makes the
+/// feature usable from this client, and it is one line that a refactor can
+/// drop silently.
+fn gateway_config(config: &EClientConfig) -> GatewayConfig {
+    GatewayConfig {
+        username: config.username.clone(),
+        password: zeroize::Zeroizing::new(config.password.clone()),
+        host: config.host.clone(),
+        paper: config.paper,
+        accept_invalid_certs: false,
+        ib_key_timeout_secs: crate::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
+        ib_key_token_sub_type: crate::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
+        code_provider: config.code_provider.clone(),
+    }
+}
+
 impl EClient {
     /// Connect to IB and start the engine.
     pub fn connect(config: &EClientConfig) -> Result<Self, Box<dyn std::error::Error>> {
@@ -174,16 +199,7 @@ impl EClient {
         config: &EClientConfig,
         event_tx: Option<Sender<Event>>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let gw_config = GatewayConfig {
-            username: config.username.clone(),
-            password: zeroize::Zeroizing::new(config.password.clone()),
-            host: config.host.clone(),
-            paper: config.paper,
-            accept_invalid_certs: false,
-            ib_key_timeout_secs: crate::auth::session::IB_KEY_DEFAULT_TIMEOUT_SECS,
-            ib_key_token_sub_type: crate::auth::session::IB_KEY_DEFAULT_TOKEN_SUB_TYPE.into(),
-            code_provider: None,
-        };
+        let gw_config = gateway_config(config);
 
         let (gw, farm_conn, ccp_conn, hmds_conn) = Gateway::connect(&gw_config)?;
         let account_id = gw.account_id.clone();

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -2706,3 +2706,38 @@ fn queued_data_is_dispatched_before_connection_closed() {
 
     assert_eq!(w.events, vec!["contract_details_end:7", "connection_closed"]);
 }
+
+/// The provider reaching the gateway is the whole of what makes the
+/// authenticator factor usable from this client, and it is one line in a
+/// struct literal. Reverting it to `None` broke nothing that was tested.
+#[test]
+fn the_second_factor_provider_reaches_the_gateway_config() {
+    use crate::api::client::gateway_config;
+
+    let base = crate::api::client::EClientConfig {
+        username: "u".into(), password: "p".into(), host: "h".into(),
+        paper: false, core_id: None, code_provider: None,
+    };
+    assert!(gateway_config(&base).code_provider.is_none(), "none stays none");
+
+    let called = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let flag = called.clone();
+    let with_provider = crate::api::client::EClientConfig {
+        code_provider: Some(std::sync::Arc::new(move |_: crate::auth::session::IbKeyChallenge| {
+            flag.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok("12345678".to_string())
+        })),
+        ..base
+    };
+    let forwarded = gateway_config(&with_provider).code_provider
+        .expect("the provider is forwarded, not dropped");
+
+    // Identity, not just presence: forwarding some other closure would pass a
+    // bare `is_some`.
+    forwarded(crate::auth::session::IbKeyChallenge {
+        factor: crate::auth::session::SecondFactor::AuthenticatorCode,
+        display_id: String::new(),
+        avth_url: String::new(),
+    }).unwrap();
+    assert!(called.load(std::sync::atomic::Ordering::SeqCst), "it is the caller's own provider");
+}

--- a/src/auth/session.rs
+++ b/src/auth/session.rs
@@ -611,6 +611,18 @@ fn ib_key_err(kind: io::ErrorKind, msg: impl Into<String>) -> io::Error {
     io::Error::new(kind, msg.into())
 }
 
+/// Which second factor the callback is being asked to answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SecondFactor {
+    /// IBKey Challenge/Response — answer with the 8-character code the app
+    /// shows for `display_id`.
+    #[default]
+    IbKeyChallengeResponse,
+    /// Authenticator code — answer with the account's current code, typically
+    /// 6 digits. `display_id` and `avth_url` are empty; there is nothing to show.
+    AuthenticatorCode,
+}
+
 /// Challenge details surfaced to a [`CodeProvider`] callback.
 ///
 /// Populated from the server's `XYZ 775` state=2 reply: the per-session
@@ -619,20 +631,33 @@ fn ib_key_err(kind: io::ErrorKind, msg: impl Into<String>) -> io::Error {
 /// fallback. Either may be empty if the server omitted it in this run.
 #[derive(Debug, Clone, Default)]
 pub struct IbKeyChallenge {
+    /// Which factor is being asked for. The two want different codes, so
+    /// branch on this before validating what the operator typed.
+    pub factor: SecondFactor,
     pub display_id: String,
     pub avth_url: String,
 }
 
-/// 8-character Challenge/Response code provider callback.
+/// Second-factor code provider callback.
 ///
-/// If supplied (via `GatewayConfig::code_provider`), the C/R variant of the
-/// IBKey gate is used instead of waiting for a mobile push approval: after
-/// the server delivers state=2, this callback is invoked once with the
-/// parsed challenge and the returned 8-character code is submitted as
-/// `XYZ 775` state=3. Per ib-agent#149, the server has no retry loop — one
-/// wrong code returns state=4 FAILED and the socket is torn down. The
-/// callback should pull the code from a deterministic source (stdin,
-/// secrets vault, etc.) or return an `io::Error` to abort the login.
+/// Invoked once per login, with [`IbKeyChallenge::factor`] naming what to
+/// return:
+///
+/// - [`SecondFactor::IbKeyChallengeResponse`] — the 8-character code shown for
+///   `display_id`, submitted as `XYZ 775` state=3. Supplying a provider selects
+///   this over waiting for a mobile push.
+/// - [`SecondFactor::AuthenticatorCode`] — the account's current authenticator
+///   code, submitted as `XYZ 774` code=1. Not optional: these accounts have no
+///   push to fall back to, so a missing provider fails the login.
+///
+/// Neither server retries. One wrong code ends the attempt and the socket is
+/// torn down, so pull the code from a deterministic source (stdin, secrets
+/// vault) or return an `io::Error` to abort.
+///
+/// Called on its own thread so the gate can keep answering the server's
+/// keepalives while it waits. It is not cancelled if the gate gives up first,
+/// so bound anything that can block indefinitely — a callback still parked on
+/// stdin outlives the login and competes with the next one for the terminal.
 pub type CodeProvider = std::sync::Arc<
     dyn Fn(IbKeyChallenge) -> io::Result<String> + Send + Sync,
 >;
@@ -654,6 +679,313 @@ pub const IB_KEY_DEFAULT_TOKEN_SUB_TYPE: &str = "2a";
 
 /// Cadence at which the server probes during the wait window.
 const IB_KEY_HEARTBEAT_CADENCE_SECS: u64 = 20;
+/// Ceiling on a frame in the auth gate, where the traffic is 774/771 replies
+/// and keepalives — none of which reach a fraction of this.
+const MAX_GATE_FRAME: usize = 64 * 1024;
+
+/// Frame reader that survives a read timeout mid-message.
+///
+/// The gate polls the socket so a time-limited code is not left unsent while
+/// the loop blocks. `ns_recv` cannot be polled: it is two `read_exact` calls,
+/// and a timeout between them discards the bytes already consumed, leaving the
+/// next read starting mid-frame. This buffers instead, so a timeout is simply
+/// "no complete frame yet".
+#[derive(Default)]
+struct GateReader {
+    buf: Vec<u8>,
+    /// Whether the code was already on the wire when the frame currently being
+    /// assembled began arriving. A frame can span polls, so the loop's own view
+    /// of that is a poll too late.
+    sent_when_frame_began: bool,
+}
+
+impl GateReader {
+    /// One non-blocking-ish step: drain what is available, return a message
+    /// once a whole frame is buffered. `Ok(None)` means "nothing complete yet".
+    /// Returns the frame and whether the code had been sent when that frame's
+    /// first byte arrived.
+    fn poll<S: Read>(&mut self, stream: &mut S, sent: bool) -> io::Result<Option<(RecvMsg, bool)>> {
+        if let Some(msg) = self.take()? {
+            return Ok(Some((msg, self.sent_when_frame_began)));
+        }
+        // Only ever ask for what the frame in progress still needs. Reading
+        // further pulls in bytes belonging to the next frame, and this buffer
+        // is dropped when the gate returns — the caller carries on reading the
+        // raw stream, so an over-read either loses a whole frame or leaves the
+        // stream mid-frame. The gate therefore always exits with an empty
+        // buffer. `take` has already validated the magic and the length.
+        let needed = if self.buf.len() < 8 {
+            8 - self.buf.len()
+        } else {
+            let len = u32::from_be_bytes([self.buf[4], self.buf[5], self.buf[6], self.buf[7]]) as usize;
+            (8 + len) - self.buf.len()
+        };
+        let mut tmp = [0u8; 4096];
+        let want = needed.min(tmp.len());
+        match stream.read(&mut tmp[..want]) {
+            Ok(0) => Err(io::Error::new(io::ErrorKind::UnexpectedEof, "server closed the socket")),
+            Ok(n) => {
+                if self.buf.is_empty() {
+                    self.sent_when_frame_began = sent;
+                }
+                self.buf.extend_from_slice(&tmp[..n]);
+                Ok(self.take()?.map(|m| (m, self.sent_when_frame_began)))
+            }
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock
+                || e.kind() == io::ErrorKind::TimedOut
+                // `read_exact` retries this for every other reader in this
+                // file; the raw read here is the only one that would die on a
+                // signal, taking the operator's code with it.
+                || e.kind() == io::ErrorKind::Interrupted => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Pull one complete `#%#%` frame out of the buffer, if there is one.
+    fn take(&mut self) -> io::Result<Option<RecvMsg>> {
+        if self.buf.len() < 8 {
+            return Ok(None);
+        }
+        if &self.buf[..4] != NS_MAGIC {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "security-code gate: framing lost (no #%#% magic)",
+            ));
+        }
+        let len = u32::from_be_bytes([self.buf[4], self.buf[5], self.buf[6], self.buf[7]]) as usize;
+        // Auth frames are tens of bytes. A length this far out is a corrupt
+        // header, and believing it means buffering toward 4 GiB while waiting
+        // for a tail that is never coming.
+        if len > MAX_GATE_FRAME {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("security-code gate: frame claims {} bytes", len),
+            ));
+        }
+        if self.buf.len() < 8 + len {
+            return Ok(None);
+        }
+        let payload: Vec<u8> = self.buf[8..8 + len].to_vec();
+        self.buf.drain(..8 + len);
+
+        if ns::is_ns_text(&payload) {
+            if let Some((version, msg_type, fields)) = ns::ns_parse(&payload) {
+                return Ok(Some(RecvMsg::Ns { version, msg_type, fields }));
+            }
+        }
+        if payload.len() >= 16 {
+            if let Some((msg_id, sub_id, state, fields)) = xyz::xyz_parse_response(&payload) {
+                return Ok(Some(RecvMsg::Xyz { msg_id, sub_id, state, fields }));
+            }
+        }
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "security-code gate: unparseable frame",
+        ))
+    }
+}
+
+/// Second factor for accounts whose token is an authenticator code (msg 774).
+///
+/// `AUTH_START` names the token type; type 4 takes this path, type 5 the IBKey
+/// push in [`do_ib_key_2fa`]. One message goes on the wire: the code as 774
+/// message code 1, framed and written raw like the IBKey messages, straight
+/// after SRP passes. The server answers with code 2 carrying `PASSED` or
+/// `FAILED`. Nothing on the wire prompts for the code first, so a gate that
+/// waits to be asked waits forever.
+///
+/// The provider runs off this thread. It typically waits on a human, and the
+/// loop has to keep answering the server's keepalives meanwhile or the
+/// connection is dropped for going quiet.
+///
+/// `stream` must carry a read timeout. The loop only gets to check for the
+/// code between reads, so on a blocking stream a code that arrives mid-wait
+/// sits unsent until the server next says something — up to a keepalive
+/// interval, against a code that is good for about thirty seconds.
+pub fn do_security_code_2fa<S: Read + Write>(
+    stream: &mut S,
+    deadline: std::time::Instant,
+    code_provider: Option<&CodeProvider>,
+) -> io::Result<IbKeyOutcome> {
+    use std::time::Instant;
+
+    let Some(provider) = code_provider else {
+        return Err(ib_key_err(
+            io::ErrorKind::InvalidInput,
+            "this account's second factor is an authenticator code; \
+             set code_provider to supply it",
+        ));
+    };
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    {
+        let provider = provider.clone();
+        std::thread::Builder::new()
+            .name("ib-security-code".into())
+            .spawn(move || {
+                let _ = tx.send(provider(IbKeyChallenge {
+                    factor: SecondFactor::AuthenticatorCode,
+                    ..Default::default()
+                }));
+            })?;
+    }
+    let mut sent = false;
+    let mut reader = GateReader::default();
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err(ib_key_err(
+                io::ErrorKind::TimedOut,
+                "security-code gate timed out (client deadline)",
+            ));
+        }
+
+        // A verdict only means anything if the code was already on the wire
+        // when the server began sending it. The reader reports that, because a
+        // frame can span polls and the loop would otherwise judge a verdict by
+        // a send that landed between its header and its body.
+        let recv = match reader.poll(stream, sent) {
+            Ok(m) => m,
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof
+                || e.kind() == io::ErrorKind::ConnectionReset
+                || e.kind() == io::ErrorKind::ConnectionAborted =>
+            {
+                return Err(ib_key_err(
+                    io::ErrorKind::ConnectionAborted,
+                    if sent {
+                        "security-code gate: server closed the socket after the code was sent"
+                    } else {
+                        "security-code gate: server closed the socket before a code was sent"
+                    },
+                ));
+            }
+            Err(e) => return Err(e),
+        };
+
+        if !sent {
+            match rx.try_recv() {
+                Ok(result) => {
+                    let code = result?;
+                    if code.trim().is_empty() {
+                        return Err(ib_key_err(
+                            io::ErrorKind::InvalidInput,
+                            "code_provider returned an empty code; the server has no retry loop, \
+                             so sending it would end the attempt",
+                        ));
+                    }
+                    // The read above can span the deadline. Sending after it
+                    // has passed puts a code on the wire for a login that is
+                    // about to be abandoned.
+                    if Instant::now() >= deadline {
+                        return Err(ib_key_err(
+                            io::ErrorKind::TimedOut,
+                            "security-code gate timed out (client deadline)",
+                        ));
+                    }
+                    // Trimmed on the way out, not just when checking for
+                    // empty: surrounding whitespace reaches the server as part
+                    // of the code and burns the one attempt.
+                    let code = code.trim();
+                    stream.write_all(&xyz::xyz_wrap(&xyz::xyz_build_security_code(code)))?;
+                    log::info!("security-code gate: sent code (len={})", code.len());
+                    sent = true;
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => {}
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    return Err(ib_key_err(
+                        io::ErrorKind::Other,
+                        "security-code gate: code_provider panicked without returning a code",
+                    ));
+                }
+            }
+        }
+
+        let Some((recv, sent_before_read)) = recv else { continue };
+        match recv {
+            RecvMsg::Xyz { msg_id, state, fields, .. }
+                if msg_id == xyz::XYZ_MSG_SECURITY_CODE && state == xyz::SECURITY_CODE_RESULT =>
+            {
+                // Nothing concludes the exchange until the code is out — an
+                // approval with no code sent is the mute failure this gate
+                // exists to prevent.
+                if !sent_before_read {
+                    log::debug!("security-code gate: 774 result before a code was sent");
+                    continue;
+                }
+                let status = fields.iter().rev().find(|f| !f.is_empty()).cloned().unwrap_or_default();
+                if status.eq_ignore_ascii_case("PASSED") {
+                    log::info!("security-code gate: accepted");
+                    return Ok(IbKeyOutcome::Approved {
+                        approval_url: String::new(),
+                        session_id: String::new(),
+                        soft_token_hex: String::new(),
+                    });
+                }
+                // Only echo a status we recognise. The reply's fields are
+                // server-controlled and this one is adjacent to the slot the
+                // code was sent in — never interpolate it blind.
+                let reason = if status.eq_ignore_ascii_case("FAILED") { "FAILED" } else { "unrecognized status" };
+                return Err(ib_key_err(
+                    io::ErrorKind::PermissionDenied,
+                    format!("security code rejected ({})", reason),
+                ));
+            }
+            RecvMsg::Xyz { msg_id, state, fields, .. }
+                if msg_id == xyz::XYZ_MSG_TOKEN_AUTH && (state == 3 || state == 5) =>
+            {
+                // Nothing here concludes the exchange until the code is out —
+                // an unsolicited verdict is neither an approval nor a denial.
+                if !sent_before_read {
+                    log::debug!("security-code gate: AUTH_FINISH before a code was sent");
+                    continue;
+                }
+                if fields.iter().any(|f| f.eq_ignore_ascii_case("PASSED")) {
+                    log::info!("security-code gate: accepted via AUTH_FINISH");
+                    return Ok(IbKeyOutcome::Approved {
+                        approval_url: String::new(),
+                        session_id: String::new(),
+                        soft_token_hex: String::new(),
+                    });
+                }
+                // A rejection arriving this way is still a rejection. Falling
+                // through would spin until the client deadline and then report
+                // a timeout, which hides the reason.
+                return Err(ib_key_err(
+                    io::ErrorKind::PermissionDenied,
+                    "second factor rejected at AUTH_FINISH",
+                ));
+            }
+            RecvMsg::Xyz { msg_id, state, .. } if msg_id == xyz::XYZ_MSG_SECURITY_CODE => {
+                if !sent_before_read {
+                    log::debug!("security-code gate: 774 code {} before a code was sent", state);
+                    continue;
+                }
+                return Err(ib_key_err(
+                    io::ErrorKind::PermissionDenied,
+                    format!("security-code gate: server returned code {}", state),
+                ));
+            }
+            RecvMsg::Ns { msg_type, .. } if msg_type == NS_ERROR_RESPONSE
+                || msg_type == NS_SECURE_ERROR =>
+            {
+                return Err(ib_key_err(
+                    io::ErrorKind::Other,
+                    format!("security-code gate: server error type={}", msg_type),
+                ));
+            }
+            RecvMsg::Ns { msg_type, fields, .. } if msg_type == NS_TEST_REQUEST => {
+                let ts = fields.iter().find(|f| !f.is_empty()).cloned().unwrap_or_default();
+                stream.write_all(&ns_build_heart_beat(NS_VERSION, &ts))?;
+            }
+            // Identifiers only. The derived `Debug` prints every field, and an
+            // echoed frame can carry the code itself.
+            RecvMsg::Ns { msg_type, .. } => log::debug!("security-code gate: ns type={}", msg_type),
+            RecvMsg::Xyz { msg_id, state, .. } => {
+                log::debug!("security-code gate: xyz id={} state={}", msg_id, state)
+            }
+        }
+    }
+}
 
 /// Execute the second-factor approval gate that follows SRP on a live login.
 ///
@@ -753,6 +1085,7 @@ pub fn do_ib_key_2fa<S: Read + Write>(
                 if !code_submitted {
                     if let Some(provider) = code_provider {
                         let challenge_info = IbKeyChallenge {
+                            factor: SecondFactor::IbKeyChallengeResponse,
                             display_id: session_id.clone(),
                             avth_url: approval_url.clone(),
                         };
@@ -1528,6 +1861,646 @@ mod tests {
         out
     }
 
+    /// A server that stays silent until the client has written something, then
+    /// answers `chunk` bytes at a time. Both halves matter: the silence keeps
+    /// these tests independent of when the provider thread happens to return,
+    /// and the chunking reproduces a polled socket handing back a frame in
+    /// pieces.
+    struct RepliesAfterWrite {
+        /// Served before the client writes anything.
+        preface: Vec<u8>,
+        pre_pos: usize,
+        /// Served once the client has written.
+        reply: Vec<u8>,
+        read_pos: usize,
+        written: Vec<u8>,
+        chunk: usize,
+        /// When set, the reply is withheld until this appears in `written` —
+        /// a server that answers the code, not merely the first thing sent.
+        trigger: Option<Vec<u8>>,
+        /// Alternates a timeout between chunks, which is what a polled socket
+        /// actually does and what `read_exact` cannot survive.
+        stall: bool,
+    }
+
+    impl RepliesAfterWrite {
+        fn new(reply: Vec<u8>) -> Self {
+            Self {
+                preface: Vec::new(), pre_pos: 0,
+                reply, read_pos: 0, written: Vec::new(),
+                chunk: usize::MAX, trigger: None, stall: false,
+            }
+        }
+        /// Hand the reply back `chunk` bytes at a time, timing out in between.
+        fn chunked(reply: Vec<u8>, chunk: usize) -> Self {
+            Self { chunk, ..Self::new(reply) }
+        }
+        /// Say something before the client has written, so the gate is
+        /// observed mid-wait rather than after the exchange.
+        fn with_preface(preface: Vec<u8>, trigger: Vec<u8>, reply: Vec<u8>) -> Self {
+            Self { preface, trigger: Some(trigger), ..Self::new(reply) }
+        }
+
+        /// Has the client sent what the server is waiting for?
+        fn ready(&self) -> bool {
+            match &self.trigger {
+                Some(t) => self.written.windows(t.len()).any(|w| w == t.as_slice()),
+                None => !self.written.is_empty(),
+            }
+        }
+    }
+
+    impl io::Read for RepliesAfterWrite {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.chunk != usize::MAX {
+                self.stall = !self.stall;
+                if self.stall {
+                    return Err(io::Error::new(io::ErrorKind::TimedOut, "poll timeout"));
+                }
+            }
+            let ready = self.ready();
+            let (src, pos) = if ready {
+                (&self.reply, &mut self.read_pos)
+            } else {
+                (&self.preface, &mut self.pre_pos)
+            };
+            let remaining = src.len().saturating_sub(*pos);
+            if remaining == 0 {
+                return if ready {
+                    Err(io::Error::new(io::ErrorKind::UnexpectedEof, "scripted EOF"))
+                } else {
+                    Err(io::Error::new(io::ErrorKind::WouldBlock, "quiet"))
+                };
+            }
+            let n = remaining.min(buf.len()).min(self.chunk);
+            buf[..n].copy_from_slice(&src[*pos..*pos + n]);
+            *pos += n;
+            Ok(n)
+        }
+    }
+
+    impl io::Write for RepliesAfterWrite {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    fn code_provider_returning(code: &'static str) -> CodeProvider {
+        std::sync::Arc::new(move |challenge| {
+            // The callback has to be told which factor it is answering; the
+            // two want different codes and the shipped example branches on it.
+            assert_eq!(
+                challenge.factor,
+                SecondFactor::AuthenticatorCode,
+                "this gate must ask for an authenticator code",
+            );
+            Ok(code.to_string())
+        })
+    }
+
+    /// A provider that never answers, so the gate is observed with `sent=false`.
+    fn code_provider_that_never_answers() -> CodeProvider {
+        std::sync::Arc::new(|_| {
+            std::thread::sleep(std::time::Duration::from_secs(60));
+            Ok(String::new())
+        })
+    }
+
+    struct VerdictAfterCodeReady {
+        incoming: Vec<u8>,
+        pos: usize,
+        ready: Arc<AtomicBool>,
+        written: Vec<u8>,
+    }
+    impl io::Read for VerdictAfterCodeReady {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            // Hand over the verdict only once the code is sitting in the
+            // channel, so the gate reads it and then sends in the same
+            // pass. That is the ordering the snapshot exists for.
+            while !self.ready.load(Ordering::SeqCst) {
+                std::thread::yield_now();
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            let remaining = self.incoming.len().saturating_sub(self.pos);
+            if remaining == 0 {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "scripted EOF"));
+            }
+            let n = remaining.min(buf.len());
+            buf[..n].copy_from_slice(&self.incoming[self.pos..self.pos + n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+    impl io::Write for VerdictAfterCodeReady {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.written.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    }
+
+    fn security_code_result(fields: &[&str]) -> Vec<u8> {
+        frame_xyz(&xyz::xyz_build(
+            xyz::XYZ_MSG_SECURITY_CODE,
+            xyz::SECURITY_CODE_RESULT,
+            "",
+            fields,
+        ))
+    }
+
+    // ── do_security_code_2fa — authenticator code (ibx#282) ─────────────
+
+    #[test]
+    fn security_code_gate_sends_the_code_and_accepts_passed() {
+        let mut stream = RepliesAfterWrite::new(security_code_result(&["", "", "", "PASSED"]));
+        let outcome = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .expect("PASSED must be accepted");
+        assert!(matches!(outcome, IbKeyOutcome::Approved { .. }));
+        // The code must actually reach the wire, in the security-token slot.
+        assert_eq!(
+            stream.written,
+            xyz::xyz_wrap(&xyz::xyz_build_security_code("123456")),
+            "the gate must send exactly the 774 code-1 frame"
+        );
+    }
+
+    #[test]
+    fn security_code_gate_reassembles_a_reply_split_across_reads() {
+        // The gate polls, so a read can return part of a frame. Byte-at-a-time
+        // delivery is the worst case: anything that drops a partial read here
+        // resumes mid-frame and dies on the next magic check.
+        let mut stream = RepliesAfterWrite::chunked(security_code_result(&["", "", "", "PASSED"]), 1);
+        let outcome = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .expect("a frame split across reads must still be accepted");
+        assert!(matches!(outcome, IbKeyOutcome::Approved { .. }));
+    }
+
+    #[test]
+    fn security_code_gate_answers_keepalives_while_it_waits() {
+        // Going quiet gets the connection dropped, so the wait loop has to keep
+        // answering NS_TEST_REQUEST.
+        let probe = ns::ns_build(NS_VERSION, NS_TEST_REQUEST, &["20260729-01:02:03"], "MISC");
+        let mut stream = RepliesAfterWrite::with_preface(
+            probe,
+            xyz::xyz_wrap(&xyz::xyz_build_security_code("123456")),
+            security_code_result(&["", "", "", "PASSED"]),
+        );
+        // Slow enough that the probe is answered while the gate is still
+        // waiting on the provider — the situation the off-thread call exists
+        // for. A provider that returns instantly never tests it.
+        let provider: CodeProvider = std::sync::Arc::new(|_| {
+            std::thread::sleep(std::time::Duration::from_millis(60));
+            Ok("123456".to_string())
+        });
+        do_security_code_2fa(&mut stream, far_future_deadline(), Some(&provider))
+            .expect("PASSED must be accepted");
+        let heartbeat = ns_build_heart_beat(NS_VERSION, "20260729-01:02:03");
+        let code_frame = xyz::xyz_wrap(&xyz::xyz_build_security_code("123456"));
+        let hb_at = stream.written.windows(heartbeat.len()).position(|w| w == heartbeat);
+        let code_at = stream.written.windows(code_frame.len()).position(|w| w == code_frame);
+        assert!(hb_at.is_some(), "the gate must answer the keepalive");
+        assert!(
+            hb_at < code_at,
+            "the keepalive must be answered while waiting, not after the code went out"
+        );
+    }
+
+    #[test]
+    fn security_code_gate_reports_a_rejection_as_a_rejection_not_a_timeout() {
+        // A rejection that falls through is answered with keepalives until the
+        // deadline and then reported as a timeout, which hides the reason.
+        let mut stream = RepliesAfterWrite::new(security_code_result(&["", "", "", "FAILED"]));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!err.to_string().contains("timed out"), "got {}", err);
+    }
+
+    #[test]
+    fn security_code_gate_reports_a_rejection_delivered_as_auth_finish() {
+        // The same rejection can arrive on 771 instead of 774.
+        let mut stream = RepliesAfterWrite::new(frame_xyz(&xyz::xyz_build(
+            xyz::XYZ_MSG_TOKEN_AUTH, 5, "", &["FAILED"],
+        )));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!err.to_string().contains("timed out"), "got {}", err);
+    }
+
+    #[test]
+    fn security_code_gate_never_puts_the_code_in_an_error_message() {
+        // The status slot is next to the one the code was sent in, and the
+        // reply is server-controlled — an echo must not reach the log.
+        let mut stream = RepliesAfterWrite::new(security_code_result(&["", "123456", "", ""]));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert!(!err.to_string().contains("123456"), "code leaked into: {}", err);
+    }
+
+    #[test]
+    fn security_code_gate_does_not_accept_passed_before_a_code_is_sent() {
+        // An unsolicited PASSED must not stand in for the exchange.
+        let mut stream = ScriptedStream::new(frame_xyz(&xyz::xyz_build(
+            xyz::XYZ_MSG_TOKEN_AUTH, 5, "", &["PASSED"],
+        )));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_that_never_answers()),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(err.to_string().contains("before a code was sent"), "got {}", err);
+    }
+
+    #[test]
+    fn security_code_gate_ignores_a_verdict_whose_read_began_before_the_code() {
+        // Sharper than the whole-frame case: the verdict's header is read, the
+        // provider returns mid-frame, the code goes out, and the frame
+        // completes on the next read. The verdict still predates the code, so
+        // a guard that checks the flag at match time rather than at read time
+        // would accept it.
+        let ready = Arc::new(AtomicBool::new(false));
+        let signal = ready.clone();
+        let provider: CodeProvider = Arc::new(move |_| {
+            signal.store(true, Ordering::SeqCst);
+            Ok("123456".to_string())
+        });
+        let mut stream = VerdictAfterCodeReady {
+            incoming: frame_xyz(&xyz::xyz_build(xyz::XYZ_MSG_TOKEN_AUTH, 5, "", &["PASSED"])),
+            pos: 0,
+            ready,
+            written: Vec::new(),
+        };
+        // The verdict predates the code even though the code is sent first.
+        let err = do_security_code_2fa(&mut stream, far_future_deadline(), Some(&provider))
+            .expect_err("a verdict read before the code was sent must not approve the login");
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+    }
+
+    /// The same straddle as above, on the 774 result arm — which is the arm a
+    /// live login actually completes through. Pinning only the AUTH_FINISH arm
+    /// left this one dark for exactly the bug class it exists to prevent.
+    #[test]
+    fn security_code_gate_ignores_a_774_verdict_whose_read_began_before_the_code() {
+        let ready = Arc::new(AtomicBool::new(false));
+        let signal = ready.clone();
+        let provider: CodeProvider = Arc::new(move |_| {
+            signal.store(true, Ordering::SeqCst);
+            Ok("123456".to_string())
+        });
+        let mut stream = VerdictAfterCodeReady {
+            incoming: security_code_result(&["", "", "", "PASSED"]),
+            pos: 0,
+            ready,
+            written: Vec::new(),
+        };
+        let err = do_security_code_2fa(&mut stream, far_future_deadline(), Some(&provider))
+            .expect_err("a 774 verdict read before the code was sent must not approve the login");
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+    }
+
+    #[test]
+    fn security_code_gate_ignores_an_unexpected_774_code_before_a_code_is_sent() {
+        let mut stream = ScriptedStream::new(frame_xyz(&xyz::xyz_build(
+            xyz::XYZ_MSG_SECURITY_CODE, 4, "", &["whatever"],
+        )));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_that_never_answers()),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(stream.written.is_empty(), "nothing should have been sent");
+    }
+
+    #[test]
+    fn security_code_gate_survives_an_interrupted_read() {
+        // Every other reader in this file goes through `read_exact`, which
+        // retries a signal. The gate's raw read is the only one that would
+        // die on it, taking a live login and the operator's code with it.
+        struct InterruptsOnce {
+            fired: bool,
+            reply: Vec<u8>,
+            pos: usize,
+            written: Vec<u8>,
+        }
+        impl io::Read for InterruptsOnce {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                if !self.fired {
+                    self.fired = true;
+                    return Err(io::Error::new(io::ErrorKind::Interrupted, "signal"));
+                }
+                if self.written.is_empty() {
+                    return Err(io::Error::new(io::ErrorKind::WouldBlock, "quiet"));
+                }
+                let remaining = self.reply.len().saturating_sub(self.pos);
+                if remaining == 0 {
+                    return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "scripted EOF"));
+                }
+                let n = remaining.min(buf.len());
+                buf[..n].copy_from_slice(&self.reply[self.pos..self.pos + n]);
+                self.pos += n;
+                Ok(n)
+            }
+        }
+        impl io::Write for InterruptsOnce {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.written.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> { Ok(()) }
+        }
+
+        let mut stream = InterruptsOnce {
+            fired: false,
+            reply: security_code_result(&["", "", "", "PASSED"]),
+            pos: 0,
+            written: Vec::new(),
+        };
+        let outcome = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .expect("a signal must not end the login");
+        assert!(matches!(outcome, IbKeyOutcome::Approved { .. }));
+    }
+
+    #[test]
+    fn security_code_gate_rejects_an_empty_code_before_sending_it() {
+        // A valid frame with an empty token slot is a guaranteed rejection,
+        // and one wrong code ends the attempt.
+        let mut stream = RepliesAfterWrite::new(Vec::new());
+        let provider: CodeProvider = Arc::new(|_| Ok("  ".to_string()));
+        let err = do_security_code_2fa(&mut stream, far_future_deadline(), Some(&provider))
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert!(stream.written.is_empty(), "an empty code must not reach the wire");
+    }
+
+    #[test]
+    fn security_code_gate_treats_a_clean_close_as_a_close() {
+        // A half-closed socket returns Ok(0) immediately and forever. Treating
+        // that as "nothing yet" spins hot until the deadline instead of
+        // reporting the close — the read timeout never fires to break it up.
+        struct CleanClose {
+            written: Vec<u8>,
+        }
+        impl io::Read for CleanClose {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                Ok(0)
+            }
+        }
+        impl io::Write for CleanClose {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.written.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> { Ok(()) }
+        }
+
+        let mut stream = CleanClose { written: Vec::new() };
+        let began = std::time::Instant::now();
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(began.elapsed() < std::time::Duration::from_secs(5), "must not spin on a closed socket");
+    }
+
+    #[test]
+    fn security_code_gate_leaves_the_next_frame_on_the_stream() {
+        // The server can coalesce its reply with what follows. The gate reads
+        // from the raw stream and the caller keeps reading it afterwards, so a
+        // read that crosses the frame boundary either swallows the next frame
+        // whole or strands the stream mid-frame — and on this path each retry
+        // costs the operator a fresh code.
+        let trailing = ns::ns_build(NS_VERSION, 24, &["next"], "MISC");
+        let mut reply = security_code_result(&["", "", "", "PASSED"]);
+        reply.extend_from_slice(&trailing);
+        let mut stream = RepliesAfterWrite::new(reply);
+        do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .expect("PASSED must be accepted");
+        let (payload, _) = ns::ns_recv(&mut stream).expect("the next frame must survive the gate");
+        assert_eq!(
+            payload,
+            trailing[8..],
+            "the frame after the gate's must be readable, whole and unconsumed"
+        );
+    }
+
+    /// A frame larger than one read buffer has to reassemble across reads
+    /// without over-running its own boundary. Every shipped test uses a frame
+    /// that fits in a single 4KiB read, which is the one size where the read
+    /// clamp does nothing — so the clamp was unpinned.
+    #[test]
+    fn security_code_gate_reassembles_a_frame_larger_than_one_read() {
+        let filler = "x".repeat(5000);
+        let trailing = ns::ns_build(NS_VERSION, 24, &["next"], "MISC");
+        let mut reply = security_code_result(&["", &filler, "", "PASSED"]);
+        assert!(reply.len() > 4096, "the frame must cross a read boundary: {}", reply.len());
+        reply.extend_from_slice(&trailing);
+
+        let mut stream = RepliesAfterWrite::new(reply);
+        do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .expect("a large PASSED frame must still be accepted");
+
+        let (payload, _) = ns::ns_recv(&mut stream).expect("the next frame must survive");
+        assert_eq!(
+            payload, trailing[8..],
+            "reassembly must stop at its own frame boundary, not read past it",
+        );
+    }
+
+    /// A code is trimmed on the way out, not merely when checking for empty:
+    /// surrounding whitespace reaches the server as part of the code and burns
+    /// the one attempt the operator gets.
+    #[test]
+    fn security_code_gate_trims_the_code_it_sends() {
+        let mut stream = RepliesAfterWrite::new(security_code_result(&["", "", "", "PASSED"]));
+        do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("  123456  ")),
+        )
+        .expect("PASSED must be accepted");
+
+        let sent = String::from_utf8_lossy(&stream.written).to_string();
+        assert!(sent.contains("123456"), "the code is sent: {sent:?}");
+        assert!(
+            !sent.contains("  123456") && !sent.contains("123456  "),
+            "and without the surrounding whitespace: {sent:?}",
+        );
+    }
+
+    #[test]
+    fn security_code_gate_does_not_accept_a_774_verdict_before_a_code_is_sent() {
+        // Approving without ever sending a code is the mute failure this gate
+        // exists to prevent.
+        let mut stream = ScriptedStream::new(security_code_result(&["", "", "", "PASSED"]));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_that_never_answers()),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionAborted);
+        assert!(err.to_string().contains("before a code was sent"), "got {}", err);
+        assert!(stream.written.is_empty(), "nothing should have been sent");
+    }
+
+    #[test]
+    fn security_code_gate_surfaces_an_ns_error_frame() {
+        let mut stream = RepliesAfterWrite::new(
+            ns::ns_build(NS_VERSION, NS_ERROR_RESPONSE, &["denied"], "MISC"),
+        );
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::Other);
+        assert!(!err.to_string().contains("timed out"), "got {}", err);
+    }
+
+    #[test]
+    fn security_code_gate_surfaces_an_unexpected_774_code() {
+        // Any 774 that is not the result carries a failure the caller must see
+        // rather than wait out.
+        let mut stream = RepliesAfterWrite::new(frame_xyz(&xyz::xyz_build(
+            xyz::XYZ_MSG_SECURITY_CODE, 4, "", &["whatever"],
+        )));
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+        assert!(err.to_string().contains("code 4"), "got {}", err);
+    }
+
+    #[test]
+    fn security_code_gate_rejects_an_absurd_frame_length_instead_of_buffering() {
+        // A corrupt header must not be believed: waiting for a 4 GiB tail
+        // means growing the buffer until the deadline or the allocator gives
+        // out. Header only, no payload — a reader that trusts the length will
+        // sit on it.
+        let mut reply = ns::NS_MAGIC.to_vec();
+        reply.extend_from_slice(&u32::MAX.to_be_bytes());
+        let mut stream = RepliesAfterWrite::new(reply);
+        let err = do_security_code_2fa(
+            &mut stream,
+            far_future_deadline(),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn security_code_gate_requires_a_provider() {
+        // These accounts have no push to fall back to.
+        let mut stream = ScriptedStream::new(Vec::new());
+        let err = do_security_code_2fa(&mut stream, far_future_deadline(), None).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn security_code_gate_does_not_send_a_code_after_the_deadline_passes() {
+        // The read can span the deadline. A login that is about to be
+        // abandoned must not put a code on the wire on its way out — the code
+        // is spent either way, and the operator has to fetch another.
+        struct SlowRead {
+            written: Vec<u8>,
+        }
+        impl io::Read for SlowRead {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                std::thread::sleep(std::time::Duration::from_millis(60));
+                Err(io::Error::new(io::ErrorKind::TimedOut, "poll timeout"))
+            }
+        }
+        impl io::Write for SlowRead {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.written.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> { Ok(()) }
+        }
+
+        let mut stream = SlowRead { written: Vec::new() };
+        let err = do_security_code_2fa(
+            &mut stream,
+            std::time::Instant::now() + std::time::Duration::from_millis(20),
+            Some(&code_provider_returning("123456")),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        assert!(stream.written.is_empty(), "no code may go out after the deadline");
+    }
+
+    #[test]
+    fn security_code_gate_honours_the_deadline() {
+        let mut stream = RepliesAfterWrite::new(Vec::new());
+        let began = std::time::Instant::now();
+        let err = do_security_code_2fa(
+            &mut stream,
+            std::time::Instant::now(),
+            Some(&code_provider_that_never_answers()),
+        )
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        // An expired deadline has to be caught before the loop does anything,
+        // not eventually. Without the check at the top this still ends in
+        // `TimedOut`, but only once the provider gives up — so the kind alone
+        // proves nothing and the elapsed time is what pins it.
+        assert!(
+            began.elapsed() < std::time::Duration::from_secs(5),
+            "an expired deadline must return at once, took {:?}",
+            began.elapsed(),
+        );
+    }
+
     fn far_future_deadline() -> std::time::Instant {
         std::time::Instant::now() + std::time::Duration::from_secs(60)
     }
@@ -1704,8 +2677,13 @@ mod tests {
             other => panic!("expected Approved, got {:?}", other),
         }
 
-        // Provider must have received the parsed display_id + avth_url.
+        // Provider must have received the parsed display_id + avth_url, and be
+        // told which factor it is answering: the two want different codes from
+        // different apps, and the shipped example branches on it. Nothing
+        // pinned it on this path, so labelling it as the authenticator went
+        // unnoticed.
         let seen = seen_challenge.lock().unwrap().clone();
+        assert_eq!(seen.factor, SecondFactor::IbKeyChallengeResponse);
         assert_eq!(seen.display_id, RUN_A_SESSION_ID);
         assert_eq!(seen.avth_url, RUN_A_AVTH_URL);
 

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -963,16 +963,20 @@ fn parse_auth_start_token(auth_start: &str) -> (String, Option<String>) {
         entries.push((ty.to_string(), (!sub.is_empty()).then(|| sub.to_string())));
     }
 
-    // The sub-type has to belong to the type the gate routes to, and routing
-    // prefers IBKey. Keeping the first sub-type stated instead sent the
-    // authenticator's sub-type in the IBKey init on a mixed account.
-    let sub_type = ["5", "4"]
-        .iter()
-        .find_map(|want| {
-            entries.iter().find(|(ty, sub)| ty == want && sub.is_some())
-        })
-        .or_else(|| entries.iter().find(|(_, sub)| sub.is_some()))
-        .and_then(|(_, sub)| sub.clone());
+    // The sub-type has to belong to the type the gate routes to, so which type
+    // that is has to be decided first — exactly as `second_factor_route`
+    // decides it, IBKey when present and the authenticator otherwise. Searching
+    // for a sub-type across types instead lets an entry the gate is not using
+    // supply one: `4.auth,5` routes to IBKey and would send `auth`.
+    let routed = ["5", "4"]
+        .into_iter()
+        .find(|want| entries.iter().any(|(ty, _)| ty == want))
+        .or_else(|| entries.first().map(|(ty, _)| ty.as_str()));
+    let sub_type = routed.and_then(|routed| {
+        entries.iter()
+            .find(|(ty, sub)| ty == routed && sub.is_some())
+            .and_then(|(_, sub)| sub.clone())
+    });
 
     let types: Vec<&str> = entries.iter().map(|(ty, _)| ty.as_str()).collect();
     (types.join(","), sub_type)
@@ -2082,6 +2086,13 @@ mod tests {
             parse_auth_start_token(&frame("4.auth,9.other")),
             ("4,9".into(), Some("auth".into())),
         );
+        // The routed entry stating no sub-type of its own must not borrow one
+        // from an entry the gate is not using. `4.auth,5` routes to IBKey, so
+        // the configured fallback is the answer — sending the authenticator's
+        // sub-type in the IBKey init is what this field kept getting wrong.
+        assert_eq!(parse_auth_start_token(&frame("4.auth,5")), ("4,5".into(), None));
+        assert_eq!(parse_auth_start_token(&frame("9.other,5")), ("9,5".into(), None));
+        assert_eq!(parse_auth_start_token(&frame("9.other,4")), ("9,4".into(), None));
         // A sub-type on a type neither gate serves is still better than none.
         assert_eq!(
             parse_auth_start_token(&frame("9.other")),

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -899,11 +899,13 @@ pub struct GatewayConfig {
     /// server-side deadline). Set lower to fail fast for unattended logins.
     /// Only consulted on non-paper logins; paper logins skip the gate entirely.
     pub ib_key_timeout_secs: u64,
-    /// Account-specific second-factor token sub-type used in the SWCR_TOKEN
-    /// state=1 init body (`M.D` field). Default `"2a"` matches the captured
-    /// reference profile; other accounts may use a different value. Capture
-    /// the live value via ib-agent's `SWCR_TOKEN_SUBTYPE` hook if the default
-    /// doesn't trigger the IBKey push for your account.
+    /// Fallback second-factor token sub-type for the SWCR_TOKEN state=1 init
+    /// body (`M.D` field).
+    ///
+    /// `AUTH_START` states the sub-type for the session, and that value wins:
+    /// it is account- and session-specific, so a fixed setting can only ever
+    /// match the profile it came from. This is what gets used when the server
+    /// states none. Default `"2a"` matches the captured reference profile.
     pub ib_key_token_sub_type: String,
     /// If set, the IBKey gate uses the **Challenge/Response** path instead
     /// of waiting for a mobile push approval. After the server delivers
@@ -912,6 +914,26 @@ pub struct GatewayConfig {
     /// [`session::CodeProvider`] for the contract; `None` leaves behavior
     /// unchanged (push approval).
     pub code_provider: Option<session::CodeProvider>,
+}
+
+/// The second-factor sub-type `AUTH_START` states for the IBKey token.
+///
+/// Field 4 carries `<type>` or `<type>.<sub-type>`, and a comma-separated list
+/// when the account has more than one factor enabled — `4,5` was advertised for
+/// an account holding both an authenticator and IBKey. The list is split before
+/// the dot, so a sub-type on one entry cannot swallow the entries after it:
+/// reading `"5.2a,4"` as one pair yields `2a,4`, which is not a sub-type at all
+/// and is rejected by a server that would have accepted `2a`.
+///
+/// The sub-type returned is the one belonging to type `5`, since that is the
+/// token this gate sends. A sub-type stated against some other type is not
+/// IBKey's and is ignored.
+fn parse_auth_start_sub_type(auth_start: &str) -> Option<String> {
+    let field = auth_start.split(';').nth(4)?;
+    field.split(',').find_map(|entry| {
+        let (ty, sub) = entry.trim().split_once('.')?;
+        (ty.trim() == "5" && !sub.trim().is_empty()).then(|| sub.trim().to_string())
+    })
 }
 
 impl Gateway {
@@ -1016,7 +1038,7 @@ impl Gateway {
         session::send_secure(&mut tls, &mut channel, connect_req.as_bytes())?;
 
         // Receive AUTH_START (may get a redirect instead for paper accounts)
-        let _auth_start = match session::recv_secure(&mut tls, &mut channel) {
+        let auth_start = match session::recv_secure(&mut tls, &mut channel) {
             Ok(data) => data,
             Err(e) if e.to_string().starts_with("REDIRECT:") => {
                 let target = e.to_string().strip_prefix("REDIRECT:").unwrap().to_string();
@@ -1028,6 +1050,15 @@ impl Gateway {
             }
             Err(e) => return Err(e),
         };
+
+        // AUTH_START field 4 names the second-factor token type and its
+        // per-session subtype, e.g. "5.2i" = tokenType 5 (IBKey), subtype "2i".
+        // The subtype is account- and session-specific, so the compiled-in
+        // default only ever matches the profile it was captured from; every
+        // other account has its SWCR_TOKEN rejected and the socket closed
+        // before a challenge is issued (ibx#279).
+        let server_token_sub_type =
+            parse_auth_start_sub_type(&String::from_utf8_lossy(&auth_start));
 
         // Authentication
         log::info!("Starting auth for {}", config.username);
@@ -1062,9 +1093,20 @@ impl Gateway {
                     config.username, config.ib_key_timeout_secs,
                 );
             }
+            // The server's per-session value wins. `ib_key_token_sub_type` is
+            // the fallback for an AUTH_START that states none, not an override
+            // — a fixed value cannot be right for a session it predates.
+            let token_sub_type = server_token_sub_type
+                .as_deref()
+                .unwrap_or(&config.ib_key_token_sub_type);
+            log::info!(
+                "2FA gate: token sub-type {:?} ({})",
+                token_sub_type,
+                if server_token_sub_type.is_some() { "from AUTH_START" } else { "configured default" },
+            );
             match session::do_ib_key_2fa(
                 &mut tls,
-                &config.ib_key_token_sub_type,
+                token_sub_type,
                 deadline,
                 config.code_provider.as_ref(),
             )? {
@@ -1883,6 +1925,37 @@ pub use crate::config::{chrono_free_timestamp, days_to_ymd};
 
 #[cfg(test)]
 mod tests {
+
+    /// Field 4 selects the second factor and states its sub-type. The whole
+    /// field was read as one pair, so a list put the following entries inside
+    /// the sub-type: `"5.2a,4"` sent `2a,4`, which is not a sub-type — an
+    /// account that worked on the compiled-in `2a` would have had its token
+    /// rejected and the socket closed before any challenge (ibx#279).
+    #[test]
+    fn the_ib_key_sub_type_comes_from_the_ib_key_entry() {
+        use super::parse_auth_start_sub_type as parse;
+        let frame = |token: &str| format!("a;b;c;d;{token};f");
+
+        // The single-factor case this was written for.
+        assert_eq!(parse(&frame("5.2i")), Some("2i".into()));
+        assert_eq!(parse(&frame(" 5.2i ")), Some("2i".into()));
+
+        // A list must not fold the later entries into the sub-type.
+        assert_eq!(parse(&frame("5.2a,4")), Some("2a".into()));
+        assert_eq!(parse(&frame("4,5.2i")), Some("2i".into()));
+
+        // A sub-type stated against another factor is not IBKey's.
+        assert_eq!(parse(&frame("4.auth")), None);
+        assert_eq!(parse(&frame("4.auth,5.2i")), Some("2i".into()));
+
+        // Nothing to take: the configured value is used instead.
+        assert_eq!(parse(&frame("5")), None);
+        assert_eq!(parse(&frame("4,5")), None);
+        assert_eq!(parse(&frame("5.")), None);
+        assert_eq!(parse(&frame("")), None);
+        assert_eq!(parse("a;b;c"), None, "a short frame has no field 4");
+    }
+
     use super::*;
 
     #[test]

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -907,33 +907,109 @@ pub struct GatewayConfig {
     /// match the profile it came from. This is what gets used when the server
     /// states none. Default `"2a"` matches the captured reference profile.
     pub ib_key_token_sub_type: String,
-    /// If set, the IBKey gate uses the **Challenge/Response** path instead
-    /// of waiting for a mobile push approval. After the server delivers
-    /// state=2, the callback is invoked once with the challenge details
-    /// and the returned 8-character code is submitted as state=3. See
-    /// [`session::CodeProvider`] for the contract; `None` leaves behavior
-    /// unchanged (push approval).
+    /// Supplies the second factor's code, for whichever exchange `AUTH_START`
+    /// selects.
+    ///
+    /// On the IBKey path it takes the **Challenge/Response** route instead of
+    /// waiting for a mobile push: after the server delivers state=2 the
+    /// callback is invoked once with the challenge details and the returned
+    /// 8-character code is submitted as state=3. `None` there leaves behaviour
+    /// unchanged, and the login completes by push approval.
+    ///
+    /// On an authenticator-code account it is the only way to log in — there is
+    /// no push to approve — so `None` fails the connect rather than falling
+    /// back. See [`session::CodeProvider`] for the contract.
     pub code_provider: Option<session::CodeProvider>,
 }
 
-/// The second-factor sub-type `AUTH_START` states for the IBKey token.
+/// Which second-factor exchange an `AUTH_START` token type selects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SecondFactorRoute {
+    /// No gate at all. Paper sessions never present a second factor.
+    None,
+    /// `XYZ 775` — the IBKey push, or its Challenge/Response variant.
+    IbKey,
+    /// `XYZ 774` — an authenticator code.
+    SecurityCode,
+    /// A type this client has no exchange for. Better to say so than to send
+    /// the wrong message and report whatever the server does about it.
+    Unsupported,
+}
+
+/// The second-factor token AUTH_START names, as `(type, sub-type)`.
 ///
-/// Field 4 carries `<type>` or `<type>.<sub-type>`, and a comma-separated list
-/// when the account has more than one factor enabled — `4,5` was advertised for
-/// an account holding both an authenticator and IBKey. The list is split before
-/// the dot, so a sub-type on one entry cannot swallow the entries after it:
-/// reading `"5.2a,4"` as one pair yields `2a,4`, which is not a sub-type at all
-/// and is rejected by a server that would have accepted `2a`.
+/// Field 4 carries the type, optionally followed by a per-session sub-type
+/// after a `.`, and carries a comma-separated list when the account has more
+/// than one factor enabled. The list is split first, so a sub-type on one
+/// entry cannot swallow the entries after it — `"5.2i,4"` is type `5`
+/// sub-type `2i` and a second entry, not a sub-type of `"2i,4"`.
 ///
-/// The sub-type returned is the one belonging to type `5`, since that is the
-/// token this gate sends. A sub-type stated against some other type is not
-/// IBKey's and is ignored.
-fn parse_auth_start_sub_type(auth_start: &str) -> Option<String> {
-    let field = auth_start.split(';').nth(4)?;
-    field.split(',').find_map(|entry| {
-        let (ty, sub) = entry.trim().split_once('.')?;
-        (ty.trim() == "5" && !sub.trim().is_empty()).then(|| sub.trim().to_string())
-    })
+/// The sub-type returned is the one belonging to the type the gate will route
+/// to, and the type string keeps the whole list for that routing decision.
+fn parse_auth_start_token(auth_start: &str) -> (String, Option<String>) {
+    let fields: Vec<&str> = auth_start.split(';').collect();
+    let token = fields.get(4).map(|f| f.trim()).unwrap_or("");
+
+    let mut entries: Vec<(String, Option<String>)> = Vec::new();
+    for entry in token.split(',') {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        let (ty, sub) = match entry.split_once('.') {
+            Some((t, s)) => (t.trim(), s.trim()),
+            None => (entry, ""),
+        };
+        entries.push((ty.to_string(), (!sub.is_empty()).then(|| sub.to_string())));
+    }
+
+    // The sub-type has to belong to the type the gate routes to, and routing
+    // prefers IBKey. Keeping the first sub-type stated instead sent the
+    // authenticator's sub-type in the IBKey init on a mixed account.
+    let sub_type = ["5", "4"]
+        .iter()
+        .find_map(|want| {
+            entries.iter().find(|(ty, sub)| ty == want && sub.is_some())
+        })
+        .or_else(|| entries.iter().find(|(_, sub)| sub.is_some()))
+        .and_then(|(_, sub)| sub.clone());
+
+    let types: Vec<&str> = entries.iter().map(|(ty, _)| ty.as_str()).collect();
+    (types.join(","), sub_type)
+}
+
+/// An absent token type routes to the IBKey gate rather than skipping the
+/// second factor. That gate opens by sending its init and reports `Skipped`
+/// when the server answers `AUTH_FINISH PASSED`, which is how an account with
+/// no second factor completes — so skipping it would leave the server waiting
+/// on an init that never comes.
+///
+/// The field carries a comma-separated list when the account has more than one
+/// factor enabled — `AUTH_START` advertised `4,5` for an account with both an
+/// authenticator and IBKey. Reading the whole field as one type refused the
+/// login outright, so each entry is considered and IBKey is preferred: it is
+/// the only one that completes without a `code_provider`, and it still serves
+/// a configured one through Challenge/Response.
+fn second_factor_route(paper: bool, token_type: &str) -> SecondFactorRoute {
+    if paper {
+        return SecondFactorRoute::None;
+    }
+    if token_type.is_empty() {
+        return SecondFactorRoute::IbKey;
+    }
+    let mut saw_security_code = false;
+    for entry in token_type.split(',') {
+        match entry.trim() {
+            "5" => return SecondFactorRoute::IbKey,
+            "4" => saw_security_code = true,
+            _ => {}
+        }
+    }
+    if saw_security_code {
+        SecondFactorRoute::SecurityCode
+    } else {
+        SecondFactorRoute::Unsupported
+    }
 }
 
 impl Gateway {
@@ -1057,8 +1133,8 @@ impl Gateway {
         // default only ever matches the profile it was captured from; every
         // other account has its SWCR_TOKEN rejected and the socket closed
         // before a challenge is issued (ibx#279).
-        let server_token_sub_type =
-            parse_auth_start_sub_type(&String::from_utf8_lossy(&auth_start));
+        let (server_token_type, server_token_sub_type) =
+            parse_auth_start_token(&String::from_utf8_lossy(&auth_start));
 
         // Authentication
         log::info!("Starting auth for {}", config.username);
@@ -1068,10 +1144,57 @@ impl Gateway {
         // Per-session second-factor approval gate (IBKey / seamless push).
         // Skipped on paper logins; live logins enter a wait state if the
         // account has a second factor configured server-side.
-        // Captures the SOFT session token from AUTH_FINISH PASSED — this is
-        // the token used for downstream farm logons (NOT the SRP session_key).
+        // Would capture a SOFT session token from AUTH_FINISH PASSED, but per
+        // ib-agent#125 that body carries none, so this stays `None` on both
+        // live paths and the farm logon falls back to the SRP session key.
         let mut soft_token: Option<BigUint> = None;
+        // An advertised type this client cannot perform is worth saying out
+        // loud: sending 775 at it gets the socket closed before any challenge,
+        // and skipping the gate leaves the server waiting until the connect
+        // dies with "Never received data start after auth". Neither names the
+        // cause (ibx#279). See `second_factor_route` for why an absent type is
+        // the one case that is not an error.
+        let route = second_factor_route(config.paper, &server_token_type);
         if !config.paper {
+            log::debug!(
+                "second factor: AUTH_START type {:?} sub {:?} -> {:?}",
+                server_token_type, server_token_sub_type, route,
+            );
+        }
+        if route == SecondFactorRoute::SecurityCode {
+            // Authenticator-code accounts take the 774 exchange rather than the
+            // IBKey push. The same code_provider supplies the code (ibx#282).
+            let deadline = std::time::Instant::now()
+                + std::time::Duration::from_secs(config.ib_key_timeout_secs);
+            log::info!(
+                "Live login for {}: second factor is an authenticator code; awaiting code_provider",
+                config.username,
+            );
+            // The code is written raw, with no DH encryption — the same
+            // transport the IBKey gate uses. The encrypted variant gets the
+            // connection reset on receipt.
+            // Poll the socket so the gate can submit as soon as the code is
+            // available instead of waiting for the server's next keepalive: an
+            // authenticator code is only valid for ~30s, and a 20s wait spends
+            // most of it. Restored afterwards.
+            tls.get_ref().set_read_timeout(Some(Duration::from_millis(500)))?;
+            let gate = session::do_security_code_2fa(
+                &mut tls, deadline, config.code_provider.as_ref(),
+            );
+            let restore = tls.get_ref().set_read_timeout(None);
+            gate?;
+            restore?;
+            log::info!("security-code gate: passed")
+        } else if route == SecondFactorRoute::Unsupported {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!(
+                    "second-factor token type {:?} is not supported; AUTH_START advertised it for {}",
+                    server_token_type, config.username,
+                ),
+            ));
+        }
+        if route == SecondFactorRoute::IbKey {
             let deadline = std::time::Instant::now()
                 + std::time::Duration::from_secs(config.ib_key_timeout_secs);
             // Live logins enter a human-approval window here: connect() blocks
@@ -1926,34 +2049,75 @@ pub use crate::config::{chrono_free_timestamp, days_to_ymd};
 #[cfg(test)]
 mod tests {
 
-    /// Field 4 selects the second factor and states its sub-type. The whole
-    /// field was read as one pair, so a list put the following entries inside
-    /// the sub-type: `"5.2a,4"` sent `2a,4`, which is not a sub-type — an
-    /// account that worked on the compiled-in `2a` would have had its token
-    /// rejected and the socket closed before any challenge (ibx#279).
+    /// Field 4 is where the second-factor type lives, and reading the wrong
+    /// field is what caused both live failures this gate was written for — a
+    /// sub-type sent to the wrong account shape, and a factor routed to the
+    /// wrong prompt. Nothing pinned it.
     #[test]
-    fn the_ib_key_sub_type_comes_from_the_ib_key_entry() {
-        use super::parse_auth_start_sub_type as parse;
+    fn auth_start_token_comes_from_field_four() {
         let frame = |token: &str| format!("a;b;c;d;{token};f");
 
-        // The single-factor case this was written for.
-        assert_eq!(parse(&frame("5.2i")), Some("2i".into()));
-        assert_eq!(parse(&frame(" 5.2i ")), Some("2i".into()));
+        assert_eq!(parse_auth_start_token(&frame("5.2i")), ("5".into(), Some("2i".into())));
+        assert_eq!(parse_auth_start_token(&frame("4")), ("4".into(), None));
+        assert_eq!(parse_auth_start_token(&frame("4,5")), ("4,5".into(), None));
+        assert_eq!(parse_auth_start_token(&frame(" 5.2i ")), ("5".into(), Some("2i".into())));
 
-        // A list must not fold the later entries into the sub-type.
-        assert_eq!(parse(&frame("5.2a,4")), Some("2a".into()));
-        assert_eq!(parse(&frame("4,5.2i")), Some("2i".into()));
+        // A sub-type on one entry must not swallow the entries after it.
+        assert_eq!(parse_auth_start_token(&frame("5.2i,4")), ("5,4".into(), Some("2i".into())));
 
-        // A sub-type stated against another factor is not IBKey's.
-        assert_eq!(parse(&frame("4.auth")), None);
-        assert_eq!(parse(&frame("4.auth,5.2i")), Some("2i".into()));
+        // On a mixed account the sub-type must belong to the type the gate
+        // routes to, which prefers IBKey. Keeping the first one stated sent
+        // the authenticator's sub-type in the IBKey init.
+        assert_eq!(
+            parse_auth_start_token(&frame("4.auth,5.2i")),
+            ("4,5".into(), Some("2i".into())),
+        );
+        assert_eq!(
+            parse_auth_start_token(&frame("5.2i,4.auth")),
+            ("5,4".into(), Some("2i".into())),
+        );
+        // With no IBKey entry the authenticator's own sub-type is the one that
+        // belongs to the route taken.
+        assert_eq!(
+            parse_auth_start_token(&frame("4.auth,9.other")),
+            ("4,9".into(), Some("auth".into())),
+        );
+        // A sub-type on a type neither gate serves is still better than none.
+        assert_eq!(
+            parse_auth_start_token(&frame("9.other")),
+            ("9".into(), Some("other".into())),
+        );
 
-        // Nothing to take: the configured value is used instead.
-        assert_eq!(parse(&frame("5")), None);
-        assert_eq!(parse(&frame("4,5")), None);
-        assert_eq!(parse(&frame("5.")), None);
-        assert_eq!(parse(&frame("")), None);
-        assert_eq!(parse("a;b;c"), None, "a short frame has no field 4");
+        // Short or absent field 4 yields no type rather than a wrong one.
+        assert_eq!(parse_auth_start_token("a;b;c"), ("".into(), None));
+        assert_eq!(parse_auth_start_token(&frame("")), ("".into(), None));
+    }
+
+    #[test]
+    fn second_factor_route_covers_every_token_type() {
+        use super::{second_factor_route, SecondFactorRoute::*};
+        // An absent type must still enter the IBKey gate. That gate opens by
+        // sending its init, and an account with no second factor completes
+        // through it — routing it to `None` sends nothing and leaves the
+        // server waiting on an init that never arrives.
+        assert_eq!(second_factor_route(false, ""), IbKey);
+        assert_eq!(second_factor_route(false, "5"), IbKey);
+        assert_eq!(second_factor_route(false, "4"), SecurityCode);
+        // The field is a list when more than one factor is enabled. An
+        // account with both an authenticator and IBKey advertises `4,5`, and
+        // reading that as one type refused the login outright.
+        assert_eq!(second_factor_route(false, "4,5"), IbKey);
+        assert_eq!(second_factor_route(false, "5,4"), IbKey, "order must not matter");
+        assert_eq!(second_factor_route(false, "3,4"), SecurityCode, "an unknown entry must not veto a known one");
+        assert_eq!(second_factor_route(false, " 4 , 5 "), IbKey, "entries may be padded");
+        assert_eq!(second_factor_route(false, "3,6"), Unsupported, "a list of unknowns is still unsupported");
+        assert_eq!(second_factor_route(false, "3"), Unsupported);
+        assert_eq!(second_factor_route(false, "05"), Unsupported);
+        assert_eq!(second_factor_route(false, "banana"), Unsupported);
+        // Paper never presents one, whatever the field says.
+        for t in ["", "3", "4", "5"] {
+            assert_eq!(second_factor_route(true, t), None, "paper, type {:?}", t);
+        }
     }
 
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() {
         host,
         paper,
         core_id: None,
+        code_provider: None,
     }).unwrap_or_else(|e| {
         eprintln!("Connection failed: {}", e);
         std::process::exit(1);

--- a/src/protocol/xyz.rs
+++ b/src/protocol/xyz.rs
@@ -181,6 +181,41 @@ pub fn xyz_build_swcr_token_code_submission(code: &str) -> Vec<u8> {
     buf
 }
 
+/// Security-code second factor (msg 774), the path used by accounts whose
+/// second factor is an authenticator code rather than an IBKey push.
+pub const XYZ_MSG_SECURITY_CODE: u32 = 774;
+
+/// Message codes on 774. The client sends its code as message code 1; the
+/// server answers with 2. Other codes exist on this message; this path sends
+/// and expects only these two.
+pub const SECURITY_CODE_SEND: u32 = 1;
+pub const SECURITY_CODE_RESULT: u32 = 2;
+
+/// Build the security-code frame: msg 774, **message code 1**, carrying the
+/// code itself.
+///
+/// This is a single message, not a request/submit pair: exactly one 774 goes
+/// on the wire after SRP passes, carrying message code 1 with the code in the
+/// security-token slot. Nothing precedes it and nothing acknowledges it but
+/// the code 2 result.
+///
+/// ```text
+/// Header: version (=20), msg_id (=774), literal 1, message_code (=1), username=""
+/// Body:   security_token = the code, challenge = "", status = ""
+/// ```
+pub fn xyz_build_security_code(code: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&20u32.to_be_bytes());
+    buf.extend_from_slice(&XYZ_MSG_SECURITY_CODE.to_be_bytes());
+    buf.extend_from_slice(&1u32.to_be_bytes());
+    buf.extend_from_slice(&SECURITY_CODE_SEND.to_be_bytes());
+    xyz_write_string(&mut buf, "");      // header username
+    xyz_write_string(&mut buf, code);    // security token = the code
+    xyz_write_string(&mut buf, "");      // challenge
+    xyz_write_string(&mut buf, "");      // status
+    buf
+}
+
 /// Parsed payload from an `XYZ_MSG_SWCR_TOKEN` state=2 reply.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct SwcrTokenChallenge {
@@ -298,6 +333,40 @@ mod tests {
     }
 
     // ── Second-factor approval (IBKey / SWCR_TOKEN) ─────────────────
+
+    /// The authenticator-code frame, byte for byte (ibx#282). One message,
+    /// code 1, the code in the security-token slot — the shape the reference
+    /// client puts on the wire after SRP passes. Verified against a live login.
+    #[test]
+    fn security_code_matches_canonical_bytes() {
+        let expected: Vec<u8> = vec![
+            0x00, 0x00, 0x00, 0x14, // version = 20
+            0x00, 0x00, 0x03, 0x06, // msg_id = 774
+            0x00, 0x00, 0x00, 0x01, // hardcoded 1
+            0x00, 0x00, 0x00, 0x01, // message code = 1
+            0x00, 0x00, 0x00, 0x00, // header username = ""
+            0x00, 0x00, 0x00, 0x06, // security token length = 6
+            0x31, 0x32, 0x33, 0x34, 0x35, 0x36, // "123456"
+            0x00, 0x00,             // padding to 4-byte alignment
+            0x00, 0x00, 0x00, 0x00, // challenge = ""
+            0x00, 0x00, 0x00, 0x00, // status = ""
+        ];
+        assert_eq!(xyz_build_security_code("123456"), expected,
+            "byte-for-byte match required");
+    }
+
+    /// The code lands in the security-token slot, not the header username the
+    /// base header writes first, and not the trailing status.
+    #[test]
+    fn security_code_parses_back_with_the_code_in_the_token_slot() {
+        let payload = xyz_build_security_code("987654");
+        let (msg_id, _, code, fields) = xyz_parse_response(&payload).unwrap();
+        assert_eq!(msg_id, XYZ_MSG_SECURITY_CODE);
+        assert_eq!(code, SECURITY_CODE_SEND);
+        // fields[0] is the header username, fields[1] the security token.
+        assert_eq!(fields[0], "", "header username is empty");
+        assert_eq!(fields[1], "987654", "the code goes in the security-token slot");
+    }
 
     #[test]
     fn swcr_token_init_matches_canonical_bytes() {

--- a/tests/rust_api_gt.rs
+++ b/tests/rust_api_gt.rs
@@ -384,6 +384,7 @@ fn get_config() -> Option<EClientConfig> {
         host,
         paper: true,
         core_id: None,
+        code_provider: None,
     })
 }
 


### PR DESCRIPTION
## Summary

- Adds the type 4 second factor, so accounts on an authenticator code can log in — previously there was no implementation and the attempt died as a socket close partway through auth.
- The code goes out as `XYZ 774` message code 1 with the code in the security-token slot, framed and written raw like the IBKey messages, straight after SRP passes. The server answers with code 2; `PASSED` is the accepted verdict and anything else is treated as a rejection.
- Nothing prompts for the code first. The prompt is local to the client, not a server message, so a gate that waits to be asked waits until its deadline. This one sends as soon as the next poll comes round after the provider returns.
- The provider runs off the socket thread, because it normally waits on a human and the loop has to keep answering keepalives meanwhile or the connection is dropped for going quiet. The gate polls the socket while it waits so a code cannot sit unsent for a keepalive interval — an authenticator code is good for about thirty seconds.
- Polling means a read can return part of a frame. `ns_recv` is two `read_exact` calls and drops what it consumed if the second times out, so the next read resumes mid-frame and the connection dies on the magic check. The gate buffers instead, and bounds the claimed length before believing it so a corrupt header cannot grow that buffer toward 4 GiB.
- A rejection is now reported as one. A 774 code 2 `FAILED`, a denial delivered as `AUTH_FINISH`, an unexpected 774 code, and NS error frames each return immediately. Only the first was recognised before, so a refused code was answered with keepalives until the deadline and surfaced as a timeout.
- `IbKeyChallenge` names the factor being answered. The two want different codes — eight characters against the IBKey display, six digits from an authenticator app — and the shipped provider example rejected anything that was not eight characters, so it could not serve this factor.
- Routing is now one pure function, `second_factor_route(paper, token_type)`, matched on at the call site. An `AUTH_START` naming no type keeps going to the IBKey gate, as before — that gate opens by sending its init and reports `Skipped` once the server answers `AUTH_FINISH PASSED`, which is how an account with no second factor completes. Routing it past the gate would send no init and leave the server waiting on one.
- A verdict is judged against whether the code was on the wire when that frame's **first byte arrived**. Judging by the moment it was matched is wrong twice: the socket is read before the provider channel is polled, and a frame can span polls, so a send landing between a verdict's header and its body would make a verdict that predates the code look like an answer to it. The deadline is rechecked between the read and the send for a related reason.
- `EClientConfig` gains `code_provider`, which is also what ibx#208 asks for. This is a new field on a public struct, so struct-literal callers need one line; the in-tree examples are updated.

Stacked on ibx#280 — that PR reads the token type out of `AUTH_START`, which is what selects this path. Review after it, or I can rebase onto main if you would rather take them in the other order.

Closes #282.

## Test plan

- [x] `cargo test --lib` — 826 pass. The two `config::expiry_tests` failures and the `E0063` in `tests/ib_paper_compat` are pre-existing on main, unrelated to this change.
- [x] Twenty-one tests over the gate, one over the routing. Among them: happy path with a byte-exact assertion on the frame, a reply split one byte per read, keepalives answered mid-wait, both rejection routes, the code kept out of error text, an unsolicited verdict ignored, provider absent, deadline honoured.
- [x] Each was checked by reverting the real code it covers rather than by inventing a mutation: restoring the old reader fails the split-read and frame-length tests, calling the provider inline fails the keepalive test, and removing the pre-send guard, the read-time verdict judgment, the length cap, the status sanitisation or the deadline recheck each fails its own test.
- [x] Byte-exact builder tests, verified to fail when the code is moved to an adjacent slot.
- [x] Live login on a type 4 account: gate accepted, both farms connected, historical data farm up, 41s wall clock.
- [ ] Live login on an account with no second factor at all — **I could not construct this case.** Every live account appears to be forced through some factor (app, SMS or authenticator), so an `AUTH_START` naming no type may not be reachable in practice. The route is kept anyway because main called that gate unconditionally, and the gate's own `Skipped` outcome exists for exactly this shape; removing it would be an unforced behaviour change on a path I cannot observe. Worst case the arm is simply never taken. It cannot behave differently from main, because it *is* main's behaviour.
- [x] Live login on a type 4 account with a deliberately wrong code: the server answers `774` code 2 `FAILED` and the gate returns `PermissionDenied` naming it, immediately. Before the rejection arms were added this same reply fell through and was answered with keepalives until the client deadline, so it surfaced as a timeout ~18 minutes later.
- [x] Live login on a type 5 (IBKey push) account: approval delivered, login completed. This PR moved the decision that selects that route into `second_factor_route`, so it is new code on a path that previously worked.
- [x] Paper login: no gate is entered at all, the `None` route. Same reason — paper used to be a `!config.paper` guard at each branch and now goes through the same function, so every existing paper caller is on new code.
- [x] All live runs above were made against this branch's head, not an earlier revision of it — the reader, the verdict handling and the routing all changed after the first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
