### PR TITLE
ccp: treat a missing position-feed quantity as no quantity, not as flat (ibx#296)

### DIFF
--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -983,6 +983,7 @@ impl ClientCore {
         let mut total_unrealized: f64 = 0.0;
         let mut total_realized: f64 = 0.0;
         let mut priced = 0usize;
+        let mut unpriceable = 0usize;
 
         for con_id in con_ids {
             let seed = seeds.get(&con_id);
@@ -993,10 +994,12 @@ impl ClientCore {
             total_realized += seed.map(|s| s.realized_pnl).unwrap_or(0.0);
 
             // A position we held at midnight and cannot currently size is not
-            // a flat one. Pricing the absence as zero reports the whole
-            // overnight holding as sold; skipping leaves the gateway's own
-            // account-level figure to stand (ibx#296).
+            // a flat one: pricing the absence as zero reports the whole
+            // overnight holding as sold. It is counted as unpriceable rather
+            // than merely skipped, because a total missing one position is not
+            // a smaller correct answer (ibx#296).
             if seed.is_some() && pi.is_none() {
+                unpriceable += 1;
                 continue;
             }
             let qty_now = pi.as_ref().map(|p| p.position).unwrap_or(0);
@@ -1005,6 +1008,7 @@ impl ClientCore {
             // parse says the position is not intraday, only that its size is
             // unknown, so there is nothing to price it against.
             let Some(qty_midnight) = seed.map_or(Some(0), |s| s.qty_midnight) else {
+                unpriceable += 1;
                 continue;
             };
 
@@ -1046,7 +1050,13 @@ impl ClientCore {
         // to the gateway's account-level P&L, which the gateway pushes independently
         // of any market-data subscription. Without this the quote-derived totals stay
         // [0,0,0] and no callback ever fires (ibx#239).
-        if priced == 0 {
+        // A position that could not be priced makes the client-side sum an
+        // incomplete account total, not a smaller correct one — and the realized
+        // figure has already accrued for it, so the three would not even agree
+        // with each other. The gateway's own account-level numbers are complete
+        // by construction, so one unpriceable position sends the whole account
+        // to them rather than reporting a partial sum as if it were the total.
+        if priced == 0 || unpriceable > 0 {
             let acct = shared.portfolio.account();
             total_daily = acct.daily_pnl as f64 / PRICE_SCALE_F;
             total_unrealized = acct.unrealized_pnl as f64 / PRICE_SCALE_F;
@@ -1102,12 +1112,14 @@ impl ClientCore {
 
             let seed = seeds.get(&con_id);
             // An unparseable overnight quantity leaves nothing to price the
-            // day's change against — see the whole-account path (ibx#296).
-            let Some(qty_midnight) = seed.map_or(Some(0), |s| s.qty_midnight) else {
-                continue;
-            };
+            // day's change against. Unlike the whole-account total, that costs
+            // this callback only its daily figure: the position, its value, the
+            // unrealized and the realized are all still known, and suppressing
+            // the callback would leave every one of them stale on the caller's
+            // side rather than reporting one it cannot compute (ibx#296).
+            let qty_midnight = seed.map_or(Some(0), |s| s.qty_midnight);
             let prev_close = q.close;
-            if prev_close == 0 && qty_midnight != 0 {
+            if prev_close == 0 && qty_midnight.unwrap_or(0) != 0 {
                 continue;
             }
 
@@ -1120,8 +1132,19 @@ impl ClientCore {
             };
 
             let mv_now = qty_now as f64 * price_now as f64 / PRICE_SCALE_F;
-            let mv_midnight = qty_midnight as f64 * prev_close as f64 / PRICE_SCALE_F;
-            let daily = mv_now - mv_midnight + money_traded;
+            // Held at the value last reported when the overnight size is
+            // unknown, rather than recomputed from an assumption that would be
+            // wrong in a specific direction: treating the absence as flat
+            // reports the whole holding as sold, and treating it as no seed at
+            // all reports the day's move as the position's entire unrealized.
+            let daily = match qty_midnight {
+                Some(qty_midnight) => {
+                    let mv_midnight = qty_midnight as f64 * prev_close as f64 / PRICE_SCALE_F;
+                    mv_now - mv_midnight + money_traded
+                }
+                None => last_cache.get(&req_id)
+                    .map_or(0.0, |prev| prev[1] as f64 / PRICE_SCALE_F),
+            };
             let unrealized = if avg_cost != 0 {
                 qty_now as f64 * (price_now - avg_cost) as f64 / PRICE_SCALE_F
             } else { 0.0 };
@@ -1729,6 +1752,74 @@ mod tests {
         let core = ClientCore::new();
         let shared = SharedState::new();
         assert!(core.poll_pnl(&shared).is_none());
+    }
+
+    /// A total missing one position is not a smaller correct total. When a
+    /// position cannot be priced the client-side sum is incomplete — and the
+    /// realized figure has already accrued for it, so the three do not even
+    /// agree with each other. The gateway's own account numbers are complete by
+    /// construction, so one unpriceable position sends the whole account there.
+    #[test]
+    fn one_unpriceable_position_sends_the_whole_account_to_the_gateway() {
+        let core = ClientCore::new();
+        let shared = SharedState::new();
+        core.subscribe_pnl(11);
+
+        // One ordinary position that prices fine.
+        seed_pnl_position(&core, &shared, 1, 0, 1, 100.00, 101.00, 100.00);
+
+        // And one held overnight that this session cannot size.
+        core.con_id_to_instrument.lock().unwrap().insert(2, 1);
+        core.instrument_to_req.lock().unwrap().insert(1, 1);
+        let mut q = Quote::default();
+        q.last = (735.00 * PRICE_SCALE_F) as i64;
+        q.close = (730.00 * PRICE_SCALE_F) as i64;
+        shared.market.push_quote(1, &q);
+        shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
+            con_id: 2, qty_midnight: Some(10), money_traded: 0.0, realized_pnl: 0.0,
+        }]);
+        shared.portfolio.set_account(&AccountState {
+            daily_pnl: (51.0 * PRICE_SCALE_F) as i64,
+            unrealized_pnl: (351.0 * PRICE_SCALE_F) as i64,
+            ..Default::default()
+        });
+
+        let update = core.poll_pnl(&shared).expect("callback must fire");
+        assert!(
+            (update.daily_pnl - 51.0).abs() < 1e-6,
+            "the gateway's complete figure, not the one priceable position: daily={}",
+            update.daily_pnl,
+        );
+    }
+
+    /// `pnlSingle` loses only its daily figure when the overnight size is
+    /// unknown. The position, its value, the unrealized and the realized are all
+    /// still known, and suppressing the callback would leave every one of them
+    /// stale on the caller's side.
+    #[test]
+    fn an_unknown_seed_does_not_suppress_the_rest_of_a_single_callback() {
+        let core = ClientCore::new();
+        let shared = SharedState::new();
+        core.subscribe_pnl_single(21, 756733);
+
+        seed_pnl_position(&core, &shared, 756733, 0, 10, 700.00, 735.00, 730.00);
+        shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
+            con_id: 756733, qty_midnight: None, money_traded: 0.0, realized_pnl: 0.0,
+        }]);
+
+        let first = core.poll_pnl_single(&shared);
+        assert!(!first.is_empty(), "the known fields must still be reported");
+        assert!((first[0].pos - 10.0).abs() < 1e-6, "position");
+        assert!((first[0].unrealized_pnl - 350.0).abs() < 1e-6, "unrealized");
+
+        // And a later change to a field that IS known still produces an update.
+        let mut q = Quote::default();
+        q.last = (736.00 * PRICE_SCALE_F) as i64;
+        q.close = (730.00 * PRICE_SCALE_F) as i64;
+        shared.market.push_quote(0, &q);
+        let second = core.poll_pnl_single(&shared);
+        assert!(!second.is_empty(), "a moved quote must still reach the caller");
+        assert!((second[0].unrealized_pnl - 360.0).abs() < 1e-6, "unrealized moved");
     }
 
     /// ibx#296, consumer side. Dropping an unusable position row stops the feed

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -987,11 +987,26 @@ impl ClientCore {
         for con_id in con_ids {
             let seed = seeds.get(&con_id);
             let pi = shared.portfolio.position_info(con_id);
+
+            // Realized P&L is stated outright by the row and does not depend on
+            // knowing either quantity, so it accrues before the guards below.
+            total_realized += seed.map(|s| s.realized_pnl).unwrap_or(0.0);
+
+            // A position we held at midnight and cannot currently size is not
+            // a flat one. Pricing the absence as zero reports the whole
+            // overnight holding as sold; skipping leaves the gateway's own
+            // account-level figure to stand (ibx#296).
+            if seed.is_some() && pi.is_none() {
+                continue;
+            }
             let qty_now = pi.as_ref().map(|p| p.position).unwrap_or(0);
             let avg_cost = pi.as_ref().map(|p| p.avg_cost).unwrap_or(0);
-            let qty_midnight = seed.map(|s| s.qty_midnight).unwrap_or(0);
-
-            total_realized += seed.map(|s| s.realized_pnl).unwrap_or(0.0);
+            // Likewise for the overnight leg: a seed row whose quantity did not
+            // parse says the position is not intraday, only that its size is
+            // unknown, so there is nothing to price it against.
+            let Some(qty_midnight) = seed.map_or(Some(0), |s| s.qty_midnight) else {
+                continue;
+            };
 
             let Some(&iid) = con_id_map.get(&con_id) else { continue; };
             let q = shared.market.quote(iid);
@@ -1086,7 +1101,11 @@ impl ClientCore {
             }
 
             let seed = seeds.get(&con_id);
-            let qty_midnight = seed.map(|s| s.qty_midnight).unwrap_or(0);
+            // An unparseable overnight quantity leaves nothing to price the
+            // day's change against — see the whole-account path (ibx#296).
+            let Some(qty_midnight) = seed.map_or(Some(0), |s| s.qty_midnight) else {
+                continue;
+            };
             let prev_close = q.close;
             if prev_close == 0 && qty_midnight != 0 {
                 continue;
@@ -1712,6 +1731,76 @@ mod tests {
         assert!(core.poll_pnl(&shared).is_none());
     }
 
+    /// ibx#296, consumer side. Dropping an unusable position row stops the feed
+    /// publishing a flat, but P&L reads the absence back as zero shares and
+    /// reports the whole overnight holding as sold. Held 10 at a $730 close,
+    /// now $735: the honest answer is 50, the flat reading is -7300, and with
+    /// nothing priceable the gateway's own account figure stands instead.
+    #[test]
+    fn an_unsizeable_overnight_position_is_not_priced_as_sold() {
+        let core = ClientCore::new();
+        let shared = SharedState::new();
+        core.subscribe_pnl(7);
+
+        // A quote and a seed, but no position row — the feed dropped it.
+        core.con_id_to_instrument.lock().unwrap().insert(756733, 0);
+        core.instrument_to_req.lock().unwrap().insert(0, 1);
+        let mut q = Quote::default();
+        q.last = (735.00 * PRICE_SCALE_F) as i64;
+        q.close = (730.00 * PRICE_SCALE_F) as i64;
+        shared.market.push_quote(0, &q);
+        shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
+            con_id: 756733,
+            qty_midnight: Some(10),
+            money_traded: 0.0,
+            realized_pnl: 0.0,
+        }]);
+        shared.portfolio.set_account(&AccountState {
+            daily_pnl: (50.0 * PRICE_SCALE_F) as i64,
+            unrealized_pnl: (350.0 * PRICE_SCALE_F) as i64,
+            ..Default::default()
+        });
+
+        let update = core.poll_pnl(&shared).expect("callback must fire");
+        assert!(
+            (update.daily_pnl - 50.0).abs() < 1e-6,
+            "the gateway's own figure stands; -7300 is the flat reading: daily={}",
+            update.daily_pnl,
+        );
+    }
+
+    /// The same absence on the overnight leg. A seed row that stated no
+    /// quantity means the position's midnight size is unknown — not that it was
+    /// opened today, which is what a missing row means. Held 10 from $700, a
+    /// $730 close and $735 now: the intraday reading synthesizes cash from
+    /// average cost and reports 350, the unrealized figure, as the day's move.
+    #[test]
+    fn a_seed_without_a_quantity_is_not_read_as_opened_today() {
+        let core = ClientCore::new();
+        let shared = SharedState::new();
+        core.subscribe_pnl(8);
+
+        seed_pnl_position(&core, &shared, 756733, 0, 10, 700.00, 735.00, 730.00);
+        shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
+            con_id: 756733,
+            qty_midnight: None,
+            money_traded: 0.0,
+            realized_pnl: 0.0,
+        }]);
+        shared.portfolio.set_account(&AccountState {
+            daily_pnl: (50.0 * PRICE_SCALE_F) as i64,
+            unrealized_pnl: (350.0 * PRICE_SCALE_F) as i64,
+            ..Default::default()
+        });
+
+        let update = core.poll_pnl(&shared).expect("callback must fire");
+        assert!(
+            (update.daily_pnl - 50.0).abs() < 1e-6,
+            "350 is the intraday synthesis, not the day's move: daily={}",
+            update.daily_pnl,
+        );
+    }
+
     #[test]
     fn poll_pnl_intraday_opened_position_fires_callback() {
         // #166: flat-at-midnight account opens an intraday position.
@@ -1742,7 +1831,7 @@ mod tests {
         seed_pnl_position(&core, &shared, 756733, 0, 10, 700.00, 735.00, 730.00);
         shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
             con_id: 756733,
-            qty_midnight: 10,
+            qty_midnight: Some(10),
             money_traded: 0.0,
             realized_pnl: 0.0,
         }]);
@@ -1768,7 +1857,7 @@ mod tests {
         seed_pnl_position(&core, &shared, 1, 0, 7, 100.00, 110.00, 100.00);
         shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
             con_id: 1,
-            qty_midnight: 10,
+            qty_midnight: Some(10),
             money_traded: 330.0,   // +330 = sold 3 @ $110 (wire sign, SELL positive)
             realized_pnl: 30.0,
         }]);
@@ -1905,7 +1994,7 @@ mod tests {
         seed_pnl_position(&core, &shared, 756733, 0, 10, 700.00, 735.00, 730.00);
         shared.portfolio.set_midnight_seeds(vec![MidnightSeed {
             con_id: 756733,
-            qty_midnight: 10,
+            qty_midnight: Some(10),
             money_traded: 0.0,
             realized_pnl: 12.34,
         }]);

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -1752,9 +1752,7 @@ fn handle_pnl_response(msg: &[u8], shared: &SharedState) {
     for part in text.split('\x01') {
         if let Some(v) = part.strip_prefix("6008=") {
             if count > 0 && con_id != 0 {
-                if let Some(qty_midnight) = qty_midnight {
-                    seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
-                }
+                seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
             }
             con_id = v.parse().unwrap_or(0);
             qty_midnight = None;
@@ -1764,7 +1762,10 @@ fn handle_pnl_response(msg: &[u8], shared: &SharedState) {
         } else if let Some(v) = part.strip_prefix("6064=") {
             // Same rule as the position feed above: a quantity that is absent
             // or unparseable is not a flat. Reading it as zero here makes the
-            // day's P&L look as though the position were opened intraday.
+            // day's P&L look as though the position were opened intraday. The
+            // row is still kept — dropping it says the same thing, because a
+            // position with no seed row *is* the intraday case, and it would
+            // discard the cash and realized figures the row does carry.
             qty_midnight = v.parse::<f64>().ok().filter(|q| q.is_finite()).map(|q| q as i64);
         } else if let Some(v) = part.strip_prefix("6822=") {
             // moneyTradedSinceMidnight: signed net cash, SELL positive / BUY
@@ -1775,9 +1776,7 @@ fn handle_pnl_response(msg: &[u8], shared: &SharedState) {
         }
     }
     if count > 0 && con_id != 0 {
-        if let Some(qty_midnight) = qty_midnight {
-            seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
-        }
+        seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
     }
     shared.portfolio.set_midnight_seeds(seeds);
 }
@@ -2098,20 +2097,32 @@ mod tests {
     /// The midnight seed carries the same quantity tag and had the same
     /// defect: reading an absent one as zero makes the day's P&L look as
     /// though the position were opened intraday, when it was held overnight.
+    ///
+    /// The row is kept with an unknown quantity rather than dropped, because
+    /// dropping it says the same wrong thing — a position with no seed row *is*
+    /// the intraday case — and would discard the cash and realized figures the
+    /// row does state.
     #[test]
     fn a_midnight_seed_without_a_quantity_is_not_seeded_flat() {
         let shared = SharedState::new();
         // Two entries: one stating its quantity, one omitting it.
         let body = [
-            "6008=756733", "6064=100", "6822=-50.0", "6099=0.0",
-            "6008=265598", "6822=-10.0", "6099=0.0",
+            "6008=756733", "6064=100", "6822=-50.0", "6099=7.5",
+            "6008=265598", "6822=-10.0", "6099=2.5",
         ].join("\x01");
         handle_pnl_response(body.as_bytes(), &shared);
 
-        let seeds = shared.portfolio.midnight_seeds();
-        assert_eq!(seeds.len(), 1, "only the entry that stated a quantity is seeded");
-        assert_eq!(seeds[0].con_id, 756733);
-        assert_eq!(seeds[0].qty_midnight, 100);
+        let mut seeds = shared.portfolio.midnight_seeds();
+        seeds.sort_by_key(|s| s.con_id);
+        assert_eq!(seeds.len(), 2, "both entries are seeded");
+
+        let stated = seeds.iter().find(|s| s.con_id == 756733).expect("stated entry");
+        assert_eq!(stated.qty_midnight, Some(100));
+
+        let silent = seeds.iter().find(|s| s.con_id == 265598).expect("silent entry");
+        assert_eq!(silent.qty_midnight, None, "absent is unknown, not flat");
+        assert_eq!(silent.money_traded, -10.0, "the figures it did state survive");
+        assert_eq!(silent.realized_pnl, 2.5);
     }
 
     /// ibx#296: the 75 feed defaulted its running quantity to zero, so an entry
@@ -2126,11 +2137,17 @@ mod tests {
             "6008=265598\x016064=abc\x016101=151.0\x01",
             // parses, but is not a quantity
             "6008=265598\x016064=NaN\x016101=151.0\x01",
+            // the same entry flushed by the next conId rather than by the end
+            // of the message — a repeating group publishes at both boundaries.
+            "6008=265598\x016101=151.0\x016008=756733\x016064=5\x01",
+            "6008=265598\x016064=abc\x016101=151.0\x016008=756733\x016064=5\x01",
         ] {
             let mut ccp = CcpState::new();
             let mut context = Context::new();
             let shared = SharedState::new();
             let mut hb = HeartbeatState::new();
+            let (tx, rx) = crossbeam_channel::unbounded();
+            let event_tx = Some(tx);
             let instrument = context.market.register(265598);
             shared.portfolio.set_position_info(PositionInfo {
                 con_id: 265598, position: 100, avg_cost: 0, ..Default::default()
@@ -2138,13 +2155,54 @@ mod tests {
             shared.portfolio.set_position(instrument, 100);
 
             ccp.handle_position_feed(
-                body.as_bytes(), &mut None, &mut context, &shared, &None, &mut hb);
+                body.as_bytes(), &mut None, &mut context, &shared, &event_tx, &mut hb);
 
+            // All three stores move together, so all three are asserted: the
+            // row callers read, the atomic the engine reads, and the event.
             assert_eq!(
                 shared.portfolio.position_info(265598).map(|p| p.position), Some(100),
-                "{:?} must not flatten a live position", body,
+                "{:?} must not flatten the position row", body,
             );
+            assert_eq!(
+                shared.portfolio.position(instrument), 100,
+                "{:?} must not flatten the shared position", body,
+            );
+            let flattened = rx.try_iter().any(|e| matches!(
+                e, Event::PositionUpdate { con_id: 265598, position: 0, .. }));
+            assert!(!flattened, "{:?} must not publish a flat", body);
         }
+    }
+
+    /// The positive control for the test above: an entry that does state a
+    /// quantity has to reach all three stores, and at the flush triggered by
+    /// the next conId rather than only at the end of the message. Without this
+    /// the absence assertions pass just as well against a feed that publishes
+    /// nothing at all.
+    #[test]
+    fn a_position_feed_entry_with_a_quantity_publishes_it_everywhere() {
+        let mut ccp = CcpState::new();
+        let mut context = Context::new();
+        let shared = SharedState::new();
+        let mut hb = HeartbeatState::new();
+        let (tx, rx) = crossbeam_channel::unbounded();
+        let event_tx = Some(tx);
+        let instrument = context.market.register(265598);
+
+        // Two entries, so the first is flushed by the second's conId.
+        let body = "6008=265598\x016064=42\x016101=151.0\x016008=756733\x016064=5\x01";
+        ccp.handle_position_feed(
+            body.as_bytes(), &mut None, &mut context, &shared, &event_tx, &mut hb);
+
+        assert_eq!(
+            shared.portfolio.position_info(265598).map(|p| p.position), Some(42),
+            "the position row",
+        );
+        assert_eq!(shared.portfolio.position(instrument), 42, "the shared position");
+        assert!(
+            rx.try_iter().any(|e| matches!(
+                e, Event::PositionUpdate { con_id: 265598, position: 42, .. })),
+            "the published event",
+        );
     }
 
     /// An explicit zero is a genuine flat and must still be published.

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -1745,22 +1745,27 @@ fn handle_pnl_response(msg: &[u8], shared: &SharedState) {
     };
     let mut seeds = Vec::new();
     let mut con_id: i64 = 0;
-    let mut qty_midnight: i64 = 0;
+    let mut qty_midnight: Option<i64> = None;
     let mut money_traded: f64 = 0.0;
     let mut realized_pnl: f64 = 0.0;
     let mut count = 0;
     for part in text.split('\x01') {
         if let Some(v) = part.strip_prefix("6008=") {
             if count > 0 && con_id != 0 {
-                seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
+                if let Some(qty_midnight) = qty_midnight {
+                    seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
+                }
             }
             con_id = v.parse().unwrap_or(0);
-            qty_midnight = 0;
+            qty_midnight = None;
             money_traded = 0.0;
             realized_pnl = 0.0;
             count += 1;
         } else if let Some(v) = part.strip_prefix("6064=") {
-            qty_midnight = v.parse::<f64>().unwrap_or(0.0) as i64;
+            // Same rule as the position feed above: a quantity that is absent
+            // or unparseable is not a flat. Reading it as zero here makes the
+            // day's P&L look as though the position were opened intraday.
+            qty_midnight = v.parse::<f64>().ok().filter(|q| q.is_finite()).map(|q| q as i64);
         } else if let Some(v) = part.strip_prefix("6822=") {
             // moneyTradedSinceMidnight: signed net cash, SELL positive / BUY
             // negative. Stored with the wire sign; poll_pnl adds it (ib-agent#163).
@@ -1770,7 +1775,9 @@ fn handle_pnl_response(msg: &[u8], shared: &SharedState) {
         }
     }
     if count > 0 && con_id != 0 {
-        seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
+        if let Some(qty_midnight) = qty_midnight {
+            seeds.push(MidnightSeed { con_id, qty_midnight, money_traded, realized_pnl });
+        }
     }
     shared.portfolio.set_midnight_seeds(seeds);
 }
@@ -1796,42 +1803,53 @@ impl CcpState {
     };
     // Parse repeating group by scanning for 6008= boundaries
     let mut con_id: i64 = 0;
-    let mut qty: i64 = 0;
+    // `None` until this entry carries a parseable, finite quantity. A zero
+    // default meant an entry without one flattened a live position, published
+    // it to reqPositions and both P&L paths, and emitted a PositionUpdate
+    // saying flat — the same defect ibx#261 fixed on the account-update path
+    // (ibx#296). A genuine flat still arrives as an explicit `6064=0`.
+    let mut qty: Option<i64> = None;
     let mut avg_cost_raw: f64 = 0.0;
     let mut count = 0;
     for part in text.split('\x01') {
         if let Some(v) = part.strip_prefix("6008=") {
             // Flush previous position if any
             if count > 0 && con_id != 0 {
-                let avg_cost = (avg_cost_raw * PRICE_SCALE as f64) as Price;
-                shared.portfolio.set_position_info(PositionInfo {
-                    con_id, position: qty, avg_cost, ..Default::default()
-                });
-                if let Some(instrument) = context.market.instrument_by_con_id(con_id) {
-                    shared.portfolio.set_position(instrument, qty);
-                    emit(event_tx, Event::PositionUpdate { instrument, con_id, position: qty, avg_cost });
+                if let Some(qty) = qty {
+                    let avg_cost = (avg_cost_raw * PRICE_SCALE as f64) as Price;
+                    shared.portfolio.set_position_info(PositionInfo {
+                        con_id, position: qty, avg_cost, ..Default::default()
+                    });
+                    if let Some(instrument) = context.market.instrument_by_con_id(con_id) {
+                        shared.portfolio.set_position(instrument, qty);
+                        emit(event_tx, Event::PositionUpdate { instrument, con_id, position: qty, avg_cost });
+                    }
                 }
                 self.auto_fetch_secdef_if_cold(con_id, ccp_conn, shared, hb);
             }
             con_id = v.parse().unwrap_or(0);
-            qty = 0;
+            qty = None;
             avg_cost_raw = 0.0;
             count += 1;
         } else if let Some(v) = part.strip_prefix("6064=") {
-            qty = v.parse::<f64>().unwrap_or(0.0) as i64;
+            // Filtered to finite: `"NaN".parse()` succeeds and `NaN as i64`
+            // is 0, which would flatten by the same route.
+            qty = v.parse::<f64>().ok().filter(|f| f.is_finite()).map(|f| f as i64);
         } else if let Some(v) = part.strip_prefix("6101=") {
             avg_cost_raw = v.parse().unwrap_or(0.0);
         }
     }
     // Flush last position
     if count > 0 && con_id != 0 {
-        let avg_cost = (avg_cost_raw * PRICE_SCALE as f64) as Price;
-        shared.portfolio.set_position_info(PositionInfo {
-            con_id, position: qty, avg_cost, ..Default::default()
-        });
-        if let Some(instrument) = context.market.instrument_by_con_id(con_id) {
-            shared.portfolio.set_position(instrument, qty);
-            emit(event_tx, Event::PositionUpdate { instrument, con_id, position: qty, avg_cost });
+        if let Some(qty) = qty {
+            let avg_cost = (avg_cost_raw * PRICE_SCALE as f64) as Price;
+            shared.portfolio.set_position_info(PositionInfo {
+                con_id, position: qty, avg_cost, ..Default::default()
+            });
+            if let Some(instrument) = context.market.instrument_by_con_id(con_id) {
+                shared.portfolio.set_position(instrument, qty);
+                emit(event_tx, Event::PositionUpdate { instrument, con_id, position: qty, avg_cost });
+            }
         }
         self.auto_fetch_secdef_if_cold(con_id, ccp_conn, shared, hb);
     }
@@ -2075,6 +2093,81 @@ mod tests {
             stop_price: 0,
         });
         (CcpState::new(), context, SharedState::new())
+    }
+
+    /// The midnight seed carries the same quantity tag and had the same
+    /// defect: reading an absent one as zero makes the day's P&L look as
+    /// though the position were opened intraday, when it was held overnight.
+    #[test]
+    fn a_midnight_seed_without_a_quantity_is_not_seeded_flat() {
+        let shared = SharedState::new();
+        // Two entries: one stating its quantity, one omitting it.
+        let body = [
+            "6008=756733", "6064=100", "6822=-50.0", "6099=0.0",
+            "6008=265598", "6822=-10.0", "6099=0.0",
+        ].join("\x01");
+        handle_pnl_response(body.as_bytes(), &shared);
+
+        let seeds = shared.portfolio.midnight_seeds();
+        assert_eq!(seeds.len(), 1, "only the entry that stated a quantity is seeded");
+        assert_eq!(seeds[0].con_id, 756733);
+        assert_eq!(seeds[0].qty_midnight, 100);
+    }
+
+    /// ibx#296: the 75 feed defaulted its running quantity to zero, so an entry
+    /// carrying a conId but no parseable 6064 flattened a live position and
+    /// published it — the same defect ibx#261 fixed on the account-update path.
+    #[test]
+    fn a_position_feed_entry_without_a_quantity_leaves_the_position_alone() {
+        for body in [
+            // no 6064 at all
+            "6008=265598\x016101=151.0\x01",
+            // present but not a number
+            "6008=265598\x016064=abc\x016101=151.0\x01",
+            // parses, but is not a quantity
+            "6008=265598\x016064=NaN\x016101=151.0\x01",
+        ] {
+            let mut ccp = CcpState::new();
+            let mut context = Context::new();
+            let shared = SharedState::new();
+            let mut hb = HeartbeatState::new();
+            let instrument = context.market.register(265598);
+            shared.portfolio.set_position_info(PositionInfo {
+                con_id: 265598, position: 100, avg_cost: 0, ..Default::default()
+            });
+            shared.portfolio.set_position(instrument, 100);
+
+            ccp.handle_position_feed(
+                body.as_bytes(), &mut None, &mut context, &shared, &None, &mut hb);
+
+            assert_eq!(
+                shared.portfolio.position_info(265598).map(|p| p.position), Some(100),
+                "{:?} must not flatten a live position", body,
+            );
+        }
+    }
+
+    /// An explicit zero is a genuine flat and must still be published.
+    #[test]
+    fn a_position_feed_entry_with_an_explicit_zero_still_flattens() {
+        let mut ccp = CcpState::new();
+        let mut context = Context::new();
+        let shared = SharedState::new();
+        let mut hb = HeartbeatState::new();
+        let instrument = context.market.register(265598);
+        shared.portfolio.set_position_info(PositionInfo {
+            con_id: 265598, position: 100, avg_cost: 0, ..Default::default()
+        });
+        shared.portfolio.set_position(instrument, 100);
+
+        ccp.handle_position_feed(
+            b"6008=265598\x016064=0\x016101=151.0\x01",
+            &mut None, &mut context, &shared, &None, &mut hb);
+
+        assert_eq!(
+            shared.portfolio.position_info(265598).map(|p| p.position), Some(0),
+            "an explicit zero is a genuine flat",
+        );
     }
 
     // ibx#205: a margin-reducing preview (close, cash-account sell) resolves to a

--- a/src/types.rs
+++ b/src/types.rs
@@ -1491,7 +1491,10 @@ pub struct PositionInfo {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MidnightSeed {
     pub con_id: i64,
-    pub qty_midnight: i64,            // position held at midnight
+    /// Position held at midnight. `None` when the row arrived without a
+    /// parseable quantity: the position exists but its overnight size is
+    /// unknown, which is not the same as having opened it today (ibx#296).
+    pub qty_midnight: Option<i64>,
     pub money_traded: f64,            // net cash from today's fills (signed)
     pub realized_pnl: f64,           // realized P&L since midnight
 }


### PR DESCRIPTION
## Summary

- The `6040=75` position feed defaults its running quantity to zero and falls back to zero on an unparseable value, then both flush sites publish it unconditionally — position row, shared position, and a `PositionUpdate`.
- So an entry carrying a conId but no parseable `6064` flattened a live position and published it to `reqPositions` and both P&L paths. A strategy reading its own position sees flat when it is not, and can open a duplicate.
- Same defect ibx#261 fixed on the account-update path; that fix did not reach this sibling handler. The unparseable case needs no protocol anomaly — one bad byte reaches `unwrap_or(0.0)`, and `"NaN".parse::<f64>()` succeeds while `NaN as i64` is zero, so a non-finite value took the same route without failing the parse.
- The running quantity is now an `Option`, filtered to finite values; an entry without one is skipped rather than flushed. A genuine flat still arrives as an explicit `6064=0` and still flattens.

Closes #296.

## Test plan

- [x] `cargo test --lib` — 804 pass. The two `config::expiry_tests` failures are pre-existing on main.
- [x] Three shapes that must leave a live position alone: absent tag, unparseable value, non-finite value.
- [x] One that must still flatten: an explicit `6064=0`. Restoring the zero default fails the first three and leaves this one passing, so the fix cannot be mistaken for "ignore zeros".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
