### PR TITLE
market data: re-subscribe L1 from the record that survives a disconnect (ibx#288)

### DIFF
--- a/src/engine/hot_loop/farm.rs
+++ b/src/engine/hot_loop/farm.rs
@@ -32,6 +32,19 @@ pub(crate) struct FarmState {
 }
 
 impl FarmState {
+    /// Whether this instrument still has market-data state that would be
+    /// repointed by a slot reuse: a live subscription, a request id waiting on
+    /// its ack, or a record kept for the next reconnect.
+    ///
+    /// The resubscribe record is the reason this matters. Before it existed a
+    /// reclaimed slot replayed nothing; now it replays the old contract's
+    /// descriptor against whatever contract holds the id at reconnect (ibx#288).
+    pub(crate) fn holds_market_data(&self, instrument: InstrumentId) -> bool {
+        self.instrument_md_reqs.iter().any(|(id, _)| *id == instrument)
+            || self.md_req_to_instrument.iter().any(|(_, id)| *id == instrument)
+            || self.md_resub_info.iter().any(|r| r.0 == instrument)
+    }
+
     pub(crate) fn new() -> Self {
         Self {
             next_md_req_id: 1,
@@ -1111,5 +1124,39 @@ mod resub_tests {
         market.unregister(instrument);
 
         assert!(farm.take_resub_targets(&market).is_empty());
+    }
+
+    /// The case the test above does not reach: the slot is not merely freed but
+    /// handed to another contract before the reconnect. `md_resub_info` holds
+    /// no con_id of its own, so the record is combined with whatever con_id the
+    /// id now resolves to — the old contract's descriptor subscribing the new
+    /// contract's instrument. The guard is that a slot holding market-data
+    /// state is not reclaimable in the first place.
+    #[test]
+    fn an_instrument_holding_a_resubscribe_record_is_not_reclaimable() {
+        let mut farm = FarmState::new();
+        let mut market = MarketState::new();
+        let instrument = market.register(756733);
+        farm.md_resub_info.push((
+            instrument, "SPY".into(), "SMART".into(), "STK".into(), String::new(),
+            0.0, String::new(), String::new(), 0,
+        ));
+
+        assert!(
+            farm.holds_market_data(instrument),
+            "the record alone must keep the slot resident",
+        );
+
+        // And each of the other two references does the same on its own.
+        let mut farm = FarmState::new();
+        farm.instrument_md_reqs.push((instrument, vec![7]));
+        assert!(farm.holds_market_data(instrument), "a live subscription");
+
+        let mut farm = FarmState::new();
+        farm.md_req_to_instrument.push((7, instrument));
+        assert!(farm.holds_market_data(instrument), "a request awaiting its ack");
+
+        // An instrument with none of the three is free to go.
+        assert!(!FarmState::new().holds_market_data(instrument));
     }
 }

--- a/src/engine/hot_loop/farm.rs
+++ b/src/engine/hot_loop/farm.rs
@@ -462,6 +462,13 @@ impl FarmState {
         farm_conn: &mut Option<Connection>,
         hb: &mut HeartbeatState,
     ) {
+        // Drop the resubscribe record first. The lookup below early-returns
+        // when the instrument has no active requests, which is always the case
+        // while the farm is down — `handle_disconnect` cleared that list — so
+        // an unsubscribe issued during an outage would otherwise leave the
+        // record standing and the reconnect would re-subscribe an instrument
+        // the caller explicitly cancelled (ibx#288).
+        self.md_resub_info.retain(|(id, ..)| *id != instrument);
         let reqs = match self.instrument_md_reqs.iter()
             .position(|(id, _)| *id == instrument)
         {
@@ -471,7 +478,6 @@ impl FarmState {
             }
             None => return,
         };
-        self.md_resub_info.retain(|(id, ..)| *id != instrument);
 
         let conn = match farm_conn.as_mut() {
             Some(c) => c,
@@ -900,6 +906,24 @@ impl FarmState {
         self.disconnected = true;
     }
 
+    /// The L1 subscriptions to re-issue on a new farm connection, drained from
+    /// the record that survives a disconnect. `handle_disconnect` clears
+    /// `instrument_md_reqs`, so selecting from that list re-subscribes nothing
+    /// and the reconnect silently delivers no market data (ibx#288). Skips
+    /// instruments whose slot was reclaimed while the farm was down.
+    fn take_resub_targets(
+        &mut self,
+        market: &crate::engine::market_state::MarketState,
+    ) -> Vec<(InstrumentId, i64, String, String, String, String, f64, String, String, i32)> {
+        std::mem::take(&mut self.md_resub_info)
+            .into_iter()
+            .filter_map(|(id, sym, exch, st, ltd, strike, right, mult, mode)| {
+                market.con_id(id)
+                    .map(|con_id| (id, con_id, sym, exch, st, ltd, strike, right, mult, mode))
+            })
+            .collect()
+    }
+
     pub(crate) fn reconnect(
         &mut self,
         conn: Connection,
@@ -913,25 +937,17 @@ impl FarmState {
         hb.last_farm_recv = Instant::now();
         hb.pending_farm_test = None;
 
-        // Snapshot active subscriptions and re-issue them on the new connection.
-        let active: Vec<(InstrumentId, i64, String, String, String, String, f64, String, String, i32)> = self.instrument_md_reqs.iter()
-            .filter_map(|(id, _)| {
-                context.market.con_id(*id).map(|con_id| {
-                    let (sym, exch, st, ltd, strike, right, mult, mode) = self.md_resub_info.iter()
-                        .find(|(iid, ..)| *iid == *id)
-                        .map(|(_, s, e, st, l, k, r, m, mode)| (s.clone(), e.clone(), st.clone(), l.clone(), *k, r.clone(), m.clone(), *mode))
-                        .unwrap_or_default();
-                    (*id, con_id, sym, exch, st, ltd, strike, right, mult, mode)
-                })
-            })
-            .collect();
+        // Re-issue the L1 subscriptions from `md_resub_info`, which survives a
+        // disconnect for exactly this purpose — the same shape the depth path
+        // below uses. Driving this off `instrument_md_reqs` re-subscribed
+        // nothing, because `handle_disconnect` clears that list before the
+        // reconnect runs (ibx#288).
+        let active = self.take_resub_targets(&context.market);
         self.md_req_to_instrument.clear();
         self.instrument_md_reqs.clear();
-        let old_resub = std::mem::take(&mut self.md_resub_info);
         for (instrument, con_id, sym, exch, st, ltd, strike, right, mult, mode) in active {
             self.send_mktdata_subscribe(con_id, &sym, &exch, &st, &ltd, strike, &right, &mult, instrument, mode, farm_conn, hb);
         }
-        drop(old_resub);
 
         // Re-subscribe depth subscriptions (depth_resub_info survived disconnect)
         let depth_params: Vec<_> = self.depth_resub_info.drain(..).collect();
@@ -1015,3 +1031,85 @@ impl FarmState {
     }
 }
 
+
+#[cfg(test)]
+mod resub_tests {
+    use super::*;
+    use crate::engine::market_state::MarketState;
+
+    /// A disconnect clears `instrument_md_reqs` and keeps `md_resub_info`.
+    /// Selecting the reconnect's work from the cleared list re-subscribed
+    /// nothing, so the farm came back healthy and delivered no ticks for the
+    /// rest of the session (ibx#288).
+    ///
+    /// Drives the real `handle_disconnect` rather than simulating what it does
+    /// — the test-only hook that skips the clearing is what let this survive,
+    /// and a hand-written stand-in can drift from the real one the same way.
+    #[test]
+    fn resub_targets_survive_a_real_disconnect() {
+        let mut farm = FarmState::new();
+        let mut context = Context::new();
+        let mut hb = HeartbeatState::new();
+        let instrument = context.market.register(756733);
+
+        farm.send_mktdata_subscribe(
+            756733, "SPY", "SMART", "STK", "", 0.0, "", "", instrument, 0,
+            &mut None, &mut hb,
+        );
+        farm.handle_disconnect(&mut context, &None);
+        assert!(farm.instrument_md_reqs.is_empty(), "the disconnect clears the request list");
+
+        let targets = farm.take_resub_targets(&context.market);
+        assert_eq!(targets.len(), 1, "the subscription must survive the disconnect");
+        assert_eq!(targets[0].0, instrument);
+        assert_eq!(targets[0].1, 756733, "con_id must be resolved for the re-issue");
+        assert_eq!(targets[0].2, "SPY");
+
+        // Re-issuing with no connection must still leave the record standing,
+        // so a later reconnect can retry rather than losing the subscription.
+        let (id, con_id, sym, exch, st, ltd, k, r, m, mode) = targets.into_iter().next().unwrap();
+        farm.send_mktdata_subscribe(
+            con_id, &sym, &exch, &st, &ltd, k, &r, &m, id, mode, &mut None, &mut hb,
+        );
+        assert_eq!(farm.md_resub_info.len(), 1, "the record must survive an absent connection");
+    }
+
+    /// An unsubscribe issued while the farm is down must still cancel. The
+    /// lookup it does first early-returns during an outage, so a record left
+    /// standing would be replayed on reconnect as a subscription the caller
+    /// had explicitly cancelled.
+    #[test]
+    fn unsubscribing_while_down_does_not_leave_a_resubscribe_record() {
+        let mut farm = FarmState::new();
+        let mut context = Context::new();
+        let mut hb = HeartbeatState::new();
+        let instrument = context.market.register(756733);
+
+        farm.send_mktdata_subscribe(
+            756733, "SPY", "SMART", "STK", "", 0.0, "", "", instrument, 0,
+            &mut None, &mut hb,
+        );
+        farm.handle_disconnect(&mut context, &None);
+        farm.send_mktdata_unsubscribe(instrument, &mut None, &mut hb);
+
+        assert!(
+            farm.take_resub_targets(&context.market).is_empty(),
+            "a cancelled subscription must not come back on reconnect",
+        );
+    }
+
+    /// A slot reclaimed while the farm was down has no con_id to subscribe.
+    #[test]
+    fn resub_targets_skip_an_instrument_reclaimed_while_down() {
+        let mut farm = FarmState::new();
+        let mut market = MarketState::new();
+        let instrument = market.register(756733);
+        farm.md_resub_info.push((
+            instrument, "SPY".into(), "SMART".into(), "STK".into(), String::new(),
+            0.0, String::new(), String::new(), 0,
+        ));
+        market.unregister(instrument);
+
+        assert!(farm.take_resub_targets(&market).is_empty());
+    }
+}

--- a/src/engine/hot_loop/farm.rs
+++ b/src/engine/hot_loop/farm.rs
@@ -33,15 +33,22 @@ pub(crate) struct FarmState {
 
 impl FarmState {
     /// Whether this instrument still has market-data state that would be
-    /// repointed by a slot reuse: a live subscription, a request id waiting on
-    /// its ack, or a record kept for the next reconnect.
+    /// repointed by a slot reuse: a live subscription, or a record kept for the
+    /// next reconnect.
     ///
     /// The resubscribe record is the reason this matters. Before it existed a
     /// reclaimed slot replayed nothing; now it replays the old contract's
     /// descriptor against whatever contract holds the id at reconnect (ibx#288).
+    ///
+    /// `md_req_to_instrument` is deliberately not consulted. A subscribe fills
+    /// it and `instrument_md_reqs` together, so it says nothing the first check
+    /// does not already cover — and an entry left there after an unsubscribe is
+    /// a defect in its own right (ibx#289), not a reason to pin the slot. Held
+    /// on that basis, a subscribe/unsubscribe cycle would consume a slot
+    /// permanently and the instrument cap would become cumulative per session,
+    /// which is the failure ibx#233 exists to prevent.
     pub(crate) fn holds_market_data(&self, instrument: InstrumentId) -> bool {
         self.instrument_md_reqs.iter().any(|(id, _)| *id == instrument)
-            || self.md_req_to_instrument.iter().any(|(_, id)| *id == instrument)
             || self.md_resub_info.iter().any(|r| r.0 == instrument)
     }
 
@@ -1111,6 +1118,40 @@ mod resub_tests {
         );
     }
 
+    /// The other side of keeping a slot resident: it has to become releasable
+    /// again, or the guard turns a bounded pool into a leak and the instrument
+    /// cap becomes cumulative-per-session — the failure ibx#233 exists to
+    /// prevent. Every route out of a subscription has to clear all three
+    /// references, whether the farm is up or down.
+    #[test]
+    fn a_slot_becomes_reclaimable_again_once_the_subscription_ends() {
+        for down in [false, true] {
+            let mut farm = FarmState::new();
+            let mut context = Context::new();
+            let mut hb = HeartbeatState::new();
+            let instrument = context.market.register(756733);
+
+            farm.send_mktdata_subscribe(
+                756733, "SPY", "SMART", "STK", "", 0.0, "", "", instrument, 0,
+                &mut None, &mut hb,
+            );
+            assert!(farm.holds_market_data(instrument), "subscribed: held");
+
+            if down {
+                farm.handle_disconnect(&mut context, &None);
+                // The record deliberately survives a disconnect, so the slot
+                // stays held — that is what makes the resubscribe possible.
+                assert!(farm.holds_market_data(instrument), "disconnected: still held");
+            }
+
+            farm.send_mktdata_unsubscribe(instrument, &mut None, &mut hb);
+            assert!(
+                !farm.holds_market_data(instrument),
+                "unsubscribed (farm down: {down}): the slot must be releasable",
+            );
+        }
+    }
+
     /// A slot reclaimed while the farm was down has no con_id to subscribe.
     #[test]
     fn resub_targets_skip_an_instrument_reclaimed_while_down() {
@@ -1147,14 +1188,10 @@ mod resub_tests {
             "the record alone must keep the slot resident",
         );
 
-        // And each of the other two references does the same on its own.
+        // And a live subscription does the same on its own.
         let mut farm = FarmState::new();
         farm.instrument_md_reqs.push((instrument, vec![7]));
         assert!(farm.holds_market_data(instrument), "a live subscription");
-
-        let mut farm = FarmState::new();
-        farm.md_req_to_instrument.push((7, instrument));
-        assert!(farm.holds_market_data(instrument), "a request awaiting its ack");
 
         // An instrument with none of the three is free to go.
         assert!(!FarmState::new().holds_market_data(instrument));

--- a/src/engine/hot_loop/mod.rs
+++ b/src/engine/hot_loop/mod.rs
@@ -252,11 +252,19 @@ impl HotLoop {
     }
 
     /// Reclaim an instrument slot if nothing references it any more
-    /// (ibx#233): no open orders, no tick-by-tick subscription, no news
-    /// subscription. A reused id would repoint those references at the
-    /// wrong contract, so referenced slots stay resident until released.
+    /// (ibx#233): no open orders, no market data, no tick-by-tick
+    /// subscription, no news subscription. A reused id would repoint those
+    /// references at the wrong contract, so referenced slots stay resident
+    /// until released.
     fn try_reclaim_instrument(&mut self, instrument: InstrumentId) {
         if !self.context.open_orders_for(instrument).is_empty() {
+            return;
+        }
+        // Market data was missing from this list. Cancelling tick-by-tick or
+        // news on an instrument that also holds an L1 subscription freed the
+        // slot underneath it, and the resubscribe record then replayed the old
+        // contract's descriptor against the id's new occupant (ibx#288).
+        if self.farm.holds_market_data(instrument) {
             return;
         }
         if self.hmds.tbt_subscriptions.iter().any(|(id, _, _)| *id == instrument) {


### PR DESCRIPTION
## Summary

- `handle_disconnect` clears `instrument_md_reqs`, and `reconnect` selected the subscriptions to re-issue by iterating that same list. By then it is empty, so a farm reconnect re-subscribed nothing: no `35=Q` went out, no acks came back, no server tags were assigned, and no ticks arrived for the rest of the session.
- The failure is silent. The reconnect reports success, `is_connected()` stays true, and the callbacks simply stop. Depth keeps working, which makes it look like a data problem rather than a client one.
- The record needed to rebuild the subscriptions already survived. `md_resub_info` is written on subscribe and pruned on unsubscribe, exactly as `depth_resub_info` is — and the depth path a few lines below already re-subscribes by draining its own record. The L1 path read `md_resub_info` only to decorate entries the empty list never produced, then dropped it unused.
- Selection now drains `md_resub_info` the same way, skipping any instrument whose slot was reclaimed while the farm was down. It is a named method so it is reachable without a live `Connection`; the previous shape was only reachable through `reconnect`, which is a large part of why this survived.
- The unsubscribe prune is hoisted above the lookup that preceded it. That lookup early-returns when an instrument has no active requests, which is always true while the farm is down — so an unsubscribe issued during an outage left the record standing, and now that reconnect replays the record it would come back as a subscription the caller had explicitly cancelled, or re-subscribe whatever contract had since taken the slot using the cancelled one's parameters.

Closes #288.
Closes #291.

## Test plan

- [x] `cargo test --lib` — 805 pass. The two `config::expiry_tests` failures are pre-existing on main.
- [x] The tests drive the real `handle_disconnect` rather than `handle_disconnect_for_test`. That hook sets the disconnected flag without clearing anything, so the existing reconnect test re-subscribed from a list the production path would have emptied — nothing exercised the real disconnect, which is why this was invisible. The real one needs only state, no socket.
- [x] Selecting from the cleared list again fails the first test at 0 targets against 1, reproducing the defect.
- [x] Putting the prune back below the early return fails the unsubscribe-while-down test.
- [x] Dropping the `con_id` filter fails the reclaimed-slot test.
- [x] Re-issuing with no connection still leaves the record standing, so a later reconnect can retry rather than losing the subscription.
- [ ] Not covered: `reconnect()` itself, its clear ordering, and the exact wire fan-out. Replacing the production selection with an empty vector still passes these tests, because they exercise the selection helper rather than the caller. Closing that needs a listener socket and decoding the emitted `35=V`, which is integration scaffolding this PR does not add.

## Note

This does not restore live market data on its own. A reconnect will now re-subscribe correctly, but the resulting acks carry the high server tags that ibx#281 drops — both are needed for ticks to actually flow after a farm drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
