### PR TITLE
historical data: send the contract's own security type and exchange (ibx#305)

### DIFF
--- a/src/api/client/reference.rs
+++ b/src/api/client/reference.rs
@@ -19,6 +19,8 @@ impl EClient {
             req_id: req_id as u32,
             con_id: contract.con_id,
             symbol: contract.symbol.clone(),
+            sec_type: contract.sec_type.clone(),
+            exchange: contract.exchange.clone(),
             end_date_time: end_date_time.into(),
             duration: duration.into(),
             bar_size: bar_size.into(),

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -1190,13 +1190,41 @@ fn req_historical_data_sends_fetch_historical() {
     client.req_historical_data(5, &spy(), "20260101 16:00:00", "1 D", "1 hour", "TRADES", true, 1, false).unwrap();
     let cmd = rx.try_recv().unwrap();
     match cmd {
-        ControlCommand::FetchHistorical { req_id, con_id, duration, bar_size, what_to_show, use_rth, .. } => {
+        ControlCommand::FetchHistorical {
+            req_id, con_id, duration, bar_size, what_to_show, use_rth, sec_type, exchange, ..
+        } => {
             assert_eq!(req_id, 5);
             assert_eq!(con_id, 756733);
             assert_eq!(duration, "1 D");
             assert_eq!(bar_size, "1 hour");
             assert_eq!(what_to_show, "TRADES");
             assert!(use_rth);
+            // The contract's own fields have to leave the client, or the
+            // engine has nothing but the old constants to fall back on
+            // (ibx#305). `spy()` states neither, so both arrive empty and the
+            // engine substitutes — that substitution is tested at its source.
+            assert_eq!(sec_type, "");
+            assert_eq!(exchange, "");
+        }
+        _ => panic!("expected FetchHistorical"),
+    }
+}
+
+/// A contract that does state its own type and venue must carry both, which is
+/// the whole of what this fixes: every historical query described itself as a
+/// SMART-routed stock regardless of the contract asked for.
+#[test]
+fn req_historical_data_carries_the_contract_s_own_type_and_venue() {
+    let (client, rx, _shared) = test_client();
+    let es = Contract {
+        con_id: 495512563, symbol: "ES".into(),
+        sec_type: "FUT".into(), exchange: "CME".into(), ..Default::default()
+    };
+    client.req_historical_data(6, &es, "20260101 16:00:00", "1 D", "1 hour", "TRADES", true, 1, false).unwrap();
+    match rx.try_recv().unwrap() {
+        ControlCommand::FetchHistorical { sec_type, exchange, .. } => {
+            assert_eq!(sec_type, "FUT");
+            assert_eq!(exchange, "CME");
         }
         _ => panic!("expected FetchHistorical"),
     }

--- a/src/control/historical.rs
+++ b/src/control/historical.rs
@@ -166,8 +166,12 @@ pub struct HistoricalRequest {
     pub query_id: String,
     pub con_id: u32,
     pub symbol: String,
-    pub sec_type: &'static str,
-    pub exchange: &'static str,
+    /// Wire security type and exchange for the contract being requested.
+    /// Owned rather than static: they come from the caller's `Contract`, and
+    /// hardcoding them described a different contract than was asked for
+    /// (ibx#305).
+    pub sec_type: String,
+    pub exchange: String,
     pub data_type: BarDataType,
     pub end_time: String,
     pub duration: String,
@@ -200,7 +204,7 @@ pub struct HistoricalResponse {
 
 /// Build the XML query for a historical bar data request.
 pub fn build_query_xml(req: &HistoricalRequest) -> String {
-    let exchange = match req.exchange {
+    let exchange = match req.exchange.as_str() {
         "SMART" => "BEST",
         e => e,
     };
@@ -838,8 +842,8 @@ mod tests {
             query_id: "q1".to_string(),
             con_id: 265598,
             symbol: "AAPL".to_string(),
-            sec_type: "CS",
-            exchange: "SMART",
+            sec_type: "CS".to_string(),
+            exchange: "SMART".to_string(),
             data_type: BarDataType::Trades,
             end_time: "20260228-15:00:00".to_string(),
             duration: "1 d".to_string(),
@@ -863,8 +867,8 @@ mod tests {
             query_id: "q1".to_string(),
             con_id: 265598,
             symbol: "AAPL".to_string(),
-            sec_type: "CS",
-            exchange: "SMART",
+            sec_type: "CS".to_string(),
+            exchange: "SMART".to_string(),
             data_type: BarDataType::Trades,
             end_time: "20260228-15:00:00".to_string(),
             duration: "1 d".to_string(),
@@ -988,6 +992,51 @@ mod tests {
         assert_eq!(extract_xml_tag("<a>hello</a>", "a"), Some("hello"));
         assert_eq!(extract_xml_tag("<x>123</x>", "x"), Some("123"));
         assert_eq!(extract_xml_tag("<x>123</x>", "y"), None);
+    }
+
+    /// The contract's own security type and exchange have to reach the query.
+    /// Hardcoding them described a stock on SMART whatever was asked for, and
+    /// the gateway rejected anything venue-specific with error 162 (ibx#305).
+    #[test]
+    fn a_futures_query_carries_its_own_sec_type_and_exchange() {
+        let req = HistoricalRequest {
+            query_id: "hist_1".into(),
+            con_id: 793356225,
+            symbol: "MNQ".into(),
+            sec_type: "FUT".into(),
+            exchange: "CME".into(),
+            data_type: BarDataType::Trades,
+            end_time: String::new(),
+            duration: "2 D".into(),
+            bar_size: BarSize::Day1,
+            use_rth: false,
+            keep_up_to_date: false,
+        };
+        let xml = build_query_xml(&req);
+        assert!(xml.contains("<secType>FUT</secType>"), "got: {}", xml);
+        assert!(xml.contains("<exchange>CME</exchange>"), "got: {}", xml);
+        assert!(!xml.contains("BEST"), "a futures query must not be routed to BEST: {}", xml);
+    }
+
+    /// SMART still maps to BEST, which is what stock callers relied on.
+    #[test]
+    fn a_smart_query_still_routes_to_best() {
+        let req = HistoricalRequest {
+            query_id: "hist_2".into(),
+            con_id: 756733,
+            symbol: "SPY".into(),
+            sec_type: "CS".into(),
+            exchange: "SMART".into(),
+            data_type: BarDataType::Trades,
+            end_time: String::new(),
+            duration: "1 D".into(),
+            bar_size: BarSize::Day1,
+            use_rth: true,
+            keep_up_to_date: false,
+        };
+        let xml = build_query_xml(&req);
+        assert!(xml.contains("<exchange>BEST</exchange>"), "got: {}", xml);
+        assert!(xml.contains("<secType>CS</secType>"), "got: {}", xml);
     }
 
     #[test]

--- a/src/engine/hot_loop/hmds.rs
+++ b/src/engine/hot_loop/hmds.rs
@@ -52,11 +52,22 @@ pub(crate) struct HmdsState {
 
 /// Wire security type for a historical query. Empty falls back to the stock
 /// encoding, which is what every caller got unconditionally before (ibx#305).
+///
+/// A type the enum does not list is passed through rather than emptied. The
+/// enum covers the types the order path understands, and `to_fix` deliberately
+/// blanks anything else so an unclassified instrument cannot masquerade as a
+/// stock (ibx#223) — but that reasoning is about the order path. A historical
+/// query for a valid type the enum happens not to carry, `FOP` say, would
+/// otherwise be narrowed to nothing. The subscribe path already passes such
+/// types through verbatim, and this now agrees with it.
 fn hist_sec_type(sec_type: &str) -> String {
     if sec_type.is_empty() {
         return "CS".to_string();
     }
-    crate::control::contracts::SecurityType::from_fix(sec_type).to_fix().to_string()
+    match crate::control::contracts::SecurityType::from_fix(sec_type).to_fix() {
+        "" => sec_type.to_string(),
+        known => known.to_string(),
+    }
 }
 
 /// Exchange for a historical query, defaulting to the previous constant.
@@ -801,14 +812,6 @@ impl HmdsState {
             } else {
                 compressed
             };
-            // Debug: dump first 80 bytes hex for wire comparison
-            let hex: String = to_send.iter().take(80).map(|b| format!("{:02x}", b)).collect();
-            log::info!("CCP keepUpToDate 35=W: {} bytes, hex={}", to_send.len(), hex);
-            if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true).open("D:/RustroverProjects/ibx/ibx_kut_debug.log") {
-                use std::io::Write;
-                let full_hex: String = to_send.iter().map(|b| format!("{:02x}", b)).collect();
-                let _ = writeln!(f, "LEN={} HEX={}", to_send.len(), full_hex);
-            }
             let _ = conn.send_raw(&to_send);
             hb.last_ccp_sent = Instant::now();
         }
@@ -1149,9 +1152,13 @@ mod historical_contract_tests {
         assert_eq!(hist_sec_type("CS"), "CS");
         // Absent keeps exactly what every caller got before.
         assert_eq!(hist_sec_type(""), "CS");
-        // An unrecognised type stays empty so the gateway names it, rather
-        // than being silently described as something else.
-        assert_eq!(hist_sec_type("NOPE"), "");
+        // A valid type the enum does not carry is sent as stated, not
+        // narrowed away — the subscribe path does the same.
+        assert_eq!(hist_sec_type("FOP"), "FOP");
+        assert_eq!(hist_sec_type("CFD"), "CFD");
+        // And a value that is not a security type at all still reaches the
+        // gateway to be named there, rather than being described as a stock.
+        assert_eq!(hist_sec_type("NOPE"), "NOPE");
     }
 
     #[test]
@@ -1387,12 +1394,74 @@ mod tests {
             true, false, "ES", "FUT", "CME", &mut conn, &mut hb, &shared,
         );
 
-        let mut buf = vec![0u8; 8192];
-        let n = peer.read(&mut buf).unwrap();
-        let sent = String::from_utf8_lossy(&buf[..n]).to_string();
+        let sent = String::from_utf8_lossy(&read_frame(&mut peer)).to_string();
 
         assert!(sent.contains("FUT"), "the contract's security type: {sent}");
         assert!(sent.contains("CME"), "the contract's venue: {sent}");
         assert!(!sent.contains("SMART"), "and not the old constant: {sent}");
+    }
+
+    /// The keep-up-to-date request is built by a second function over a
+    /// different transport, and it was changed too. Reverting only that one
+    /// passes every other test here.
+    #[test]
+    fn the_streaming_query_carries_them_too() {
+        use crate::protocol::connection::Connection;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = std::net::TcpStream::connect(addr).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(5))).unwrap();
+        let mut conn = Some(Connection::new_raw(client).unwrap());
+
+        let mut hmds = super::HmdsState::new();
+        let mut hb = crate::engine::hot_loop::HeartbeatState::new();
+        let shared = crate::bridge::SharedState::new();
+        let sign_iv = std::sync::Mutex::new(Vec::new());
+
+        hmds.send_historical_request_via_ccp(
+            1, 495512563, "20260101 16:00:00", "1800 S", "5 secs", "TRADES",
+            true, "ES", "FUT", "CME", &mut conn, &mut hb, &[], &sign_iv, &shared,
+        );
+
+        // This transport compresses, so the bytes have to be decoded before
+        // the query is readable at all.
+        let raw = read_frame(&mut peer);
+        let inner = crate::protocol::fixcomp::fixcomp_decompress(&raw)
+            .expect("the frame decompresses");
+        let sent: String = inner.iter()
+            .map(|m| String::from_utf8_lossy(m).to_string())
+            .collect::<Vec<_>>()
+            .join("");
+
+        assert!(sent.contains("<secType>FUT</secType>"), "the contract's security type: {sent}");
+        assert!(sent.contains("<exchange>CME</exchange>"), "the contract's venue: {sent}");
+        assert!(!sent.contains("SMART"), "and not the old constant: {sent}");
+    }
+
+    /// Read until the query XML has closed. A single `read` can legally return
+    /// a partial frame, which would make these tests fail intermittently while
+    /// production is correct.
+    fn read_frame(peer: &mut std::net::TcpStream) -> Vec<u8> {
+        use std::io::Read;
+        let mut acc = Vec::new();
+        let mut buf = vec![0u8; 8192];
+        for _ in 0..64 {
+            match peer.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    acc.extend_from_slice(&buf[..n]);
+                    if String::from_utf8_lossy(&acc).contains("</secType>")
+                        || crate::protocol::fixcomp::fixcomp_length(&acc)
+                            .is_some_and(|len| acc.len() >= len)
+                    {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        acc
     }
 }

--- a/src/engine/hot_loop/hmds.rs
+++ b/src/engine/hot_loop/hmds.rs
@@ -1132,6 +1132,37 @@ impl HmdsState {
 }
 
 #[cfg(test)]
+mod historical_contract_tests {
+    use super::{hist_exchange, hist_sec_type};
+
+    /// The substitution the engine applies to whatever the client sent. The
+    /// query builder honoured these fields before this change too, so testing
+    /// it alone cannot tell the fix from the bug — the constants used to be
+    /// applied here, above it.
+    #[test]
+    fn a_stated_security_type_reaches_the_wire_in_its_own_spelling() {
+        assert_eq!(hist_sec_type("FUT"), "FUT");
+        assert_eq!(hist_sec_type("OPT"), "OPT");
+        assert_eq!(hist_sec_type("CASH"), "CASH");
+        // Both vocabularies for a stock land on the wire spelling.
+        assert_eq!(hist_sec_type("STK"), "CS");
+        assert_eq!(hist_sec_type("CS"), "CS");
+        // Absent keeps exactly what every caller got before.
+        assert_eq!(hist_sec_type(""), "CS");
+        // An unrecognised type stays empty so the gateway names it, rather
+        // than being silently described as something else.
+        assert_eq!(hist_sec_type("NOPE"), "");
+    }
+
+    #[test]
+    fn a_stated_venue_reaches_the_wire_and_an_absent_one_defaults() {
+        assert_eq!(hist_exchange("CME"), "CME");
+        assert_eq!(hist_exchange("IDEALPRO"), "IDEALPRO");
+        assert_eq!(hist_exchange(""), "SMART");
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -1330,5 +1361,38 @@ mod tests {
         assert_eq!(hmds.pending_historical.len(), 1, "unrelated entry must stay");
         assert!(shared.reference.drain_historical_errors().is_empty());
         assert!(shared.reference.drain_historical_data().is_empty());
+    }
+    /// The helpers above are only worth anything if the request that reaches
+    /// the wire uses them. Reinstating the old `CS`/`SMART` constants in the
+    /// builder passes every test that checks the helpers or the query encoder
+    /// in isolation, so this drives the real function and reads the socket.
+    #[test]
+    fn the_query_on_the_wire_carries_the_contract_s_own_type_and_venue() {
+        use crate::protocol::connection::Connection;
+        use std::io::Read;
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = std::net::TcpStream::connect(addr).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(5))).unwrap();
+        let mut conn = Some(Connection::new_raw(client).unwrap());
+
+        let mut hmds = super::HmdsState::new();
+        let mut hb = crate::engine::hot_loop::HeartbeatState::new();
+        let shared = crate::bridge::SharedState::new();
+
+        hmds.send_historical_request_ex(
+            1, 495512563, "20260101 16:00:00", "1 D", "1 hour", "TRADES",
+            true, false, "ES", "FUT", "CME", &mut conn, &mut hb, &shared,
+        );
+
+        let mut buf = vec![0u8; 8192];
+        let n = peer.read(&mut buf).unwrap();
+        let sent = String::from_utf8_lossy(&buf[..n]).to_string();
+
+        assert!(sent.contains("FUT"), "the contract's security type: {sent}");
+        assert!(sent.contains("CME"), "the contract's venue: {sent}");
+        assert!(!sent.contains("SMART"), "and not the old constant: {sent}");
     }
 }

--- a/src/engine/hot_loop/hmds.rs
+++ b/src/engine/hot_loop/hmds.rs
@@ -58,16 +58,37 @@ pub(crate) struct HmdsState {
 /// blanks anything else so an unclassified instrument cannot masquerade as a
 /// stock (ibx#223) — but that reasoning is about the order path. A historical
 /// query for a valid type the enum happens not to carry, `FOP` say, would
-/// otherwise be narrowed to nothing. The subscribe path already passes such
-/// types through verbatim, and this now agrees with it.
+/// otherwise be narrowed to nothing. The descriptive branch of the subscribe
+/// path passes such types through in the same way.
+///
+/// The value goes into a query document, so what passes through is restricted
+/// to the shape a security type actually has. Anything else is blanked rather
+/// than embedded: a caller-supplied `&` or `<` would otherwise produce a
+/// malformed query instead of a refused one.
+///
+/// This helps a caller that states the type itself. It does not recover one the
+/// client has already lost: a contract returned by `req_contract_details` for
+/// an unlisted type arrives with an empty `sec_type`, because the enum cannot
+/// carry it, and an empty type still means stock here. That round trip needs
+/// the enum to stop discarding what it cannot name (ibx#230).
 fn hist_sec_type(sec_type: &str) -> String {
     if sec_type.is_empty() {
         return "CS".to_string();
     }
     match crate::control::contracts::SecurityType::from_fix(sec_type).to_fix() {
-        "" => sec_type.to_string(),
+        "" if is_plausible_sec_type(sec_type) => sec_type.to_string(),
+        "" => String::new(),
         known => known.to_string(),
     }
+}
+
+/// Whether a string is shaped like a security type: short, and letters or
+/// digits only. Deliberately strict — it guards a document, and every type the
+/// gateway uses fits inside it.
+fn is_plausible_sec_type(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 8
+        && s.bytes().all(|b| b.is_ascii_alphanumeric())
 }
 
 /// Exchange for a historical query, defaulting to the previous constant.
@@ -1156,9 +1177,17 @@ mod historical_contract_tests {
         // narrowed away — the subscribe path does the same.
         assert_eq!(hist_sec_type("FOP"), "FOP");
         assert_eq!(hist_sec_type("CFD"), "CFD");
-        // And a value that is not a security type at all still reaches the
-        // gateway to be named there, rather than being described as a stock.
+        // A value shaped like a type but unknown to both the enum and the
+        // gateway still reaches it, to be named there rather than silently
+        // described as a stock.
         assert_eq!(hist_sec_type("NOPE"), "NOPE");
+        // Anything that could break the query document is blanked instead of
+        // embedded. The value lands in XML, so this is the difference between
+        // a refused query and a malformed one.
+        assert_eq!(hist_sec_type("FOP&"), "");
+        assert_eq!(hist_sec_type("<x>"), "");
+        assert_eq!(hist_sec_type("A B"), "");
+        assert_eq!(hist_sec_type("VERYLONGTYPE"), "");
     }
 
     #[test]
@@ -1452,10 +1481,19 @@ mod tests {
                 Ok(0) => break,
                 Ok(n) => {
                     acc.extend_from_slice(&buf[..n]);
-                    if String::from_utf8_lossy(&acc).contains("</secType>")
+                    // Stop on a complete frame, not on a field in the middle
+                    // of one: a split right after the query would otherwise
+                    // return a truncated read that happens to satisfy the
+                    // assertions above it.
+                    // A plain FIX frame ends with its checksum field; a
+                    // compressed one states its own length.
+                    let ends_with_trailer = acc.len() >= 7
+                        && acc[acc.len() - 1] == 0x01
+                        && acc[acc.len() - 7..acc.len() - 4] == *b"\x0110=";
+                    let complete = ends_with_trailer
                         || crate::protocol::fixcomp::fixcomp_length(&acc)
-                            .is_some_and(|len| acc.len() >= len)
-                    {
+                            .is_some_and(|len| acc.len() >= len);
+                    if complete {
                         break;
                     }
                 }

--- a/src/engine/hot_loop/hmds.rs
+++ b/src/engine/hot_loop/hmds.rs
@@ -50,6 +50,20 @@ pub(crate) struct HmdsState {
     pub(crate) cold_scanner_results: Vec<(u32, crate::control::scanner::ScannerResult)>,
 }
 
+/// Wire security type for a historical query. Empty falls back to the stock
+/// encoding, which is what every caller got unconditionally before (ibx#305).
+fn hist_sec_type(sec_type: &str) -> String {
+    if sec_type.is_empty() {
+        return "CS".to_string();
+    }
+    crate::control::contracts::SecurityType::from_fix(sec_type).to_fix().to_string()
+}
+
+/// Exchange for a historical query, defaulting to the previous constant.
+fn hist_exchange(exchange: &str) -> String {
+    if exchange.is_empty() { "SMART".to_string() } else { exchange.to_string() }
+}
+
 impl HmdsState {
     pub(crate) fn new() -> Self {
         Self {
@@ -627,6 +641,8 @@ impl HmdsState {
         use_rth: bool,
         keep_up_to_date: bool,
         symbol: &str,
+        sec_type: &str,
+        exchange: &str,
         hmds_conn: &mut Option<Connection>,
         hb: &mut HeartbeatState,
         shared: &SharedState,
@@ -668,8 +684,8 @@ impl HmdsState {
             query_id: query_id.clone(),
             con_id: con_id as u32,
             symbol: symbol.to_string(),
-            sec_type: "CS",
-            exchange: "SMART",
+            sec_type: hist_sec_type(sec_type),
+            exchange: hist_exchange(exchange),
             data_type,
             end_time: end_date_time.to_string(),
             duration: duration.to_string(),
@@ -704,6 +720,8 @@ impl HmdsState {
         what_to_show: &str,
         use_rth: bool,
         symbol: &str,
+        sec_type: &str,
+        exchange: &str,
         ccp_conn: &mut Option<Connection>,
         hb: &mut HeartbeatState,
         sign_key: &[u8],
@@ -755,8 +773,8 @@ impl HmdsState {
             query_id: query_id.clone(),
             con_id: con_id as u32,
             symbol: symbol.to_string(),
-            sec_type: "CS",
-            exchange: "SMART",
+            sec_type: hist_sec_type(sec_type),
+            exchange: hist_exchange(exchange),
             data_type,
             end_time: end_date_time,
             duration: duration.to_string(),
@@ -1246,7 +1264,7 @@ mod tests {
         let mut conn: Option<Connection> = None;
 
         hmds.send_historical_request_ex(9, 756733, "", "2 d", "1 Min", "TRADES",
-            true, false, "SPY", &mut conn, &mut hb, &shared);
+            true, false, "SPY", "STK", "SMART", &mut conn, &mut hb, &shared);
 
         assert!(hmds.pending_historical.is_empty(), "rejected request must not go pending");
         let errors = shared.reference.drain_historical_errors();

--- a/src/engine/hot_loop/mod.rs
+++ b/src/engine/hot_loop/mod.rs
@@ -457,17 +457,17 @@ impl HotLoop {
                 ControlCommand::RegisterInstrument { con_id, symbol, sec_type, exchange, reply_tx } => {
                     self.register_or_reject(con_id, symbol, &sec_type, &exchange, &reply_tx);
                 }
-                ControlCommand::FetchHistorical { req_id, con_id, symbol, end_date_time, duration, bar_size, what_to_show, use_rth, keep_up_to_date } => {
+                ControlCommand::FetchHistorical { req_id, con_id, symbol, sec_type, exchange, end_date_time, duration, bar_size, what_to_show, use_rth, keep_up_to_date } => {
                     // keepUpToDate sends via CCP but bars/end arrive on HMDS — both
                     // paths require an authed HMDS socket to deliver a completion.
                     if self.hmds_conn.is_none() {
                         self.emit_hmds_unavailable(req_id, true);
                     } else if keep_up_to_date {
-                        if self.hmds.send_historical_request_via_ccp(req_id, con_id, &end_date_time, &duration, &bar_size, &what_to_show, use_rth, &symbol, &mut self.ccp_conn, &mut self.hb, &self.ccp.ccp_sign_key, &self.ccp.ccp_sign_iv, &self.shared) {
+                        if self.hmds.send_historical_request_via_ccp(req_id, con_id, &end_date_time, &duration, &bar_size, &what_to_show, use_rth, &symbol, &sec_type, &exchange, &mut self.ccp_conn, &mut self.hb, &self.ccp.ccp_sign_key, &self.ccp.ccp_sign_iv, &self.shared) {
                             self.hmds.keep_up_to_date_reqs.insert(req_id);
                         }
                     } else {
-                        self.hmds.send_historical_request_ex(req_id, con_id, &end_date_time, &duration, &bar_size, &what_to_show, use_rth, false, &symbol, &mut self.hmds_conn, &mut self.hb, &self.shared);
+                        self.hmds.send_historical_request_ex(req_id, con_id, &end_date_time, &duration, &bar_size, &what_to_show, use_rth, false, &symbol, &sec_type, &exchange, &mut self.hmds_conn, &mut self.hb, &self.shared);
                     }
                 }
                 ControlCommand::CancelHistorical { req_id } => {

--- a/src/python/compat/client/reference.rs
+++ b/src/python/compat/client/reference.rs
@@ -44,6 +44,8 @@ impl EClient {
                 req_id: req_id as u32,
                 con_id: contract.con_id,
                 symbol: contract.symbol.clone(),
+                sec_type: contract.sec_type.clone(),
+                exchange: contract.exchange.clone(),
                 end_date_time: end_date_time.to_string(),
                 duration: duration_str.to_string(),
                 bar_size: bar_size_setting.to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1313,6 +1313,11 @@ pub enum ControlCommand {
         req_id: u32,
         con_id: i64,
         symbol: String,
+        /// Security type and exchange from the caller's contract. Hardcoding
+        /// these described a stock on SMART regardless of what was asked for,
+        /// so anything venue-specific was rejected (ibx#305).
+        sec_type: String,
+        exchange: String,
         end_date_time: String,
         duration: String,
         bar_size: String,

--- a/tests/control_plane.rs
+++ b/tests/control_plane.rs
@@ -214,8 +214,8 @@ fn historical_request_full_workflow() {
         query_id: "hd1;;AAPL@SMART TRADES;;1;;true;;0;;I".to_string(),
         con_id: 265598,
         symbol: "AAPL".to_string(),
-        sec_type: "CS",
-        exchange: "SMART",
+        sec_type: "CS".to_string(),
+        exchange: "SMART".to_string(),
         data_type: BarDataType::Trades,
         end_time: "20260228-16:00:00".to_string(),
         duration: "1 d".to_string(),
@@ -304,8 +304,8 @@ fn historical_streaming_subscription_flow() {
         query_id: "rt1".to_string(),
         con_id: 265598,
         symbol: "AAPL".to_string(),
-        sec_type: "CS",
-        exchange: "SMART",
+        sec_type: "CS".to_string(),
+        exchange: "SMART".to_string(),
         data_type: BarDataType::Trades,
         end_time: "".to_string(),
         duration: "1800 S".to_string(),
@@ -472,14 +472,14 @@ fn contract_lookup_feeds_historical_request() {
     let query_id = format!("hd;;{}@{}", contract.symbol, contract.exchange);
     let con_id = contract.con_id;
     let symbol = contract.symbol.clone();
-    let sec_type = contract.sec_type.to_fix();
+    let sec_type = contract.sec_type.to_fix().to_string();
 
     let req = HistoricalRequest {
         query_id,
         con_id,
         symbol,
         sec_type,
-        exchange: "NASDAQ",
+        exchange: "NASDAQ".to_string(),
         data_type: BarDataType::Trades,
         end_time: "20260228-16:00:00".to_string(),
         duration: "1 d".to_string(),


### PR DESCRIPTION
## Summary

- Both historical query builders filled the contract descriptor with constants — `sec_type: "CS"`, `exchange: "SMART"` — and `ControlCommand::FetchHistorical` carried neither field, so the caller's `Contract` contributed only its conId and symbol. Every request described a stock on SMART regardless of what was asked for, and SMART maps to BEST on this query.
- Requesting a daily bar for a front-month CME future on a live account returns `error 162: BEST queries are not supported for this contract`, and no bars. `req_mkt_data` on the same contract in the same session streams normally, so only the historical path was affected.
- The failure is quiet from the caller's side: the rejection arrives as an error callback but `historical_data_end` still fires, so anything waiting on the end marker sees an empty result rather than a failure.
- Both fields now travel on the command and reach the query. An empty security type still falls back to the stock encoding and an empty exchange to SMART, so a caller supplying neither gets exactly what it got before. A supplied type goes through the same `SecurityType` mapping the subscription path already uses, so `STK` still encodes as `CS`.

Closes #305.

## Test plan

- [x] `cargo test --offline --lib` — 809 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline` on every target that builds offline — `--lib`, `--features python`, `--test control_plane`, `--test scenarios`, `--test hot_loop_lifecycle`: all clean. `control_plane` was broken by this branch and is the reason the list is now explicit.
- [x] Mutation check: reinstating `CS`/`SMART` in the batch builder fails `the_query_on_the_wire_carries_the_contract_s_own_type_and_venue`; in the keep-up-to-date builder alone, `the_streaming_query_carries_them_too`; dropping the unlisted-type passthrough fails `a_stated_security_type_reaches_the_wire_in_its_own_spelling`; dropping the client forwarding fails `req_historical_data_carries_the_contract_s_own_type_and_venue`. All by name.
- [ ] Not in this PR: the head-timestamp constructor still hardcodes `CS`/`SMART` — same family, same file, its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

