### PR TITLE
orders: keep the sign when a price has no whole part (ibx#332)

### DIFF
--- a/src/engine/hot_loop/mod.rs
+++ b/src/engine/hot_loop/mod.rs
@@ -1299,6 +1299,12 @@ pub(crate) fn format_price(price: Price) -> StackStr {
     let whole = price / PRICE_SCALE;
     let frac = (price % PRICE_SCALE).unsigned_abs();
     let mut s = StackStr::new();
+    // Division truncates toward zero, so a price in (-1, 0) has a whole part
+    // of 0 and carries its sign only in the fraction. Writing the integer
+    // alone would turn -0.35 into 0.35.
+    if price < 0 && whole == 0 {
+        s.push(b'-');
+    }
     s.write_i64(whole);
     if frac != 0 {
         s.push(b'.');
@@ -1669,7 +1675,35 @@ mod tests {
         assert!(hist[0].1.bars.is_empty());
     }
 
+    /// A price between -1 and 0 has a whole part of 0, so the sign lives only
+    /// in the fraction. Writing the integer alone turns a credit into a debit —
+    /// the same number with the opposite meaning, and nothing rejects it.
     #[test]
+    fn format_price_keeps_the_sign_below_one() {
+        let p = |v: f64| format_price((v * PRICE_SCALE as f64) as Price).to_string();
+        assert_eq!(p(-0.35), "-0.35");
+        assert_eq!(p(-0.5), "-0.5");
+        assert_eq!(p(-0.01), "-0.01");
+        // Either side of the boundary, and the cases that already worked.
+        assert_eq!(p(-1.5), "-1.5");
+        assert_eq!(p(-1.0), "-1");
+        assert_eq!(p(0.0), "0");
+        assert_eq!(p(0.35), "0.35");
+        assert_eq!(p(1.5), "1.5");
+        assert_eq!(p(737.53), "737.53");
+
+        // Raw fixed-point units, so the boundary is pinned at the smallest
+        // representable tick rather than only at prices a float can express.
+        // A guard that fires slightly too late still formats these positive.
+        let raw = |v: Price| format_price(v).to_string();
+        assert_eq!(raw(-1), "-0.00000001", "the smallest negative tick keeps its sign");
+        assert_eq!(raw(-PRICE_SCALE + 1), "-0.99999999", "just inside the interval");
+        assert_eq!(raw(-PRICE_SCALE), "-1", "the boundary itself");
+        assert_eq!(raw(-PRICE_SCALE - 1), "-1.00000001", "just outside it");
+        assert_eq!(raw(0), "0");
+        assert_eq!(raw(1), "0.00000001");
+    }
+
     // ibx#218: the CCP/farm ladder — floor 2s, ladder 0/5/15/30/50/60s,
     // jitter range growing 5s -> 20s, ceiling 82s.
     #[test]


### PR DESCRIPTION
## Summary

- `format_price` writes the integer and fractional parts separately. Integer division truncates toward zero, so any price strictly between -1 and 0 has a whole part of `0`, and `unsigned_abs` has already stripped the sign from the fraction.
- Nothing wrote the minus. `-0.35` went out as `0.35`.
- Outside that band the sign survives, because it lives in the whole part — `-1.5` was always correct. Only the interval where the integer rounds away was wrong.

Closes #332.

## Why it matters

The result is the right magnitude with the wrong sign — a credit stated as a debit. There is nothing malformed for the gateway to reject; it is a valid price for the opposite side of the trade.

This is the single price formatter on the order path, reached from 67 call sites: limit and stop prices, bracket entry and exit legs, trailing amounts and limit offsets, adjusted stop and stop-limit prices, the discretionary amount and the cash quantity.

Prices in that band are ordinary wherever a net price can be negative — a spread quoted as a net credit under a dollar sits exactly there. Submission is restricted to `STK` today, which keeps most of them out of reach, but the formatter is shared and that restriction is not what makes it correct.

## Test

Pins both sides of the boundary: `-1.5`, `-1.0`, `-0.35`, `-0.01`, `0`, and the positive cases. Dropping the guard fails it with `0.35` where `-0.35` was expected.

## Test plan

- [x] `cargo test --offline --lib` — 802 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

