### PR TITLE
orders: report the order's cumulative fill on order_status, not the last print (ibx#315)

### DIFF
--- a/src/api/client/dispatch.rs
+++ b/src/api/client/dispatch.rs
@@ -54,9 +54,12 @@ impl EClient {
             let (perm_id, parent_id) = self.shared.orders.get_order_info(fill.order_id)
                 .map(|info| (info.order.perm_id, info.order.parent_id))
                 .unwrap_or((0, 0));
+            // `filled` and `avgFillPrice` describe the order so far;
+            // `lastFillPrice` describes this print.
+            let avg_price_f = fill.avg_price as f64 / PRICE_SCALE_F;
             wrapper.order_status(
-                fill.order_id as i64, status, fill.qty as f64, fill.remaining as f64,
-                price_f, perm_id, parent_id, price_f, 0, "", 0.0,
+                fill.order_id as i64, status, fill.cum_qty as f64, fill.remaining as f64,
+                avg_price_f, perm_id, parent_id, price_f, 0, "", 0.0,
             );
 
             let side_str = match fill.side {
@@ -102,7 +105,7 @@ impl EClient {
             self.core.push_execution(req_id, c, exec, report);
 
             // Update open order tracking
-            self.core.update_order_fill(fill.order_id, status, fill.qty as f64, fill.remaining as f64);
+            self.core.update_order_fill(fill.order_id, status, fill.cum_qty as f64, fill.remaining as f64);
         }
 
         // Order updates → order_status

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -1644,6 +1644,7 @@ fn process_msgs_dispatches_fill() {
         instrument: 0, order_id: 42, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 123456789,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
@@ -1658,10 +1659,38 @@ fn process_msgs_dispatches_partial_fill() {
         instrument: 0, order_id: 42, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 50, remaining: 50,
         commission: PRICE_SCALE, timestamp_ns: 123456789,
+        cum_qty: 50, avg_price: 150 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
     assert!(w.events.iter().any(|e| e.starts_with("order_status:42:PartiallyFilled")));
+}
+
+/// IB's `orderStatus` contract: `filled` is cumulative across the order and
+/// `avgFillPrice` is volume-weighted across every print, while `lastFillPrice`
+/// is this print. Reporting the print's own size and price as the cumulative
+/// pair means an order that fills in more than one print never reports its
+/// true average, and `filled` never reaches the order quantity.
+#[test]
+fn order_status_reports_the_order_total_not_the_last_print() {
+    let (client, _rx, shared) = test_client();
+    // Second print: 100 more at 151, taking the order to 200 filled at an
+    // average of 150.50, with 100 still working.
+    shared.orders.push_fill(Fill {
+        instrument: 0, order_id: 42, side: Side::Buy,
+        price: 151 * PRICE_SCALE, qty: 100, remaining: 100,
+        commission: PRICE_SCALE, timestamp_ns: 0,
+        cum_qty: 200, avg_price: 150 * PRICE_SCALE + PRICE_SCALE / 2,
+    });
+    let mut w = RecordingWrapper::default();
+    client.process_msgs(&mut w);
+
+    let status = w.events.iter().find(|e| e.starts_with("order_status:42:"))
+        .expect("order_status was dispatched");
+    assert_eq!(
+        status, "order_status:42:PartiallyFilled:200:100:150.5",
+        "filled and avgFillPrice must describe the order, not the print",
+    );
 }
 
 #[test]
@@ -1671,6 +1700,7 @@ fn process_msgs_dispatches_sell_fill() {
         instrument: 0, order_id: 43, side: Side::Sell,
         price: 151 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 0,
+        cum_qty: 100, avg_price: 151 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
@@ -2232,6 +2262,7 @@ fn process_msgs_drains_on_first_call_empty_on_second() {
         instrument: 0, order_id: 1, side: Side::Buy,
         price: PRICE_SCALE, qty: 1, remaining: 0,
         commission: 0, timestamp_ns: 0,
+        cum_qty: 1, avg_price: PRICE_SCALE,
     });
     shared.orders.push_order_update(OrderUpdate {
         order_id: 2, instrument: 0, status: OrderStatus::Submitted,
@@ -2263,6 +2294,7 @@ fn process_msgs_fill_uses_instrument_to_req_mapping() {
         instrument: 0, order_id: 1, side: Side::Buy,
         price: PRICE_SCALE, qty: 100, remaining: 0,
         commission: 0, timestamp_ns: 0,
+        cum_qty: 100, avg_price: PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
@@ -2350,6 +2382,7 @@ fn modify_filled_order_receives_cancel_reject() {
         instrument: 0, order_id: 120, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: 0, timestamp_ns: 1000,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -882,11 +882,13 @@ mod tests {
             instrument: 0, order_id: 1, side: Side::Buy,
             price: 100 * PRICE_SCALE, qty: 10, remaining: 0,
             commission: 0, timestamp_ns: 0,
+            cum_qty: 10, avg_price: 100 * PRICE_SCALE,
         });
         ss.orders.push_fill(Fill {
             instrument: 0, order_id: 2, side: Side::Sell,
             price: 101 * PRICE_SCALE, qty: 5, remaining: 0,
             commission: 0, timestamp_ns: 0,
+            cum_qty: 5, avg_price: 101 * PRICE_SCALE,
         });
         let fills = ss.orders.drain_fills();
         assert_eq!(fills.len(), 2);

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -848,12 +848,17 @@ impl ClientCore {
                 } else {
                     info.contract
                 };
+                // The order carries its own filled quantity; reporting zero
+                // here made a partially filled order that this client did not
+                // place read as untouched.
+                let filled = info.order.filled_quantity;
+                let remaining = (info.order.total_quantity - filled).max(0.0);
                 result.push((oid, TrackedOrder {
                     contract,
                     order: info.order,
                     status: info.order_state.status.clone(),
-                    filled: 0.0,
-                    remaining: 0.0,
+                    filled,
+                    remaining,
                     instrument: 0,
                 }));
             }
@@ -1633,6 +1638,32 @@ impl ClientCore {
 mod tests {
     use super::*;
     use crate::types::SmartComponent;
+
+    /// An order this client did not place still arrives through the shared
+    /// cache, and it carries its own filled quantity. Reporting zero made a
+    /// partially filled order read as untouched to anything polling
+    /// `req_open_orders`.
+    #[test]
+    fn a_shared_order_reports_its_filled_quantity() {
+        let shared = SharedState::new();
+        let core = ClientCore::new();
+        let mut order = crate::api::types::Order::default();
+        order.total_quantity = 10.0;
+        order.filled_quantity = 4.0;
+        let mut order_state = crate::api::types::OrderState::default();
+        order_state.status = "Submitted".to_string();
+        shared.orders.push_order_info(55, crate::bridge::RichOrderInfo {
+            contract: crate::api::types::Contract::default(),
+            order,
+            order_state,
+            last_exec: crate::api::types::Execution::default(),
+        });
+
+        let open = core.collect_open_orders(&shared);
+        let (_, tracked) = open.iter().find(|(id, _)| *id == 55).expect("the shared order");
+        assert_eq!(tracked.filled, 4.0, "the filled quantity it carries");
+        assert_eq!(tracked.remaining, 6.0, "and what is left of the order");
+    }
 
     fn shared_with_components(comps: Vec<(i32, &str)>) -> SharedState {
         let s = SharedState::new();

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -894,6 +894,13 @@ impl Context {
         self.market.register(con_id)
     }
 
+    /// Register without panicking when the instrument table is full. Inbound
+    /// message handling must use this — a full table is a condition to report,
+    /// not one to abort the engine on.
+    pub fn try_register_instrument(&mut self, con_id: i64) -> Option<InstrumentId> {
+        self.market.try_register(con_id)
+    }
+
     pub fn set_symbol(&mut self, id: InstrumentId, symbol: String) {
         self.market.set_symbol(id, symbol);
     }

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -843,6 +843,26 @@ impl CcpState {
         let last_px = parsed.get(&31).and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
         let last_shares = parsed.get(&32).and_then(|s| s.parse::<i64>().ok()).unwrap_or(0);
         let leaves_qty = parsed.get(&151).and_then(|s| s.parse::<i64>().ok()).unwrap_or(0);
+        // 14 CumQty and 6 AvgPx describe the order as a whole; 32 and 31
+        // describe this print alone. The gateway sends all four on every
+        // execution report.
+        //
+        // When the cumulative quantity is absent, the print alone is not a
+        // substitute: on the second fill of an order it is smaller than what
+        // was already reported, so `filled` would go backwards. Add the print
+        // to what the order has already accumulated instead. The average price
+        // is not reconstructible that way, so it falls back to the print — and
+        // a negative average is a real value for a spread, so only an absent
+        // or unparseable tag falls back at all.
+        let order_cum_qty = parsed.get(&14).and_then(|s| s.parse::<f64>().ok())
+            .map(|q| q as i64)
+            .filter(|q| *q > 0)
+            .unwrap_or_else(|| {
+                context.order(clord_id).map_or(last_shares, |o| o.filled as i64 + last_shares)
+            });
+        let order_avg_px = parsed.get(&6)
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(last_px);
         let commission = parsed.get(&12).and_then(|s| s.parse::<f64>().ok()).unwrap_or(0.0);
 
         if ord_status == "8" {
@@ -926,6 +946,8 @@ impl CcpState {
                         remaining: leaves_qty,
                         commission: (commission * PRICE_SCALE as f64) as i64,
                         timestamp_ns: context.now_ns(),
+                        cum_qty: order_cum_qty,
+                        avg_price: (order_avg_px * PRICE_SCALE as f64) as i64,
                     };
                     let delta = match side {
                         Side::Buy => last_shares,
@@ -2278,6 +2300,114 @@ mod tests {
             context.position(fills[0].instrument), 5,
             "the position must move by the filled quantity",
         );
+    }
+
+    /// The cumulative pair has to come off the wire. Tag 14 is the order's
+    /// filled total and tag 6 its volume-weighted average; 32 and 31 describe
+    /// only the print that triggered the report.
+    #[test]
+    fn the_fill_carries_the_orders_totals_not_the_prints() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        // Second print of 5 at 101, taking the order to 12 filled at 100.50.
+        let frame = untracked_fill(&[
+            (32, "5"), (31, "101.00"), (14, "12"), (6, "100.50"), (151, "3"), (39, "1"),
+        ]);
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        let fills = shared.orders.drain_fills();
+        assert_eq!(fills.len(), 1);
+        assert_eq!(fills[0].qty, 5, "qty stays the print");
+        assert_eq!(fills[0].price, 101 * PRICE_SCALE, "price stays the print");
+        assert_eq!(fills[0].cum_qty, 12, "cum_qty is the order total from tag 14");
+        assert_eq!(
+            fills[0].avg_price, 100 * PRICE_SCALE + PRICE_SCALE / 2,
+            "avg_price is the volume-weighted average from tag 6",
+        );
+    }
+
+    /// Without tag 14 the print alone is not a substitute: on a later fill it
+    /// is smaller than what was already reported, so `filled` would go
+    /// backwards. The order's own accumulated quantity carries it instead.
+    #[test]
+    fn a_missing_cumulative_quantity_does_not_walk_backwards() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+
+        // Seven filled so far, stated.
+        ccp.handle_exec_report(
+            &exec_report_frame(&[
+                (150, "2"), (39, "1"), (32, "7"), (31, "100.00"), (14, "7"), (6, "100.00"),
+                (151, "3"), (17, "E1"),
+            ]),
+            &mut context, &shared, &None, "",
+        );
+        let first = shared.orders.drain_fills();
+        assert_eq!(first[0].cum_qty, 7);
+
+        // One more, with the cumulative fields absent.
+        ccp.handle_exec_report(
+            &exec_report_frame(&[
+                (150, "2"), (39, "1"), (32, "1"), (31, "101.00"), (151, "2"), (17, "E2"),
+            ]),
+            &mut context, &shared, &None, "",
+        );
+        let second = shared.orders.drain_fills();
+        assert_eq!(
+            second[0].cum_qty, 8,
+            "the order's own total carries it, rather than dropping back to the print",
+        );
+    }
+
+    /// A negative average price is a real value for a spread quoted as a net
+    /// credit, so only an absent or unparseable tag falls back.
+    #[test]
+    fn a_negative_average_price_is_not_treated_as_absent() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = untracked_fill(&[(32, "5"), (31, "-2.00"), (14, "5"), (6, "-1.50")]);
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        let fills = shared.orders.drain_fills();
+        assert_eq!(fills[0].avg_price, -(PRICE_SCALE + PRICE_SCALE / 2), "-1.50 is kept");
+    }
+
+    /// With no order to accumulate against and no tags, the print is all there
+    /// is — which is what the callback reported before.
+    #[test]
+    fn the_fill_falls_back_to_the_print_when_the_totals_are_absent() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = untracked_fill(&[(32, "5"), (31, "101.00"), (14, ""), (6, "")]);
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        let fills = shared.orders.drain_fills();
+        assert_eq!(fills.len(), 1);
+        assert_eq!(fills[0].cum_qty, 5);
+        assert_eq!(fills[0].avg_price, 101 * PRICE_SCALE);
+    }
+
+    /// The side mapping is the whole sign of the position delta, so every arm
+    /// is pinned — a short sale booked as an ordinary sell is the same
+    /// direction, but a buy booked as a sell is twice the fill in the wrong one.
+    #[test]
+    fn every_side_maps_to_the_right_position_delta() {
+        for (tag54, expected_side, expected_delta) in [
+            ("1", Side::Buy, 5),
+            ("2", Side::Sell, -5),
+            ("5", Side::ShortSell, -5),
+        ] {
+            let (mut ccp, mut context, shared) = ord_status_test_state();
+            ccp.handle_exec_report(
+                &untracked_fill(&[(54, tag54)]), &mut context, &shared, &None, "",
+            );
+            let fills = shared.orders.drain_fills();
+            assert_eq!(fills.len(), 1, "Side={tag54} books");
+            assert_eq!(fills[0].side, expected_side, "Side={tag54}");
+            assert_eq!(
+                context.position(fills[0].instrument), expected_delta,
+                "Side={tag54} moves the position {expected_delta}",
+            );
+        }
     }
 
     /// A sell books the other way. Taking the side from the report rather than

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -16,6 +16,52 @@ use crossbeam_channel::Sender;
 
 use super::{HeartbeatState, emit, clone_for_event, parse_price_tag, decode_tif};
 
+/// Where to book a fill whose order this session does not track.
+///
+/// Both the contract and the side come off the report, and both are required:
+/// a guessed side would move the position the wrong way, which is worse than
+/// reporting that the fill could not be placed.
+fn untracked_fill_target(
+    context: &mut Context,
+    parsed: &std::collections::HashMap<u32, String>,
+) -> Option<(InstrumentId, Side)> {
+    // A replayed execution restates history rather than reporting something
+    // new. On a fresh process the gateway resends prior fills with 97=Y and
+    // their original ExecIDs, for orders no session tracks; booking those
+    // would build a position out of the past on top of the one the position
+    // feed already reports. Within a process the ExecID window catches the
+    // reconnect burst, so only the untracked case needs this.
+    let replayed = |tag| parsed.get(&tag).map(|v| v.eq_ignore_ascii_case("Y")).unwrap_or(false);
+    if replayed(97) || replayed(43) {
+        log::debug!("Untracked fill is a replay, leaving the position alone");
+        return None;
+    }
+    let con_id: i64 = parsed.get(&6008).and_then(|s| s.parse().ok()).unwrap_or(0);
+    if con_id == 0 {
+        log::warn!("Untracked fill carries no ContractID, position not updated");
+        return None;
+    }
+    let side = match parsed.get(&54).map(|s| s.as_str()) {
+        Some("1") => Side::Buy,
+        Some("2") => Side::Sell,
+        Some("5") => Side::ShortSell,
+        other => {
+            log::warn!("Untracked fill has Side={:?}, position not updated", other);
+            return None;
+        }
+    };
+    // Fallible: a full instrument table must not abort the engine on an
+    // inbound message.
+    let Some(instrument) = context.try_register_instrument(con_id) else {
+        log::warn!("Untracked fill for conId {con_id}: instrument table full, position not updated");
+        return None;
+    };
+    if let Some(symbol) = parsed.get(&55) {
+        context.set_symbol(instrument, symbol.clone());
+    }
+    Some((instrument, side))
+}
+
 /// Bound for an in-flight contract-details request (secdef reply or
 /// per-exchange fan-out). Refreshed on fan-out activity; on expiry the
 /// request surfaces error 200 + contract_details_end instead of hanging
@@ -848,32 +894,50 @@ impl CcpState {
 
         let mut had_fill = false;
         if matches!(exec_type, "F" | "1" | "2") && last_shares > 0 {
-            if !exec_id.is_empty() && !self.record_exec_id(exec_id) {
-                log::warn!("Duplicate ExecID={} — skipping fill", exec_id);
-                return;
-            }
-            if let Some(order) = context.order(clord_id).copied() {
-                context.update_order_filled(clord_id, last_shares as u32);
-                let fill = Fill {
-                    instrument: order.instrument,
-                    order_id: clord_id,
-                    side: order.side,
-                    price: (last_px * PRICE_SCALE as f64) as i64,
-                    qty: last_shares,
-                    remaining: leaves_qty,
-                    commission: (commission * PRICE_SCALE as f64) as i64,
-                    timestamp_ns: context.now_ns(),
-                };
-                let delta = match order.side {
-                    Side::Buy => last_shares,
-                    Side::Sell | Side::ShortSell => -last_shares,
-                };
-                context.update_position(order.instrument, delta);
-                // notify_fill inlined
-                shared.orders.push_fill(fill);
-                shared.portfolio.set_position(fill.instrument, context.position(fill.instrument));
-                emit(event_tx, Event::Fill(fill));
-                had_fill = true;
+            // A fill can arrive for an order this session does not track: one
+            // that raced its own cancel-ack out of the book, one placed from
+            // another client, or one left from an earlier session. The report
+            // names the contract and the side, so book it from that rather
+            // than dropping a position the account actually holds.
+            let booked = match context.order(clord_id).copied() {
+                Some(order) => Some((order.instrument, order.side)),
+                None => untracked_fill_target(context, parsed),
+            };
+            match booked {
+                // The reason is logged where it is decided — the causes are
+                // distinct and a single message would misdiagnose three of them.
+                None => {}
+                Some((instrument, side)) => {
+                    // Recorded only once the fill can be booked, so one that
+                    // could not be stays replayable rather than being burnt.
+                    if !exec_id.is_empty() && !self.record_exec_id(exec_id) {
+                        log::warn!("Duplicate ExecID={} — skipping fill", exec_id);
+                        return;
+                    }
+                    // No-op when the order is untracked, which is the case
+                    // that reaches here through the fallback.
+                    context.update_order_filled(clord_id, last_shares as u32);
+                    let fill = Fill {
+                        instrument,
+                        order_id: clord_id,
+                        side,
+                        price: (last_px * PRICE_SCALE as f64) as i64,
+                        qty: last_shares,
+                        remaining: leaves_qty,
+                        commission: (commission * PRICE_SCALE as f64) as i64,
+                        timestamp_ns: context.now_ns(),
+                    };
+                    let delta = match side {
+                        Side::Buy => last_shares,
+                        Side::Sell | Side::ShortSell => -last_shares,
+                    };
+                    context.update_position(instrument, delta);
+                    // notify_fill inlined
+                    shared.orders.push_fill(fill);
+                    shared.portfolio.set_position(fill.instrument, context.position(fill.instrument));
+                    emit(event_tx, Event::Fill(fill));
+                    had_fill = true;
+                }
             }
         }
 
@@ -2166,6 +2230,130 @@ mod tests {
             42, instrument, Side::Buy, 1, 100 * PRICE_SCALE, b'2', b'0', 0,
         )); // starts at PendingSubmit
         (CcpState::new(), context, SharedState::new())
+    }
+
+    /// A fill whose ClOrdID this session never tracked. Every field the engine
+    /// needs to book it is on the report itself.
+    fn untracked_fill(pairs: &[(u32, &str)]) -> std::collections::HashMap<u32, String> {
+        let mut m = std::collections::HashMap::new();
+        for (tag, val) in [
+            (11u32, "99"),      // ClOrdID the context does not know
+            (150, "2"),         // ExecType: trade
+            (39, "2"),          // OrdStatus: filled
+            (32, "5"),          // LastShares
+            (31, "100.00"),     // LastPx
+            (54, "1"),          // Side: buy
+            (6008, "888888"),   // ContractID
+            (55, "ZZZ"),
+            (17, "EXEC-1"),
+        ] {
+            m.insert(tag, val.to_string());
+        }
+        for (tag, val) in pairs {
+            if val.is_empty() {
+                m.remove(tag);
+            } else {
+                m.insert(*tag, val.to_string());
+            }
+        }
+        m
+    }
+
+    /// A fill for an order this session does not track is still a position the
+    /// account holds. Dropping it leaves the engine short of the truth with
+    /// nothing to say so — the cancel/fill race reaches this every time.
+    #[test]
+    fn a_fill_for_an_untracked_order_is_still_booked() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = untracked_fill(&[]);
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        let fills = shared.orders.drain_fills();
+        assert_eq!(fills.len(), 1, "the fill must be reported");
+        assert_eq!(fills[0].qty, 5);
+        assert_eq!(fills[0].order_id, 99);
+        assert_eq!(fills[0].side, Side::Buy);
+        assert_eq!(
+            context.position(fills[0].instrument), 5,
+            "the position must move by the filled quantity",
+        );
+    }
+
+    /// A sell books the other way. Taking the side from the report rather than
+    /// defaulting is the whole point: the wrong sign is worse than no fill.
+    #[test]
+    fn an_untracked_sell_moves_the_position_down() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = untracked_fill(&[(54, "2")]);
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        let fills = shared.orders.drain_fills();
+        assert_eq!(fills.len(), 1);
+        assert_eq!(fills[0].side, Side::Sell);
+        assert_eq!(context.position(fills[0].instrument), -5);
+    }
+
+    /// Without a contract or a side there is nothing to book against, and
+    /// guessing either one would move a real position the wrong way.
+    #[test]
+    fn an_untracked_fill_is_not_booked_on_a_guess() {
+        for missing in [6008u32, 54] {
+            let (mut ccp, mut context, shared) = ord_status_test_state();
+            let frame = untracked_fill(&[(missing, "")]);
+
+            ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+            assert!(
+                shared.orders.drain_fills().is_empty(),
+                "tag {missing} missing: must not book a guessed fill",
+            );
+        }
+    }
+
+    /// On a fresh process the gateway resends prior executions with 97=Y and
+    /// their original ExecIDs, for orders no session tracks. Booking those
+    /// builds a position out of history on top of the one the position feed
+    /// already reports.
+    #[test]
+    fn a_replayed_execution_is_not_booked_as_a_new_position() {
+        for (tag, name) in [(97u32, "PossResend"), (43, "PossDupFlag")] {
+            let (mut ccp, mut context, shared) = ord_status_test_state();
+
+            ccp.handle_exec_report(&untracked_fill(&[(tag, "Y")]), &mut context, &shared, &None, "");
+
+            assert!(
+                shared.orders.drain_fills().is_empty(),
+                "{name}=Y restates history and must not move the position",
+            );
+        }
+
+        // The same report without the marker is booked, so the guard is the
+        // marker and not something else about the frame.
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        ccp.handle_exec_report(&untracked_fill(&[(97, "N")]), &mut context, &shared, &None, "");
+        assert_eq!(shared.orders.drain_fills().len(), 1);
+    }
+
+    /// An execution that could not be booked must stay replayable. Consuming
+    /// the ExecID for a fill that was dropped makes the loss permanent: the
+    /// replay after a reconnect is then rejected as a duplicate.
+    #[test]
+    fn an_unbookable_fill_does_not_consume_its_exec_id() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+
+        // Same execution, first seen without the contract that would let the
+        // engine place it.
+        ccp.handle_exec_report(&untracked_fill(&[(6008, "")]), &mut context, &shared, &None, "");
+        assert!(shared.orders.drain_fills().is_empty());
+
+        // Replayed in full — it must not be rejected as already seen.
+        ccp.handle_exec_report(&untracked_fill(&[]), &mut context, &shared, &None, "");
+        assert_eq!(
+            shared.orders.drain_fills().len(), 1,
+            "the replay must be booked, not dropped as a duplicate",
+        );
     }
 
     fn exec_report_frame(pairs: &[(u32, &str)]) -> std::collections::HashMap<u32, String> {

--- a/src/engine/hot_loop/mod.rs
+++ b/src/engine/hot_loop/mod.rs
@@ -1537,6 +1537,7 @@ mod tests {
             remaining: 0,
             commission: 1_00000000,
             timestamp_ns: 0,
+            cum_qty: 100, avg_price: 150_00000000,
         };
         engine.inject_fill(&fill);
         assert_eq!(engine.context_mut().position(0), 100);

--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -60,8 +60,11 @@ impl EClient {
             let (perm_id, parent_id) = shared.orders.get_order_info(fill.order_id)
                 .map(|info| (info.order.perm_id, info.order.parent_id))
                 .unwrap_or((0, 0));
-            call_wrapper!(self.wrapper, py, "order_status", (fill.order_id as i64, status, fill.qty as f64, fill.remaining as f64,
-                 price, perm_id, parent_id, price, 0i64, "", 0.0f64));
+            // `filled` and `avgFillPrice` describe the order so far;
+            // `lastFillPrice` describes this print.
+            let avg_price = fill.avg_price as f64 / PRICE_SCALE_F;
+            call_wrapper!(self.wrapper, py, "order_status", (fill.order_id as i64, status, fill.cum_qty as f64, fill.remaining as f64,
+                 avg_price, perm_id, parent_id, price, 0i64, "", 0.0f64));
 
             // Track execution for req_executions
             let exec_id = format!("{}.{}", fill.order_id, fill.timestamp_ns);
@@ -140,7 +143,7 @@ impl EClient {
             call_wrapper!(self.wrapper, py, "exec_details", (req_id, &c_py, &exec_py));
 
             // Update open order tracking
-            self.core.update_order_fill(fill.order_id, status, fill.qty as f64, fill.remaining as f64);
+            self.core.update_order_fill(fill.order_id, status, fill.cum_qty as f64, fill.remaining as f64);
 
             // Dispatch commission_and_fees_report
             let report = CommissionAndFeesReport {

--- a/src/python/compat/client/test_helpers.rs
+++ b/src/python/compat/client/test_helpers.rs
@@ -95,6 +95,8 @@ impl EClient {
             price: (price * ps) as i64, qty, remaining,
             commission: (commission * ps) as i64,
             timestamp_ns: 100,
+            // Single-print injection: the order total is this print.
+            cum_qty: qty, avg_price: (price * ps) as i64,
         });
         Ok(())
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -154,6 +154,11 @@ pub struct Fill {
     pub remaining: i64,
     pub commission: Price,
     pub timestamp_ns: u64,
+    /// FIX tag 14 CumQty — filled across the whole order, not this print.
+    pub cum_qty: i64,
+    /// FIX tag 6 AvgPx — volume-weighted across every print of this order.
+    /// `price` is this print alone.
+    pub avg_price: Price,
 }
 
 /// Order status change notification.
@@ -1988,6 +1993,7 @@ mod tests {
             remaining: 0,
             commission: 0,
             timestamp_ns: 123456789,
+            cum_qty: 100, avg_price: 150 * PRICE_SCALE,
         };
         let f2 = f; // Copy
         assert_eq!(f.order_id, f2.order_id);

--- a/tests/hot_loop_lifecycle.rs
+++ b/tests/hot_loop_lifecycle.rs
@@ -34,6 +34,7 @@ fn full_lifecycle() {
         remaining: 0,
         commission: 0,
         timestamp_ns: 0,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     };
     engine.inject_fill(&fill);
 

--- a/tests/scenarios.rs
+++ b/tests/scenarios.rs
@@ -55,6 +55,7 @@ fn order_lifecycle_partial_then_full_fill() {
         instrument: 0, order_id: 100, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 120, remaining: 80,
         commission: PRICE_SCALE / 2, timestamp_ns: 2000,
+        cum_qty: 120, avg_price: 150 * PRICE_SCALE,
     });
     w.events.clear();
     client.process_msgs(&mut w);
@@ -66,6 +67,7 @@ fn order_lifecycle_partial_then_full_fill() {
         instrument: 0, order_id: 100, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 80, remaining: 0,
         commission: PRICE_SCALE / 2, timestamp_ns: 3000,
+        cum_qty: 80, avg_price: 150 * PRICE_SCALE,
     });
     w.events.clear();
     client.process_msgs(&mut w);
@@ -133,6 +135,7 @@ fn order_lifecycle_partial_fill_then_cancel() {
         instrument: 0, order_id: 70, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 30, remaining: 70,
         commission: 0, timestamp_ns: 1000,
+        cum_qty: 30, avg_price: 150 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
@@ -176,6 +179,7 @@ fn order_lifecycle_modify_then_fill() {
         instrument: 0, order_id: 80, side: Side::Buy,
         price: 151 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 0,
+        cum_qty: 100, avg_price: 151 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
@@ -256,6 +260,7 @@ fn order_lifecycle_algo_vwap_partial_fills() {
             instrument: 0, order_id: 110, side: Side::Buy,
             price: prices[i as usize], qty: qtys[i] as i64, remaining,
             commission: PRICE_SCALE / 10, timestamp_ns: (i as u64 + 1) * 1000,
+            cum_qty: qtys[i] as i64, avg_price: prices[i as usize],
         });
     }
 
@@ -283,6 +288,7 @@ fn order_lifecycle_cancel_reject_on_filled_order() {
         instrument: 0, order_id: 120, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: 0, timestamp_ns: 1000,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
     let mut w = RecordingWrapper::default();
     client.process_msgs(&mut w);
@@ -416,6 +422,7 @@ fn account_round_trip_position() {
         instrument: spy_id, order_id: 1, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 1000,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
     assert_eq!(engine.context_mut().position(spy_id), 100);
     assert_eq!(shared.portfolio.position(spy_id), 100);
@@ -425,6 +432,7 @@ fn account_round_trip_position() {
         instrument: spy_id, order_id: 2, side: Side::Sell,
         price: 152 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 2000,
+        cum_qty: 100, avg_price: 152 * PRICE_SCALE,
     });
     assert_eq!(engine.context_mut().position(spy_id), 0);
     assert_eq!(shared.portfolio.position(spy_id), 0);
@@ -449,6 +457,7 @@ fn account_multi_instrument_positions() {
         instrument: spy_id, order_id: 1, side: Side::Buy,
         price: 450 * PRICE_SCALE, qty: 50, remaining: 0,
         commission: 0, timestamp_ns: 1000,
+        cum_qty: 50, avg_price: 450 * PRICE_SCALE,
     });
 
     // Buy 100 AAPL
@@ -456,6 +465,7 @@ fn account_multi_instrument_positions() {
         instrument: aapl_id, order_id: 2, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: 0, timestamp_ns: 2000,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
 
     // Sell 20 SPY
@@ -463,6 +473,7 @@ fn account_multi_instrument_positions() {
         instrument: spy_id, order_id: 3, side: Side::Sell,
         price: 452 * PRICE_SCALE, qty: 20, remaining: 0,
         commission: 0, timestamp_ns: 3000,
+        cum_qty: 20, avg_price: 452 * PRICE_SCALE,
     });
 
     assert_eq!(engine.context_mut().position(spy_id), 30);
@@ -678,6 +689,7 @@ fn engine_full_trade_lifecycle() {
         instrument: spy_id, order_id: 1, side: Side::Buy,
         price: 450 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 1000,
+        cum_qty: 100, avg_price: 450 * PRICE_SCALE,
     });
     assert_eq!(engine.context_mut().position(spy_id), 100);
 
@@ -692,6 +704,7 @@ fn engine_full_trade_lifecycle() {
         instrument: spy_id, order_id: 2, side: Side::Sell,
         price: 455 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 2000,
+        cum_qty: 100, avg_price: 455 * PRICE_SCALE,
     });
     assert_eq!(engine.context_mut().position(spy_id), 0);
 
@@ -732,6 +745,7 @@ fn engine_to_eclient_end_to_end() {
         instrument: spy_id, order_id: 42, side: Side::Buy,
         price: 450 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: PRICE_SCALE, timestamp_ns: 1000,
+        cum_qty: 100, avg_price: 450 * PRICE_SCALE,
     });
 
     // Process — should see fill
@@ -753,6 +767,7 @@ fn engine_short_sell_then_cover() {
         instrument: spy_id, order_id: 1, side: Side::ShortSell,
         price: 450 * PRICE_SCALE, qty: 50, remaining: 0,
         commission: 0, timestamp_ns: 1000,
+        cum_qty: 50, avg_price: 450 * PRICE_SCALE,
     });
     assert_eq!(engine.context_mut().position(spy_id), -50);
 
@@ -761,6 +776,7 @@ fn engine_short_sell_then_cover() {
         instrument: spy_id, order_id: 2, side: Side::Buy,
         price: 445 * PRICE_SCALE, qty: 50, remaining: 0,
         commission: 0, timestamp_ns: 2000,
+        cum_qty: 50, avg_price: 445 * PRICE_SCALE,
     });
     assert_eq!(engine.context_mut().position(spy_id), 0);
 }
@@ -786,6 +802,7 @@ fn mixed_ticks_during_fills() {
         instrument: 0, order_id: 42, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: 0, timestamp_ns: 0,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
 
     // Order update arrives at same time
@@ -830,6 +847,7 @@ fn mixed_news_between_orders() {
         instrument: 0, order_id: 50, side: Side::Buy,
         price: 150 * PRICE_SCALE, qty: 100, remaining: 0,
         commission: 0, timestamp_ns: 2000,
+        cum_qty: 100, avg_price: 150 * PRICE_SCALE,
     });
 
     let mut w = RecordingWrapper::default();
@@ -856,6 +874,7 @@ fn mixed_all_data_types_single_process() {
         instrument: 0, order_id: 1, side: Side::Buy,
         price: PRICE_SCALE, qty: 1, remaining: 0,
         commission: 0, timestamp_ns: 0,
+        cum_qty: 1, avg_price: PRICE_SCALE,
     });
 
     // TBT trade


### PR DESCRIPTION
> Stacked on #322. The first commit is that PR; review this one from its second commit.

## Summary

- `order_status` was given the size and price of the print that triggered it, where the callback's contract asks for the order as a whole. Argument 3 (`filled`) received the print's quantity and argument 5 (`avgFillPrice`) its price. Argument 8, `lastFillPrice`, received the same price — the one place it belonged.
- IB's contract is `filled` cumulative, `avgFillPrice` volume-weighted across every print, `lastFillPrice` this print.
- A 300-share order filling in three 100-share prints should report `filled=100 avg=P1 → filled=200 avg=(P1+P2)/2 → filled=300 avg=VWAP`. It reported `filled=100` three times, at three different prices each presented as the average.
- Any average-cost or P&L calculation reading `avgFillPrice` is wrong whenever an order fills in more than one print, which above a round lot is most of the time. `filled` never reaches the order quantity, so completion detection on that field never fires.

Closes #315.

## Change

The gateway sends both numbers on every execution report — CumQty (14) and AvgPx (6). They were already parsed, but only into the execution record, never into the status callback.

They now travel on the fill itself. Reading them from the order cache at dispatch time would have been a smaller change, but a second print arriving between the push and the drain would report its cumulative against the earlier fill; carrying them with the event keeps each one self-consistent. A report that omits either field falls back to the print, which is what the callback reported before.

## Every consumer, not just the one the issue named

- **Python compat client** — dispatches the same drained fill through its own `order_status` and had the identical pair.
- **Open-order snapshot** — both clients stored the print as the order's filled quantity, so after a partial fill the push callback said `filled=200` while `reqOpenOrders` said `filled=100` for the same order.

## Tests

One end-to-end assertion pins the whole callback string, so it covers `filled` and `avgFillPrice` together:

```
order_status:42:PartiallyFilled:200:100:150.5
```

Reverting the dispatch produces `...:100:100:151`, which is the reported bug exactly. Two more tests drive an execution report through the handler and assert the drained fill's cumulative pair comes off tags 14 and 6 rather than 32 and 31, and that it falls back to the print when neither is present.

## Test plan

- [x] `cargo test --offline --lib` — 814 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

