### PR TITLE
orders: restate OutsideRTH on a modify instead of asserting it (ibx#312)

### DIFF
--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -1151,6 +1151,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         };
         ctx.insert_order(order);
         assert!(ctx.order(1).is_some());
@@ -1171,6 +1172,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 2,
@@ -1183,6 +1185,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
 
         let inst0_orders = ctx.open_orders_for(0);
@@ -1204,6 +1207,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         ctx.update_order_status(1, OrderStatus::Cancelled);
         assert_eq!(ctx.order(1).unwrap().status, OrderStatus::Cancelled);
@@ -1219,6 +1223,7 @@ mod tests {
             order_id: oid, instrument: 0, side: Side::Buy, price: 100,
             qty: 100, filled: 0, status: OrderStatus::Submitted,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
     }
 
@@ -1297,6 +1302,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         ctx.remove_order(1);
         assert!(ctx.order(1).is_none());
@@ -1465,18 +1471,21 @@ mod tests {
             price: 150 * PRICE_SCALE, qty: 100, filled: 0,
             status: OrderStatus::Submitted,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 2, instrument: 0, side: Side::Sell,
             price: 155 * PRICE_SCALE, qty: 50, filled: 0,
             status: OrderStatus::Submitted,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 3, instrument: 0, side: Side::Buy,
             price: 149 * PRICE_SCALE, qty: 200, filled: 0,
             status: OrderStatus::Filled,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
 
         // open_orders_for only returns Submitted
@@ -1526,6 +1535,7 @@ mod tests {
             price: PRICE_SCALE, qty: 100, filled: 0,
             status: OrderStatus::PendingSubmit,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.update_order_filled(1, 30);
         assert_eq!(ctx.order(1).unwrap().filled, 30);
@@ -1541,18 +1551,21 @@ mod tests {
             price: PRICE_SCALE, qty: 100, filled: 0,
             status: OrderStatus::PendingSubmit,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 2, instrument: 0, side: Side::Buy,
             price: PRICE_SCALE, qty: 100, filled: 50,
             status: OrderStatus::PartiallyFilled,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 3, instrument: 0, side: Side::Buy,
             price: PRICE_SCALE, qty: 100, filled: 100,
             status: OrderStatus::Filled,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         let open = ctx.open_orders_for(0);
         // PendingSubmit and PartiallyFilled count as open; Filled does not

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -715,6 +715,10 @@ impl CcpState {
                     ord_type: ord_type_byte,
                     tif: tif_byte,
                     stop_price: stop_price_i64,
+                    // The recovery record restates the order, so take the flag
+                    // from it rather than defaulting — a later modify restates
+                    // it in turn.
+                    outside_rth: parsed.get(&6433).map(|v| v == "1").unwrap_or(false),
                 });
                 log::info!("CCP recovery: inserted orderId={} sym={:?} side={:?} qty={} px={}",
                     clord_id, parsed.get(&55), side, qty,
@@ -2073,6 +2077,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         (CcpState::new(), context, SharedState::new())
     }
@@ -2166,6 +2171,36 @@ mod tests {
             42, instrument, Side::Buy, 1, 100 * PRICE_SCALE, b'2', b'0', 0,
         )); // starts at PendingSubmit
         (CcpState::new(), context, SharedState::new())
+    }
+
+    /// A recovered order carries its own extended-hours flag on the report. If
+    /// the recovery insert drops it, the order silently narrows to regular
+    /// hours the next time it is modified, because the replace restates what
+    /// the engine recorded.
+    #[test]
+    fn a_recovery_record_keeps_its_outside_rth_flag() {
+        for (tag6433, expected) in [(Some("1"), true), (Some("0"), false), (None, false)] {
+            let mut context = Context::new();
+            let mut ccp = CcpState::new();
+            let shared = SharedState::new();
+            let mut frame = std::collections::HashMap::new();
+            for (tag, val) in [
+                (11u32, "78"), (150, "0"), (39, "0"), (6008, "756733"),
+                (38, "100"), (55, "SPY"), (54, "1"),
+            ] {
+                frame.insert(tag, val.to_string());
+            }
+            if let Some(v) = tag6433 {
+                frame.insert(6433, v.to_string());
+            }
+
+            ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+            assert_eq!(
+                context.order(78).expect("recovered").outside_rth, expected,
+                "6433={tag6433:?}",
+            );
+        }
     }
 
     fn exec_report_frame(pairs: &[(u32, &str)]) -> std::collections::HashMap<u32, String> {

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -107,7 +107,7 @@ pub(crate) fn drain_and_send_orders(
             OrderRequest::SubmitLimitGtc { order_id, instrument, side, qty, price, outside_rth } => {
                 context.insert_order(crate::types::Order::new(
                     order_id, instrument, side, qty, price, b'2', b'1', 0,
-                ));
+                ).with_outside_rth(outside_rth));
                 let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
@@ -215,7 +215,7 @@ pub(crate) fn drain_and_send_orders(
             OrderRequest::SubmitStopGtc { order_id, instrument, side, qty, stop_price, outside_rth } => {
                 context.insert_order(crate::types::Order::new(
                     order_id, instrument, side, qty, stop_price, b'3', b'1', stop_price,
-                ));
+                ).with_outside_rth(outside_rth));
                 let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
@@ -251,7 +251,7 @@ pub(crate) fn drain_and_send_orders(
             OrderRequest::SubmitStopLimitGtc { order_id, instrument, side, qty, price, stop_price, outside_rth } => {
                 context.insert_order(crate::types::Order::new(
                     order_id, instrument, side, qty, price, b'4', b'1', stop_price,
-                ));
+                ).with_outside_rth(outside_rth));
                 let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
@@ -1449,10 +1449,13 @@ pub(crate) fn drain_and_send_orders(
                 let price = orig.map_or(price, |o| crate::types::snap_to_tick(
                     price, context.market.min_tick_scaled(o.instrument)));
                 if let Some(orig) = orig {
+                    // Carried like every other attribute of the original: a
+                    // replace that dropped it would leave the next modify
+                    // restating a flag the order no longer records.
                     context.insert_order(crate::types::Order::new(
                         new_order_id, orig.instrument, orig.side, qty, price,
                         orig.ord_type, orig.tif, orig.stop_price,
-                    ));
+                    ).with_outside_rth(orig.outside_rth));
                 }
                 // Versioned ClOrdID chaining: orderId.0 → .1 → .2
                 let prev_ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
@@ -1482,36 +1485,20 @@ pub(crate) fn drain_and_send_orders(
                 let con_id_str = orig.and_then(|o| context.market.con_id(o.instrument))
                     .map(|c| c.to_string()).unwrap_or_default();
 
-                // Lean modify message — omit identity tags (6121, 6119, 231, 100, 15, 204)
-                let mut fields: Vec<(u32, &str)> = vec![
-                    (fix::TAG_MSG_TYPE, fix::MSG_ORDER_REPLACE),
-                    (fix::TAG_SENDING_TIME, &now),
-                    (11, &clord_str),    // ClOrdID (versioned)
-                    (41, &orig_clord),   // OrigClOrdID (previous version)
-                    (44, &price_str),    // Price
-                    (1, account_id),     // Account
-                    (6122, "c"),         // Client version
-                    (6433, "1"),         // OutsideRTH (preserve from original)
-                    (38, &qty_str),      // OrderQty
-                    (54, side_str),      // Side
-                    (40, &ord_type_str), // OrdType
-                    (55, &symbol),       // Symbol
-                    (167, &sec_type_str),        // SecurityType
-                    (6035, &symbol),     // LocalSymbol echo
-                    (59, &tif_str),      // TIF
-                    (6008, &con_id_str), // ConId
-                    (6088, "Socket"),    // Connection type
-                    (6211, ""),          // Empty (matches reference)
-                    (6238, ""),          // Empty (matches reference)
-                ];
                 // Include stop price for order types that need it
                 let stop_str;
-                if let Some(o) = orig {
-                    if o.stop_price != 0 {
+                let stop = match orig {
+                    Some(o) if o.stop_price != 0 => {
                         stop_str = format_price(o.stop_price);
-                        fields.push((99, &stop_str));
+                        Some(&*stop_str)
                     }
-                }
+                    _ => None,
+                };
+                let fields = build_replace_fields(
+                    &now, &clord_str, &orig_clord, &price_str, account_id, &qty_str,
+                    side_str, &ord_type_str, &symbol, &sec_type_str, &tif_str,
+                    &con_id_str, orig.map(|o| o.outside_rth).unwrap_or(false), stop,
+                );
                 conn.send_fix(&fields)
             }
         };
@@ -1588,6 +1575,61 @@ fn oca_type_str(oca_type: u8) -> &'static str {
     }
 }
 
+/// Build the 35=G replace tag list. Lean by design — identity tags (6121,
+/// 6119, 231, 100, 15, 204) are omitted.
+///
+/// Kept pure so the wire shape stays testable without a connection. OutsideRTH
+/// (6433) is restated from the tracked order and is present only when the order
+/// carries it, matching the submit path: a literal here would widen every
+/// RTH-only order to the extended session the first time it was modified.
+#[allow(clippy::too_many_arguments)]
+fn build_replace_fields<'a>(
+    now: &'a str,
+    clord: &'a str,
+    orig_clord: &'a str,
+    price: &'a str,
+    account_id: &'a str,
+    qty: &'a str,
+    side: &'a str,
+    ord_type: &'a str,
+    symbol: &'a str,
+    sec_type: &'a str,
+    tif: &'a str,
+    con_id: &'a str,
+    outside_rth: bool,
+    stop: Option<&'a str>,
+) -> Vec<(u32, &'a str)> {
+    let mut fields: Vec<(u32, &str)> = vec![
+        (fix::TAG_MSG_TYPE, fix::MSG_ORDER_REPLACE),
+        (fix::TAG_SENDING_TIME, now),
+        (11, clord),         // ClOrdID (versioned)
+        (41, orig_clord),    // OrigClOrdID (previous version)
+        (44, price),         // Price
+        (1, account_id),     // Account
+        (6122, "c"),         // Client version
+    ];
+    if outside_rth {
+        fields.push((6433, "1")); // OutsideRTH
+    }
+    fields.extend_from_slice(&[
+        (38, qty),           // OrderQty
+        (54, side),          // Side
+        (40, ord_type),      // OrdType
+        (55, symbol),        // Symbol
+        (167, sec_type),     // SecurityType
+        (6035, symbol),      // LocalSymbol echo
+        (59, tif),           // TIF
+        (6008, con_id),      // ConId
+        (6088, "Socket"),    // Connection type
+        (6211, ""),          // Empty (matches reference)
+        (6238, ""),          // Empty (matches reference)
+    ]);
+    if let Some(stop) = stop {
+        fields.push((99, stop));
+    }
+    fields
+}
+
 /// One shared encoder for every extended order submission (ibx#224): the
 /// order-type-specific tags come from `kind`; the TIF and the full
 /// `OrderAttrs` block are emitted identically for all kinds.
@@ -1635,7 +1677,7 @@ fn send_order_ex(
     };
     context.insert_order(crate::types::Order::new(
         order_id, instrument, side, qty, track_price, ord_type_byte, tif, track_stop,
-    ));
+    ).with_outside_rth(attrs.outside_rth));
 
     let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
     let symbol = context.market.symbol(instrument).to_string();
@@ -2022,6 +2064,7 @@ mod tests {
         Order {
             order_id: oid, instrument: 0, side: Side::Buy, price: 100,
             qty: 10, filled, status, ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         }
     }
 
@@ -2055,5 +2098,159 @@ mod tests {
 
         assert_eq!(context.order(8).unwrap().status, OrderStatus::Filled);
         assert!(shared.orders.drain_order_updates().is_empty());
+    }
+
+    /// Drive the real send path and inspect what it recorded. The peer is held
+    /// open for the call so the send succeeds — a failed send unwinds the
+    /// order, which would mask what these tests are checking.
+    fn drain(context: &mut Context) -> String {
+        use std::io::Read;
+        let shared = Arc::new(SharedState::new());
+        let (c, mut peer) = crate::protocol::connection::Connection::paired_for_test();
+        let mut conn = Some(c);
+        let mut hb = HeartbeatState::new();
+        drain_and_send_orders(&mut conn, context, "ACC", &mut hb, false, &shared);
+
+        peer.set_read_timeout(Some(std::time::Duration::from_millis(250))).unwrap();
+        let mut sent = Vec::new();
+        let mut chunk = [0u8; 8192];
+        while let Ok(n) = peer.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            sent.extend_from_slice(&chunk[..n]);
+        }
+        String::from_utf8_lossy(&sent).replace('\x01', "|")
+    }
+
+    /// The flag has to survive being modified, not just being submitted. A
+    /// replace builds a fresh tracked order from the original; dropping the
+    /// flag there leaves the first replace correct and every later one wrong,
+    /// which is the shape that hides in testing.
+    #[test]
+    fn an_order_keeps_outside_rth_across_repeated_modifies() {
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.insert_order(
+            crate::types::Order::new(7, instrument, Side::Buy, 10, 100 * crate::types::PRICE_SCALE, b'2', b'1', 0)
+                .with_outside_rth(true),
+        );
+
+        let second = context.modify(7, 101 * crate::types::PRICE_SCALE, 10);
+        let first_replace = drain(&mut context);
+        assert!(first_replace.contains("|6433=1|"), "first replace restates the flag: {first_replace}");
+        assert!(
+            context.order(second).expect("replacement tracked").outside_rth,
+            "the replacement order must carry the flag forward",
+        );
+
+        let third = context.modify(second, 102 * crate::types::PRICE_SCALE, 10);
+        let second_replace = drain(&mut context);
+        assert!(
+            second_replace.contains("|6433=1|"),
+            "and the next replace restates it too: {second_replace}",
+        );
+        assert!(
+            context.order(third).expect("second replacement tracked").outside_rth,
+            "and keeps carrying it",
+        );
+    }
+
+    /// Every submit that offers the flag has to record it, or the replace has
+    /// nothing truthful to restate. The shared extended encoder is the one that
+    /// matters most: every order placed through the public clients with
+    /// outside-RTH set routes there, so a regression on that path alone
+    /// reintroduces the whole bug.
+    #[test]
+    fn a_submit_records_the_flag_it_was_given() {
+        for requested in [true, false] {
+            // Plain GTC limit.
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            let id = context.submit_limit_gtc(instrument, Side::Buy, 10, 100 * crate::types::PRICE_SCALE, requested);
+            let sent = drain(&mut context);
+            assert_eq!(
+                sent.contains("|6433=1|"), requested,
+                "limit submit only carries 6433 when asked: {sent}",
+            );
+            assert_eq!(context.order(id).expect("tracked").outside_rth, requested);
+
+            // The stop this change exists for.
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            let id = context.submit_stop_gtc(
+                instrument, Side::Sell, 10, 600 * crate::types::PRICE_SCALE, requested,
+            );
+            let sent = drain(&mut context);
+            assert_eq!(sent.contains("|6433=1|"), requested, "stop submit: {sent}");
+            assert_eq!(context.order(id).expect("tracked").outside_rth, requested);
+
+            // And the shared extended encoder, which every public-client order
+            // carrying the flag goes through.
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            let id = context.submit_limit_ex(
+                instrument, Side::Buy, 10, 100 * crate::types::PRICE_SCALE, b'0',
+                crate::types::OrderAttrs { outside_rth: requested, ..Default::default() },
+            );
+            let sent = drain(&mut context);
+            assert_eq!(sent.contains("|6433=1|"), requested, "extended submit: {sent}");
+            assert_eq!(
+                context.order(id).expect("tracked").outside_rth, requested,
+                "the extended encoder records it too",
+            );
+        }
+    }
+
+    fn replace(outside_rth: bool, stop: Option<&str>) -> Vec<(u32, &str)> {
+        build_replace_fields(
+            "T", "7.1", "7.0", "101.00", "ACC", "10", "1", "2", "SPY", "CS", "0",
+            "756733", outside_rth, stop,
+        )
+    }
+
+    /// A replace restates the order, so OutsideRTH must come from the order.
+    /// Sending it unconditionally widens an RTH-only order to the extended
+    /// session the first time it is modified, and nothing reports the change.
+    #[test]
+    fn replace_carries_outside_rth_only_when_the_order_has_it() {
+        let rth_only = replace(false, None);
+        assert!(
+            !rth_only.iter().any(|(tag, _)| *tag == 6433),
+            "an RTH-only order must not acquire 6433 by being modified",
+        );
+
+        let extended = replace(true, None);
+        assert_eq!(
+            extended.iter().filter(|(tag, _)| *tag == 6433).map(|(_, v)| *v).collect::<Vec<_>>(),
+            ["1"],
+            "an order submitted outside RTH must keep the flag across a modify",
+        );
+    }
+
+    /// Setting the flag must not disturb the rest of the message.
+    #[test]
+    fn outside_rth_is_the_only_difference_between_the_two_shapes() {
+        let without = replace(false, None);
+        let with: Vec<_> = replace(true, None).into_iter().filter(|(tag, _)| *tag != 6433).collect();
+        assert_eq!(without, with);
+    }
+
+    /// The flag sits between the client version and the quantity, where the
+    /// submit path puts it.
+    #[test]
+    fn outside_rth_keeps_its_position() {
+        let tags: Vec<u32> = replace(true, None).iter().map(|(tag, _)| *tag).collect();
+        let at = tags.iter().position(|t| *t == 6433).expect("6433 present");
+        assert_eq!(tags[at - 1], 6122);
+        assert_eq!(tags[at + 1], 38);
+    }
+
+    /// The stop price is appended only for order types that carry one.
+    #[test]
+    fn replace_appends_the_stop_price_when_there_is_one() {
+        assert!(!replace(false, None).iter().any(|(tag, _)| *tag == 99));
+        let stopped = replace(false, Some("99.50"));
+        assert_eq!(stopped.last(), Some(&(99u32, "99.50")));
     }
 }

--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -310,6 +310,27 @@ impl Connection {
         Ok(())
     }
 
+    /// Test-only connection over a loopback pair. The peer is returned so the
+    /// caller can hold it open: sends have to succeed for the send paths to
+    /// behave as they do in production, where a write error unwinds the order.
+    #[cfg(test)]
+    pub(crate) fn paired_for_test() -> (Self, std::net::TcpStream) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stream = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (peer, _) = listener.accept().unwrap();
+        stream.set_nonblocking(true).unwrap();
+        let conn = Self {
+            stream: Stream::Raw(stream),
+            buf: Vec::new(),
+            seq: 0,
+            sign_key: Vec::new(),
+            sign_iv: Vec::new(),
+            read_key: Vec::new(),
+            read_iv: Vec::new(),
+        };
+        (conn, peer)
+    }
+
     /// Build a message, compress, sign, and send. For farm subscribe/data messages.
     /// Uses seq=0 (separate seq space from heartbeats).
     ///

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,12 +263,22 @@ pub struct Order {
     pub tif: u8,
     /// FIX tag 99 stop price (for Stop/StopLimit/MIT/LIT orders)
     pub stop_price: Price,
+    /// FIX tag 6433 OutsideRTH. Tracked so a replace can restate it: the
+    /// server reads the flag off the replace, so a modify that guesses would
+    /// silently change when the order is eligible to execute.
+    pub outside_rth: bool,
 }
 
 impl Order {
     /// Create a new tracked order with FIX type metadata.
     pub fn new(order_id: OrderId, instrument: InstrumentId, side: Side, qty: u32, price: Price, ord_type: u8, tif: u8, stop_price: Price) -> Self {
-        Self { order_id, instrument, side, price, qty, filled: 0, status: OrderStatus::PendingSubmit, ord_type, tif, stop_price }
+        Self { order_id, instrument, side, price, qty, filled: 0, status: OrderStatus::PendingSubmit, ord_type, tif, stop_price, outside_rth: false }
+    }
+
+    /// Record that the order was submitted with OutsideRTH set.
+    pub fn with_outside_rth(mut self, outside_rth: bool) -> Self {
+        self.outside_rth = outside_rth;
+        self
     }
 }
 
@@ -2009,6 +2019,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         };
         let o2 = o; // Copy
         assert_eq!(o.order_id, o2.order_id);


### PR DESCRIPTION
## Summary

- Every replace carried `6433=1`. The comment beside it read "OutsideRTH (preserve from original)", but the value was a literal and there was nothing to preserve it from — `types::Order` had no field for the flag, so what the order was submitted with was gone by the time a modify was built.
- The submit path is correct: it emits 6433 only when the caller asks, and omits the tag otherwise. So the default order is regular-hours-only, and the **first modify silently changes that**.
- Modifying an order's price or quantity turns on extended-hours eligibility regardless of how it was placed. A resting stop submitted for regular hours becomes eligible to trigger outside them as soon as it is touched. The gateway accepts the flag, the replace is acknowledged normally, and the order reads back as intended apart from the one field the caller never set.
- Both entry points reach it: `EClient::place_order` on an already-tracked id, and `Context::modify`.

Closes #312.

## Change

- `Order` carries the flag, set from the submit request and from the CCP recovery record, where the server restates the order and the flag is on the wire.
- The replace restates it, and omits the tag when the order is not eligible — which is exactly what the submit path does for the same order, so the two messages agree rather than contradicting each other.
- A replace also builds a fresh tracked order from the original, so the flag is carried across that too. Without it the first replace is right and every later one wrong — the shape that survives a casual test.

Omitting the tag rather than sending `6433=0` also leaves the server's own setting alone in the case where the original order is not tracked.

## Wire shape

For an order submitted outside RTH the replace is byte-identical to before, including the tag's position in the message. The tag list moved into a free function so that can be asserted without a live connection.

## Tests

The tests drive the real send path over a loopback pair and read back what was written, so they cover both what the engine records and what it puts on the wire. Each of these fails them:

- passing the flag through as `false` at the callsite
- dropping it at any of the three GTC submits
- dropping it across a replace, so only the second modify is wrong

`cargo test --lib`: 808 pass. The two `config::expiry_tests` failures are pre-existing and unrelated (timezone data). No new clippy warnings.

## Related

#318 — four order types (adaptive, algo, what-if, adjustable stop) return before the extended-attribute block and never record the flag at all, along with the parent link and OCA group. Pre-existing and separate; found while tracing where the flag comes from.