### PR TITLE
market data: scale wire quantities into the fixed-point the readers expect (ibx#287)

### DIFF
--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -1782,11 +1782,19 @@ fn process_msgs_dispatches_all_quote_fields() {
     assert!(w.events.iter().any(|e| e.starts_with("tick_price:1:7:")));   // low
     assert!(w.events.iter().any(|e| e.starts_with("tick_price:1:9:")));   // close
     assert!(w.events.iter().any(|e| e.starts_with("tick_price:1:14:"))); // open
-    // tick_size for: bid_size(0), ask_size(3), last_size(5), volume(8)
-    assert!(w.events.iter().any(|e| e.starts_with("tick_size:1:0:")));   // bid_size
-    assert!(w.events.iter().any(|e| e.starts_with("tick_size:1:3:")));   // ask_size
-    assert!(w.events.iter().any(|e| e.starts_with("tick_size:1:5:")));   // last_size
-    assert!(w.events.iter().any(|e| e.starts_with("tick_size:1:8:")));   // volume
+    // tick_size for: bid_size(0), ask_size(3), last_size(5), volume(8).
+    // Assert the delivered quantity, not just that a tick appeared — the
+    // scaling defect in ibx#287 fired every one of these with a value four
+    // orders of magnitude off, and a `starts_with` check passed throughout.
+    let delivered = |prefix: &str| -> Option<f64> {
+        w.events.iter().find(|e| e.starts_with(prefix))
+            .and_then(|e| e.rsplit(':').next())
+            .and_then(|v| v.parse().ok())
+    };
+    assert_eq!(delivered("tick_size:1:0:"), Some(1000.0), "bid_size");
+    assert_eq!(delivered("tick_size:1:3:"), Some(2000.0), "ask_size");
+    assert_eq!(delivered("tick_size:1:5:"), Some(500.0), "last_size");
+    assert_eq!(delivered("tick_size:1:8:"), Some(10_000.0), "volume");
 }
 
 #[test]

--- a/src/bin/bench_decode.rs
+++ b/src/bin/bench_decode.rs
@@ -295,10 +295,10 @@ fn apply_tick(q: &mut Quote, tick: &RawTick, min_tick_scaled: i64) {
         tick_decoder::O_LOW_PRICE => q.low = tick.magnitude * min_tick_scaled,
         tick_decoder::O_OPEN_PRICE => q.open = tick.magnitude * min_tick_scaled,
         tick_decoder::O_CLOSE_PRICE => q.close = tick.magnitude * min_tick_scaled,
-        tick_decoder::O_BID_SIZE => q.bid_size = tick.magnitude,
-        tick_decoder::O_ASK_SIZE => q.ask_size = tick.magnitude,
-        tick_decoder::O_LAST_SIZE => q.last_size = tick.magnitude,
-        tick_decoder::O_VOLUME => q.volume = tick.magnitude,
+        tick_decoder::O_BID_SIZE => q.bid_size = ibx::types::qty_from_wire(tick.magnitude),
+        tick_decoder::O_ASK_SIZE => q.ask_size = ibx::types::qty_from_wire(tick.magnitude),
+        tick_decoder::O_LAST_SIZE => q.last_size = ibx::types::qty_from_wire(tick.magnitude),
+        tick_decoder::O_VOLUME => q.volume = ibx::types::qty_from_wire(tick.magnitude),
         tick_decoder::O_TIMESTAMP | tick_decoder::O_LAST_TS => {
             q.timestamp_ns = tick.magnitude as u64;
         }

--- a/src/bin/bench_replay.rs
+++ b/src/bin/bench_replay.rs
@@ -618,10 +618,10 @@ fn apply_tick(q: &mut Quote, tick: &RawTick, min_tick_scaled: i64) {
         tick_decoder::O_LOW_PRICE => q.low = tick.magnitude * min_tick_scaled,
         tick_decoder::O_OPEN_PRICE => q.open = tick.magnitude * min_tick_scaled,
         tick_decoder::O_CLOSE_PRICE => q.close = tick.magnitude * min_tick_scaled,
-        tick_decoder::O_BID_SIZE => q.bid_size = tick.magnitude,
-        tick_decoder::O_ASK_SIZE => q.ask_size = tick.magnitude,
-        tick_decoder::O_LAST_SIZE => q.last_size = tick.magnitude,
-        tick_decoder::O_VOLUME => q.volume = tick.magnitude,
+        tick_decoder::O_BID_SIZE => q.bid_size = ibx::types::qty_from_wire(tick.magnitude),
+        tick_decoder::O_ASK_SIZE => q.ask_size = ibx::types::qty_from_wire(tick.magnitude),
+        tick_decoder::O_LAST_SIZE => q.last_size = ibx::types::qty_from_wire(tick.magnitude),
+        tick_decoder::O_VOLUME => q.volume = ibx::types::qty_from_wire(tick.magnitude),
         tick_decoder::O_TIMESTAMP | tick_decoder::O_LAST_TS => {
             q.timestamp_ns = tick.magnitude as u64;
         }

--- a/src/engine/hot_loop/farm.rs
+++ b/src/engine/hot_loop/farm.rs
@@ -7,7 +7,7 @@ use crate::protocol::connection::{Connection, Frame};
 use crate::protocol::fix;
 use crate::protocol::fixcomp;
 use crate::protocol::tick_decoder;
-use crate::types::InstrumentId;
+use crate::types::{qty_from_wire, InstrumentId};
 use crossbeam_channel::Sender;
 
 use super::{HeartbeatState, emit, fast_extract_msg_type, find_body_after_tag};
@@ -229,10 +229,12 @@ impl FarmState {
                 tick_decoder::O_LOW_PRICE => { q.low = tick.magnitude * mts; }
                 tick_decoder::O_OPEN_PRICE => { q.open = tick.magnitude * mts; }
                 tick_decoder::O_CLOSE_PRICE => { q.close = tick.magnitude * mts; }
-                tick_decoder::O_BID_SIZE => { q.bid_size = tick.magnitude; }
-                tick_decoder::O_ASK_SIZE => { q.ask_size = tick.magnitude; }
-                tick_decoder::O_LAST_SIZE => { q.last_size = tick.magnitude; }
-                tick_decoder::O_VOLUME => { q.volume = tick.magnitude; }
+                // Quantities are fixed-point, the same way prices are; every
+                // reader divides by `QTY_SCALE` on the way out (ibx#287).
+                tick_decoder::O_BID_SIZE => { q.bid_size = qty_from_wire(tick.magnitude); }
+                tick_decoder::O_ASK_SIZE => { q.ask_size = qty_from_wire(tick.magnitude); }
+                tick_decoder::O_LAST_SIZE => { q.last_size = qty_from_wire(tick.magnitude); }
+                tick_decoder::O_VOLUME => { q.volume = qty_from_wire(tick.magnitude); }
                 tick_decoder::O_TIMESTAMP | tick_decoder::O_LAST_TS => { q.timestamp_ns = tick.magnitude as u64; }
                 tick_decoder::O_BID_EXCH => { q.bid_exch_mask = tick.magnitude; }
                 tick_decoder::O_ASK_EXCH => { q.ask_exch_mask = tick.magnitude; }
@@ -1015,3 +1017,97 @@ impl FarmState {
     }
 }
 
+
+#[cfg(test)]
+mod decode_publish_tests {
+    use super::*;
+    use crate::bridge::SharedState;
+    use crate::engine::context::Context;
+    use crate::protocol::tick_decoder;
+    use crate::types::QTY_SCALE;
+
+    fn push_bits(bits: &mut Vec<u8>, val: u64, n: usize) {
+        for i in (0..n).rev() {
+            bits.push(((val >> i) & 1) as u8);
+        }
+    }
+
+    /// One 35=P body carrying `ticks` for `server_tag`, framed as the farm
+    /// connection delivers it.
+    fn framed_35p(server_tag: u32, ticks: &[(u64, u64, u64)]) -> Vec<u8> {
+        let mut bits: Vec<u8> = Vec::new();
+        push_bits(&mut bits, 0, 1);
+        push_bits(&mut bits, server_tag as u64, 31);
+        for (i, &(tick_type, width, value)) in ticks.iter().enumerate() {
+            push_bits(&mut bits, tick_type, 5);
+            push_bits(&mut bits, if i < ticks.len() - 1 { 1 } else { 0 }, 1);
+            push_bits(&mut bits, width - 1, 2);
+            push_bits(&mut bits, 0, 1); // positive
+            push_bits(&mut bits, value, (width * 8 - 1) as usize);
+        }
+        let byte_count = (bits.len() + 7) / 8;
+        let mut payload = vec![0u8; byte_count];
+        for (i, &b) in bits.iter().enumerate() {
+            if b == 1 {
+                payload[i >> 3] |= 1 << (7 - (i & 7));
+            }
+        }
+        let mut tick_payload = Vec::with_capacity(2 + byte_count);
+        tick_payload.push((bits.len() >> 8) as u8);
+        tick_payload.push((bits.len() & 0xFF) as u8);
+        tick_payload.extend_from_slice(&payload);
+
+        let body_len = 5 + tick_payload.len() + 15;
+        let mut msg = format!("8=O\x019={}\x01", body_len).into_bytes();
+        msg.extend_from_slice(b"35=P\x01");
+        msg.extend_from_slice(&tick_payload);
+        msg.extend_from_slice(b"\x018349=AABBCCDD\x01");
+        msg
+    }
+
+    /// The producer half of the quantity contract. Everything downstream
+    /// divides by `QTY_SCALE`, so a decode path that stores the wire magnitude
+    /// raw delivers quantities 10_000x too small (ibx#287) — and nothing else
+    /// in the suite reaches this function, which is why that shipped.
+    #[test]
+    fn decoded_quantities_are_stored_as_fixed_point() {
+        let mut farm = FarmState::new();
+        let mut context = Context::new();
+        let shared = SharedState::new();
+        let id = context.market.register(756733);
+        context.market.register_server_tag(7, id);
+        context.market.set_min_tick(id, 0.01);
+
+        let msg = framed_35p(7, &[
+            (tick_decoder::O_BID_SIZE, 1, 42),
+            (tick_decoder::O_ASK_SIZE, 1, 17),
+            (tick_decoder::O_LAST_SIZE, 1, 5),
+            (tick_decoder::O_VOLUME, 2, 1234),
+        ]);
+        farm.handle_tick_data(&msg, &mut context, &shared, &None);
+
+        let q = context.market.quote(id);
+        assert_eq!(q.bid_size, 42 * QTY_SCALE, "bid_size must be stored fixed-point");
+        assert_eq!(q.ask_size, 17 * QTY_SCALE, "ask_size must be stored fixed-point");
+        assert_eq!(q.last_size, 5 * QTY_SCALE, "last_size must be stored fixed-point");
+        assert_eq!(q.volume, 1234 * QTY_SCALE, "volume must be stored fixed-point");
+    }
+
+    /// Prices were already scaled correctly; pin that the quantity change did
+    /// not disturb them.
+    #[test]
+    fn decoded_prices_are_still_scaled_by_min_tick() {
+        let mut farm = FarmState::new();
+        let mut context = Context::new();
+        let shared = SharedState::new();
+        let id = context.market.register(756733);
+        context.market.register_server_tag(9, id);
+        context.market.set_min_tick(id, 0.01);
+        let mts = context.market.min_tick_scaled(id);
+
+        let msg = framed_35p(9, &[(tick_decoder::O_BID_PRICE, 2, 15000)]);
+        farm.handle_tick_data(&msg, &mut context, &shared, &None);
+
+        assert_eq!(context.market.quote(id).bid, 15000 * mts);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,16 @@ pub type Qty = i64;
 pub const PRICE_SCALE: i64 = 100_000_000; // 10^8
 pub const QTY_SCALE: i64 = 10_000; // 10^4
 
+/// Convert a wire quantity into the `QTY_SCALE` fixed-point form the `Quote`
+/// fields hold. Every reader divides by `QTY_SCALE`, so a decode path that
+/// stores the magnitude raw delivers quantities 10_000x too small (ibx#287).
+/// Saturating: the magnitude is server-supplied, and a clamped quantity is
+/// preferable to a wrapped one.
+#[inline(always)]
+pub fn qty_from_wire(magnitude: i64) -> Qty {
+    magnitude.saturating_mul(QTY_SCALE)
+}
+
 /// Snap a fixed-point price to the nearest multiple of `tick` (ties round
 /// away from zero). A non-positive tick means the grid is unknown and the
 /// price is returned unchanged. Pure integer math — exact on the fixed-point
@@ -1498,6 +1508,32 @@ pub struct MidnightSeed {
 
 #[cfg(test)]
 mod tests {
+
+    /// The producer and the consumer have to agree on the units. This is the
+    /// disagreement that shipped: the decode path stored the wire magnitude
+    /// and every reader divided by `QTY_SCALE`, so one contract arrived as
+    /// 0.0001. Pinning both halves together is what catches it — either side
+    /// changing alone fails here.
+    #[test]
+    fn wire_quantity_survives_the_round_trip_through_qty_scale() {
+        for wire in [0i64, 1, 2, 7, 500, 10_000, 1_000_000] {
+            let stored = qty_from_wire(wire);
+            let delivered = stored as f64 / QTY_SCALE as f64;
+            assert_eq!(delivered, wire as f64, "wire quantity {} came back as {}", wire, delivered);
+        }
+    }
+
+    #[test]
+    fn qty_from_wire_clamps_instead_of_wrapping() {
+        // Server-supplied magnitude; a wrapped quantity would read as a
+        // plausible negative size rather than an obvious ceiling.
+        assert_eq!(qty_from_wire(i64::MAX), i64::MAX);
+        assert_eq!(qty_from_wire(i64::MIN), i64::MIN);
+        // Not a fixed point of the identity function, so this fails if the
+        // conversion is dropped as well as if it wraps.
+        assert_eq!(qty_from_wire(i64::MAX / 2), i64::MAX);
+    }
+
     use super::*;
     use std::mem;
 


### PR DESCRIPTION
## Summary

- `Quote`'s quantity fields are `QTY_SCALE` fixed-point (10^4). Both readers divide by it — the Rust dispatch in `client_core.rs` and the Python bridge in `market_data.rs` — but the live decode path stored the raw wire magnitude. Prices on the adjacent lines are scaled (`tick.magnitude * mts`); quantities were not.
- So every size and volume reaching either API from live market data was 10,000x too small. Streaming a front-month CME future, volume ticks arrived as `0.0001` and `0.0002` for one and two contracts, while prices on the same messages were correct — which is exactly what the split between the two paths predicts.
- The conversion is now a named function beside the constant, so producer and reader refer to the same thing. It saturates: the magnitude is server-supplied, and a clamped quantity beats a wrapped one that would surface as a plausible negative size.
- Scaled on store rather than dropping the readers' divisors, because the fixed-point form is the intended contract — order quantities are documented fixed-point, the Python test helper multiplies user units in, and both bridges divide on the way out. Removing the divisors would make fractional sizes unrepresentable.
- The tick-by-tick quote path is deliberately untouched. `TbtQuote` sizes are a different type and are delivered undivided, so that path is internally consistent; adding a divisor there breaks its existing test.

Closes #287.

## Test plan

- [x] `cargo test --lib` — 806 pass. The two `config::expiry_tests` failures are pre-existing on main.
- [x] `decoded_quantities_are_stored_as_fixed_point` pushes a real binary `35=P` body through the decode path and asserts what lands in the quote. This is the first test to reach that function — before it, reverting all four conversions left the suite bit-identical, so the defect could have returned silently. Each of the four is now individually killed by mutation.
- [x] A round-trip test pins the conversion against the reader's divisor; replacing the helper with the identity fails it with the live symptom, one contract arriving as 0.0001.
- [x] `process_msgs_dispatches_all_quote_fields` asserts the delivered quantities. It previously asserted only that a tick appeared, which is a large part of why this shipped.
- [x] A price test pins that the quantity change did not disturb the scaling that was already correct.
- [ ] Not covered: the Python bridge is feature-gated and outside a default `cargo test --lib`, and the two benchmark binaries carry their own copies of the apply loop (updated here, but not reached by the test run).

## Note

`tick_decoder::VOLUME_MULT` is dead and documents "IB encodes volume * 10000", which would mean volume must not be scaled again. It does not describe this field: across a live capture the magnitudes were single digits and fell as often as they rose, so whatever `O_VOLUME` carries is neither pre-scaled nor cumulative. That it does not look like cumulative volume at all is filed separately as ibx#290.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
