### PR TITLE
orders: move the trigger when a stop order is modified (ibx#324)

### DIFF
--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -38,6 +38,7 @@ impl EClient {
                 order_id: oid,
                 price,
                 qty,
+                outside_rth: order.outside_rth,
             })
         } else {
             ClientCore::build_order_request(order, oid, instrument)?

--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -33,12 +33,17 @@ impl EClient {
         let cmd = if self.core.is_order_tracked(oid) {
             let price = (order.lmt_price * PRICE_SCALE_F) as i64;
             let qty = order.total_quantity as u32;
+            // A stop's trigger rides on aux_price, exactly as it does on the
+            // submit path. Reading only lmt_price left a stop order modifying
+            // itself to a limit price of zero.
+            let stop_price = (order.aux_price * PRICE_SCALE_F) as i64;
             ControlCommand::Order(OrderRequest::Modify {
                 new_order_id: oid,
                 order_id: oid,
                 price,
                 qty,
                 outside_rth: order.outside_rth,
+                stop_price,
             })
         } else {
             ClientCore::build_order_request(order, oid, instrument)?

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -31,6 +31,31 @@ fn spy() -> Contract {
 //  Algo parsing
 // ═══════════════════════════════════════════════════════════════════
 
+/// Re-placing a tracked id is a modify, and a stop order's price lives in
+/// `aux_price`. Reading only `lmt_price` sent a limit price of zero for an
+/// order that has no limit leg, which the gateway rejects outright.
+#[test]
+fn modifying_a_stop_carries_the_new_trigger() {
+    let (client, rx, _shared) = test_client();
+    let stop = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "STP".into(),
+        aux_price: 600.0, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9201, &spy(), &stop).unwrap();
+    rx.try_recv().expect("the submit");
+
+    let moved = Order { aux_price: 610.0, ..stop };
+    client.place_order(9201, &spy(), &moved).unwrap();
+
+    match rx.try_recv().expect("the modify") {
+        ControlCommand::Order(OrderRequest::Modify { stop_price, .. }) => assert_eq!(
+            stop_price, (610.0 * PRICE_SCALE_F) as i64,
+            "the new trigger must reach the request",
+        ),
+        other => panic!("expected a Modify, got {other:?}"),
+    }
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -393,6 +393,42 @@ fn place_order_adjustable_trail_carries_trailing_amount_and_unit() {
 }
 
 #[test]
+fn modify_carries_outside_rth_from_the_resubmitted_order() {
+    // ibx#247: the replace asserted 6433=1 unconditionally, so an order placed
+    // with outside_rth=false came back outside-RTH after any modify. The flag
+    // has to travel with the modify, since the tracked record has no field for
+    // it.
+    let (client, rx, shared) = test_client();
+    shared.market.set_instrument_count(1);
+    let order = Order {
+        action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+        lmt_price: 100.0, outside_rth: false, ..Default::default()
+    };
+    client.place_order(70, &spy(), &order).unwrap();
+    let _submit = rx.try_recv().unwrap();
+
+    // Same id -> modify. Caller still says outside_rth=false.
+    let reprice = Order { lmt_price: 101.0, ..order.clone() };
+    client.place_order(70, &spy(), &reprice).unwrap();
+    match rx.try_recv().unwrap() {
+        ControlCommand::Order(OrderRequest::Modify { outside_rth, .. }) => {
+            assert!(!outside_rth, "a modify must not opt the order into the extended session");
+        }
+        cmd => panic!("expected Modify, got {:?}", cmd),
+    }
+
+    // And it survives when the caller does want it.
+    let rth_out = Order { lmt_price: 102.0, outside_rth: true, ..order.clone() };
+    client.place_order(70, &spy(), &rth_out).unwrap();
+    match rx.try_recv().unwrap() {
+        ControlCommand::Order(OrderRequest::Modify { outside_rth, .. }) => {
+            assert!(outside_rth, "an explicit outside_rth=true must reach the replace");
+        }
+        cmd => panic!("expected Modify, got {:?}", cmd),
+    }
+}
+
+#[test]
 fn place_order_adjustable_trail_percent_unit_passes_through() {
     // Percent unit (100) must survive; the trailing amount is a percent value.
     let (client, rx, shared) = test_client();

--- a/src/bin/bench_order_modify.rs
+++ b/src/bin/bench_order_modify.rs
@@ -113,6 +113,7 @@ fn main() {
             qty: 1,
             // Matches the outside_rth=true the order was placed with above.
             outside_rth: true,
+            stop_price: 0,
         });
 
         // Wait for ack on new_order_id

--- a/src/bin/bench_order_modify.rs
+++ b/src/bin/bench_order_modify.rs
@@ -111,6 +111,8 @@ fn main() {
             order_id: current_order_id,
             price: new_price,
             qty: 1,
+            // Matches the outside_rth=true the order was placed with above.
+            outside_rth: true,
         });
 
         // Wait for ack on new_order_id

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -853,7 +853,9 @@ impl Context {
             .push(OrderRequest::CancelAll { instrument });
     }
 
-    pub fn modify(&mut self, order_id: OrderId, price: Price, qty: u32) -> OrderId {
+    /// `outside_rth` is asserted on the replace: the tracked record has no
+    /// field for it, so it has to come from the caller (ibx#247).
+    pub fn modify(&mut self, order_id: OrderId, price: Price, qty: u32, outside_rth: bool) -> OrderId {
         let new_id = self.next_order_id;
         self.next_order_id += 1;
         self.pending_orders.push(OrderRequest::Modify {
@@ -861,6 +863,7 @@ impl Context {
             order_id,
             price,
             qty,
+            outside_rth,
         });
         new_id
     }
@@ -1067,7 +1070,7 @@ mod tests {
     #[test]
     fn modify_drains_correctly() {
         let mut ctx = Context::new();
-        ctx.modify(7, 200 * PRICE_SCALE, 50);
+        ctx.modify(7, 200 * PRICE_SCALE, 50, false);
 
         let orders: Vec<_> = ctx.drain_pending_orders().collect();
         match orders[0] {

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -862,6 +862,9 @@ impl Context {
             new_order_id: new_id,
             order_id,
             price,
+            // Not supplied: on a trigger-only order the single price argument
+            // can only have meant the trigger, and the builder routes it there.
+            stop_price: 0,
             qty,
             outside_rth,
         });

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -1442,7 +1442,7 @@ pub(crate) fn drain_and_send_orders(
                 }
                 last_result
             }
-            OrderRequest::Modify { new_order_id, order_id, price, qty } => {
+            OrderRequest::Modify { new_order_id, order_id, price, qty, outside_rth } => {
                 let orig = context.order(order_id).copied();
                 // Modify carries no instrument; resolve it from the tracked
                 // order to snap the new price to the tick grid (ibx#216).
@@ -1491,7 +1491,15 @@ pub(crate) fn drain_and_send_orders(
                     (44, &price_str),    // Price
                     (1, account_id),     // Account
                     (6122, "c"),         // Client version
-                    (6433, "1"),         // OutsideRTH (preserve from original)
+                ];
+                // OutsideRTH, from the order the caller resubmitted rather than
+                // hard-coded: the tracked record cannot express it, and asserting
+                // 1 unconditionally opted every modified order into the extended
+                // session (ibx#247). Same position it held in the capture.
+                if outside_rth {
+                    fields.push((6433, "1"));
+                }
+                let rest: [(u32, &str); 11] = [
                     (38, &qty_str),      // OrderQty
                     (54, side_str),      // Side
                     (40, &ord_type_str), // OrdType
@@ -1504,6 +1512,7 @@ pub(crate) fn drain_and_send_orders(
                     (6211, ""),          // Empty (matches reference)
                     (6238, ""),          // Empty (matches reference)
                 ];
+                fields.extend(rest);
                 // Include stop price for order types that need it
                 let stop_str;
                 if let Some(o) = orig {
@@ -2055,5 +2064,51 @@ mod tests {
 
         assert_eq!(context.order(8).unwrap().status, OrderStatus::Filled);
         assert!(shared.orders.drain_order_updates().is_empty());
+    }
+}
+
+#[cfg(test)]
+mod modify_wire_tests {
+    use super::*;
+    use crate::protocol::connection::Connection;
+    use std::io::Read;
+
+    /// Drive the Modify arm and read what actually reaches the socket.
+    fn replace_bytes(outside_rth: bool) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = std::net::TcpStream::connect(addr).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(5))).unwrap();
+        let mut conn = Some(Connection::new_raw(client).unwrap());
+
+        let mut context = Context::new();
+        context.insert_order(crate::types::Order::new(
+            7, 0, Side::Buy, 1, 100 * crate::types::PRICE_SCALE, b'2', b'0', 0,
+        ));
+        context.modify(7, 200 * crate::types::PRICE_SCALE, 50, outside_rth);
+
+        let shared = std::sync::Arc::new(SharedState::new());
+        let mut hb = HeartbeatState::new();
+        drain_and_send_orders(&mut conn, &mut context, "DU111111", &mut hb, false, &shared);
+
+        let mut buf = [0u8; 4096];
+        let n = peer.read(&mut buf).unwrap();
+        String::from_utf8_lossy(&buf[..n]).replace('\u{1}', "|")
+    }
+
+    /// ibx#247: the replace asserted 6433=1 unconditionally, so an RTH-only
+    /// order was opted into the extended session by its first modify. Pins the
+    /// 6122/6433/38 neighbourhood in both polarities — presence and captured
+    /// position when the caller sets the flag, absence when it does not.
+    #[test]
+    fn modify_emits_outside_rth_only_when_the_caller_set_it() {
+        let on = replace_bytes(true);
+        assert!(on.contains("|6122=c|6433=1|38=50|"),
+            "6433 must keep its captured position between 6122 and 38: {}", on);
+
+        let off = replace_bytes(false);
+        assert!(!off.contains("|6433="), "an RTH-only order must not assert 6433: {}", off);
+        assert!(off.contains("|6122=c|38=50|"), "the rest of the message is unchanged: {}", off);
     }
 }

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -1442,16 +1442,49 @@ pub(crate) fn drain_and_send_orders(
                 }
                 last_result
             }
-            OrderRequest::Modify { new_order_id, order_id, price, qty, outside_rth } => {
+            OrderRequest::Modify {
+                new_order_id, order_id, price, qty, outside_rth, stop_price,
+            } => {
                 let orig = context.order(order_id).copied();
                 // Modify carries no instrument; resolve it from the tracked
                 // order to snap the new price to the tick grid (ibx#216).
                 let price = orig.map_or(price, |o| crate::types::snap_to_tick(
                     price, context.market.min_tick_scaled(o.instrument)));
+                // Which tag each price belongs on depends on the order type,
+                // and the answer is needed twice: once for what the engine
+                // records, once for what goes on the wire. A replacement that
+                // recorded the old trigger would leave the next modify
+                // restating a price this one just moved.
+                let ord_type_byte = orig.map(|o| o.ord_type).unwrap_or(b'2');
+                let trigger_only = is_trigger_only(ord_type_byte);
+                let orig_stop = orig.map_or(0, |o| o.stop_price);
+                // A two-legged type can have its trigger moved, but only if it
+                // has one: b'K' is Limit-if-Touched and Market-to-Limit both,
+                // and the tracked trigger is what separates them. Every other
+                // type keeps the shape it had, so a trigger supplied on the
+                // request cannot become a tag 99 for a limit order.
+                //
+                // A pegged or relative order tracks its offset in `stop_price`,
+                // so its replace does restate that on 99 — unchanged from
+                // before, and one of the reasons those types are refused a
+                // modify outright (ibx#334).
+                let carries_trigger =
+                    trigger_only || (matches!(ord_type_byte, b'4' | b'K') && orig_stop != 0);
+                let new_stop = if trigger_only && stop_price == 0 {
+                    price
+                } else if carries_trigger && stop_price != 0 {
+                    stop_price
+                } else {
+                    orig_stop
+                };
+
                 if let Some(orig) = orig {
+                    // The moved trigger is recorded too: a replacement that
+                    // kept the old one would leave the next modify restating a
+                    // price this one just moved.
                     context.insert_order(crate::types::Order::new(
                         new_order_id, orig.instrument, orig.side, qty, price,
-                        orig.ord_type, orig.tif, orig.stop_price,
+                        orig.ord_type, orig.tif, new_stop,
                     ));
                 }
                 // Versioned ClOrdID chaining: orderId.0 → .1 → .2
@@ -1488,10 +1521,16 @@ pub(crate) fn drain_and_send_orders(
                     (fix::TAG_SENDING_TIME, &now),
                     (11, &clord_str),    // ClOrdID (versioned)
                     (41, &orig_clord),   // OrigClOrdID (previous version)
-                    (44, &price_str),    // Price
-                    (1, account_id),     // Account
-                    (6122, "c"),         // Client version
                 ];
+                // Each price goes to the tag its order type uses. A
+                // trigger-only type has no limit leg, so its price is the
+                // trigger and tag 44 is left off entirely — the shape its own
+                // submit has. Anything else keeps 44 for the limit.
+                if !trigger_only {
+                    fields.push((44, &price_str)); // Price
+                }
+                fields.push((1, account_id)); // Account
+                fields.push((6122, "c"));     // Client version
                 // OutsideRTH, from the order the caller resubmitted rather than
                 // hard-coded: the tracked record cannot express it, and asserting
                 // 1 unconditionally opted every modified order into the extended
@@ -1513,13 +1552,11 @@ pub(crate) fn drain_and_send_orders(
                     (6238, ""),          // Empty (matches reference)
                 ];
                 fields.extend(rest);
-                // Include stop price for order types that need it
+                // The trigger the caller moved, or the one the order already had.
                 let stop_str;
-                if let Some(o) = orig {
-                    if o.stop_price != 0 {
-                        stop_str = format_price(o.stop_price);
-                        fields.push((99, &stop_str));
-                    }
+                if new_stop != 0 {
+                    stop_str = format_price(new_stop);
+                    fields.push((99, &stop_str));
                 }
                 conn.send_fix(&fields)
             }
@@ -1595,6 +1632,13 @@ fn oca_type_str(oca_type: u8) -> &'static str {
         4 => "ReduceOnFillWBlockFromTotal",
         _ => "ReduceOnFillNonBlock",
     }
+}
+
+/// Order types whose price *is* the trigger: they have no limit leg, so a
+/// replace states the price in tag 99 and sends no tag 44 at all — which is
+/// the shape their own submit has.
+fn is_trigger_only(ord_type: u8) -> bool {
+    matches!(ord_type, b'3' | b'J') || ord_type == crate::types::ORD_STP_PRT
 }
 
 /// One shared encoder for every extended order submission (ibx#224): the
@@ -2073,8 +2117,8 @@ mod modify_wire_tests {
     use crate::protocol::connection::Connection;
     use std::io::Read;
 
-    /// Drive the Modify arm and read what actually reaches the socket.
-    fn replace_bytes(outside_rth: bool) -> String {
+    /// Drive the order queue and read what actually reaches the socket.
+    fn drain(context: &mut Context) -> String {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         let client = std::net::TcpStream::connect(addr).unwrap();
@@ -2082,19 +2126,23 @@ mod modify_wire_tests {
         peer.set_read_timeout(Some(std::time::Duration::from_secs(5))).unwrap();
         let mut conn = Some(Connection::new_raw(client).unwrap());
 
+        let shared = std::sync::Arc::new(SharedState::new());
+        let mut hb = HeartbeatState::new();
+        drain_and_send_orders(&mut conn, context, "DU111111", &mut hb, false, &shared);
+
+        let mut buf = [0u8; 4096];
+        let n = peer.read(&mut buf).unwrap();
+        String::from_utf8_lossy(&buf[..n]).replace('\u{1}', "|")
+    }
+
+    /// A plain limit modified with the flag in each polarity.
+    fn replace_bytes(outside_rth: bool) -> String {
         let mut context = Context::new();
         context.insert_order(crate::types::Order::new(
             7, 0, Side::Buy, 1, 100 * crate::types::PRICE_SCALE, b'2', b'0', 0,
         ));
         context.modify(7, 200 * crate::types::PRICE_SCALE, 50, outside_rth);
-
-        let shared = std::sync::Arc::new(SharedState::new());
-        let mut hb = HeartbeatState::new();
-        drain_and_send_orders(&mut conn, &mut context, "DU111111", &mut hb, false, &shared);
-
-        let mut buf = [0u8; 4096];
-        let n = peer.read(&mut buf).unwrap();
-        String::from_utf8_lossy(&buf[..n]).replace('\u{1}', "|")
+        drain(&mut context)
     }
 
     /// ibx#247: the replace asserted 6433=1 unconditionally, so an RTH-only
@@ -2110,5 +2158,166 @@ mod modify_wire_tests {
         let off = replace_bytes(false);
         assert!(!off.contains("|6433="), "an RTH-only order must not assert 6433: {}", off);
         assert!(off.contains("|6122=c|38=50|"), "the rest of the message is unchanged: {}", off);
+    }
+
+    /// ibx#324: a stop has no limit leg, so the price a caller supplies to a
+    /// modify can only mean the trigger. Writing it to tag 44 and restating the
+    /// original trigger in 99 leaves the stop where it was — and on a live
+    /// gateway the replace is rejected outright, so the order the caller meant
+    /// to move ends up Inactive.
+    #[test]
+    fn modifying_a_stop_moves_its_trigger() {
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.insert_order(crate::types::Order::new(
+            7, instrument, Side::Sell, 1, 600 * crate::types::PRICE_SCALE, b'3', b'0',
+            600 * crate::types::PRICE_SCALE,
+        ));
+
+        context.modify(7, 610 * crate::types::PRICE_SCALE, 1, false);
+        let sent = drain(&mut context);
+
+        assert!(sent.contains("|99=610|"), "the trigger moves to the new price: {sent}");
+        assert!(!sent.contains("|99=600|"), "and does not restate the old one: {sent}");
+        assert!(!sent.contains("|44="), "a stop has no limit leg to state: {sent}");
+    }
+
+    /// Every trigger-only type, not just the plain stop. Market-if-touched and
+    /// stop-with-protection have no limit leg either.
+    #[test]
+    fn every_trigger_only_type_moves_its_trigger() {
+        for (ord_type, name) in [
+            (b'3', "STP"), (b'J', "MIT"), (crate::types::ORD_STP_PRT, "STP PRT"),
+        ] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            context.insert_order(crate::types::Order::new(
+                7, instrument, Side::Sell, 1, 600 * crate::types::PRICE_SCALE, ord_type, b'0',
+                600 * crate::types::PRICE_SCALE,
+            ));
+
+            context.modify(7, 610 * crate::types::PRICE_SCALE, 1, false);
+            let sent = drain(&mut context);
+
+            assert!(sent.contains("|99=610|"), "{name}: trigger moves: {sent}");
+            assert!(!sent.contains("|44="), "{name}: no limit leg to state: {sent}");
+        }
+
+        // The bucket is pinned from above as well: a type that is not
+        // trigger-only must keep its limit leg.
+        for ord_type in [b'U', b'2', b'1'] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            context.insert_order(crate::types::Order::new(
+                7, instrument, Side::Sell, 1, 100 * crate::types::PRICE_SCALE, ord_type, b'0', 0,
+            ));
+            context.modify(7, 610 * crate::types::PRICE_SCALE, 1, false);
+            let sent = drain(&mut context);
+            assert!(
+                sent.contains("|44=610|"),
+                "{ord_type} is not trigger-only and keeps tag 44: {sent}",
+            );
+        }
+    }
+
+    /// A type that carries no trigger must not acquire one. The public client
+    /// fills the request's trigger from `aux_price`, which is meaningless on a
+    /// limit and is the offset on a pegged order — neither belongs in tag 99.
+    #[test]
+    fn a_type_without_a_trigger_never_gains_one() {
+        for (ord_type, name) in [
+            (b'2', "LMT"), (b'1', "MKT"), (b'P', "TRAIL"), (b'K', "MTL"),
+            (crate::types::ORD_PEG_MID, "PEG MID"),
+        ] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            // Tracked with no trigger. A pegged or relative order tracks its
+            // offset in this field, so this pins the request-supplied path
+            // rather than claiming those types never emit a 99.
+            context.insert_order(crate::types::Order::new(
+                7, instrument, Side::Sell, 1, 100 * crate::types::PRICE_SCALE, ord_type, b'0', 0,
+            ));
+
+            // A trigger arrives on the request anyway.
+            context.pending_orders.push(crate::types::OrderRequest::Modify {
+                new_order_id: 8,
+                order_id: 7,
+                price: 101 * crate::types::PRICE_SCALE,
+                qty: 1,
+                outside_rth: false,
+                stop_price: 610 * crate::types::PRICE_SCALE,
+            });
+            let sent = drain(&mut context);
+
+            assert!(!sent.contains("|99="), "{name} must not gain a trigger: {sent}");
+            assert!(sent.contains("|44=101|"), "{name} keeps its limit leg: {sent}");
+        }
+    }
+
+    /// A two-legged type can have its trigger moved when it has one.
+    #[test]
+    fn a_supplied_trigger_moves_a_two_legged_order() {
+        for (ord_type, name) in [(b'4', "STP LMT"), (b'K', "LIT")] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            context.insert_order(crate::types::Order::new(
+                7, instrument, Side::Sell, 1, 605 * crate::types::PRICE_SCALE, ord_type, b'0',
+                600 * crate::types::PRICE_SCALE,
+            ));
+
+            context.pending_orders.push(crate::types::OrderRequest::Modify {
+                new_order_id: 8,
+                order_id: 7,
+                price: 610 * crate::types::PRICE_SCALE,
+                qty: 1,
+                outside_rth: false,
+                stop_price: 590 * crate::types::PRICE_SCALE,
+            });
+            let sent = drain(&mut context);
+
+            assert!(sent.contains("|44=610|"), "{name}: the limit moves: {sent}");
+            assert!(sent.contains("|99=590|"), "{name}: and so does the trigger: {sent}");
+        }
+    }
+
+    /// The replacement carries the trigger forward, so a second modify still
+    /// has one to restate.
+    #[test]
+    fn the_replacement_keeps_the_trigger() {
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.insert_order(crate::types::Order::new(
+            7, instrument, Side::Sell, 1, 600 * crate::types::PRICE_SCALE, b'3', b'0',
+            600 * crate::types::PRICE_SCALE,
+        ));
+
+        let second = context.modify(7, 610 * crate::types::PRICE_SCALE, 1, false);
+        drain(&mut context);
+        assert_eq!(
+            context.order(second).expect("tracked").stop_price,
+            610 * crate::types::PRICE_SCALE,
+            "the replacement records the trigger it just asked for",
+        );
+
+        context.modify(second, 620 * crate::types::PRICE_SCALE, 1, false);
+        let sent = drain(&mut context);
+        assert!(sent.contains("|99=620|"), "and the next modify moves it again: {sent}");
+    }
+
+    /// A type with both legs keeps the limit on 44 and holds its trigger.
+    #[test]
+    fn modifying_a_stop_limit_moves_the_limit_and_keeps_the_trigger() {
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.insert_order(crate::types::Order::new(
+            7, instrument, Side::Sell, 1, 605 * crate::types::PRICE_SCALE, b'4', b'0',
+            600 * crate::types::PRICE_SCALE,
+        ));
+
+        context.modify(7, 610 * crate::types::PRICE_SCALE, 1, false);
+        let sent = drain(&mut context);
+
+        assert!(sent.contains("|44=610|"), "the limit moves: {sent}");
+        assert!(sent.contains("|99=600|"), "the trigger is restated unchanged: {sent}");
     }
 }

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -44,6 +44,7 @@ impl EClient {
                 order_id: oid,
                 price,
                 qty,
+                outside_rth: api_order.outside_rth,
             })
         } else {
             ClientCore::build_order_request(&api_order, oid, instrument)

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -39,12 +39,16 @@ impl EClient {
         let cmd = if self.core.is_order_tracked(oid) {
             let price = (api_order.lmt_price * crate::api::types::PRICE_SCALE_F) as i64;
             let qty = api_order.total_quantity as u32;
+            // A stop's trigger rides on aux_price, exactly as it does on the
+            // submit path.
+            let stop_price = (api_order.aux_price * crate::api::types::PRICE_SCALE_F) as i64;
             ControlCommand::Order(OrderRequest::Modify {
                 new_order_id: oid,
                 order_id: oid,
                 price,
                 qty,
                 outside_rth: api_order.outside_rth,
+                stop_price,
             })
         } else {
             ClientCore::build_order_request(&api_order, oid, instrument)

--- a/src/types.rs
+++ b/src/types.rs
@@ -869,6 +869,10 @@ pub enum OrderRequest {
         /// asserts tag 6433 from this rather than from the tracked record,
         /// which has no field for it (ibx#247).
         outside_rth: bool,
+        /// New trigger price. Zero means the caller did not supply one, in
+        /// which case a trigger-only order type takes `price` as its trigger
+        /// and every other type keeps the trigger it already had.
+        stop_price: Price,
     },
 }
 
@@ -1625,6 +1629,7 @@ mod tests {
             price: 100 * PRICE_SCALE,
             qty: 200,
             outside_rth: false,
+            stop_price: 0,
         };
         let req2 = req.clone();
         match (req, req2) {
@@ -1873,7 +1878,7 @@ mod tests {
         assert_eq!(req.instrument(), Some(7));
         assert_eq!(OrderRequest::Cancel { order_id: 1 }.instrument(), None);
         assert_eq!(
-            OrderRequest::Modify { new_order_id: 2, order_id: 1, price: 0, qty: 1, outside_rth: false }.instrument(),
+            OrderRequest::Modify { new_order_id: 2, order_id: 1, price: 0, qty: 1, outside_rth: false, stop_price: 0 }.instrument(),
             None
         );
     }
@@ -1898,7 +1903,7 @@ mod tests {
 
     #[test]
     fn order_request_modify_fields() {
-        let req = OrderRequest::Modify { new_order_id: 100, order_id: 99, price: 200 * PRICE_SCALE, qty: 10, outside_rth: false };
+        let req = OrderRequest::Modify { new_order_id: 100, order_id: 99, price: 200 * PRICE_SCALE, qty: 10, outside_rth: false, stop_price: 0 };
         match req {
             OrderRequest::Modify { order_id, price, qty, .. } => {
                 assert_eq!(order_id, 99);

--- a/src/types.rs
+++ b/src/types.rs
@@ -865,6 +865,10 @@ pub enum OrderRequest {
         order_id: OrderId,
         price: Price,
         qty: u32,
+        /// Outside-RTH flag from the order the caller resubmitted. The replace
+        /// asserts tag 6433 from this rather than from the tracked record,
+        /// which has no field for it (ibx#247).
+        outside_rth: bool,
     },
 }
 
@@ -1620,6 +1624,7 @@ mod tests {
             order_id: 1,
             price: 100 * PRICE_SCALE,
             qty: 200,
+            outside_rth: false,
         };
         let req2 = req.clone();
         match (req, req2) {
@@ -1868,7 +1873,7 @@ mod tests {
         assert_eq!(req.instrument(), Some(7));
         assert_eq!(OrderRequest::Cancel { order_id: 1 }.instrument(), None);
         assert_eq!(
-            OrderRequest::Modify { new_order_id: 2, order_id: 1, price: 0, qty: 1 }.instrument(),
+            OrderRequest::Modify { new_order_id: 2, order_id: 1, price: 0, qty: 1, outside_rth: false }.instrument(),
             None
         );
     }
@@ -1893,7 +1898,7 @@ mod tests {
 
     #[test]
     fn order_request_modify_fields() {
-        let req = OrderRequest::Modify { new_order_id: 100, order_id: 99, price: 200 * PRICE_SCALE, qty: 10 };
+        let req = OrderRequest::Modify { new_order_id: 100, order_id: 99, price: 200 * PRICE_SCALE, qty: 10, outside_rth: false };
         match req {
             OrderRequest::Modify { order_id, price, qty, .. } => {
                 assert_eq!(order_id, 99);

--- a/tests/ib_paper_compat/orders.rs
+++ b/tests/ib_paper_compat/orders.rs
@@ -231,7 +231,7 @@ pub(super) fn phase_modify_order(conns: Conns) -> Conns {
                         } else if !order_acked {
                             order_acked = true;
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 1,
+                                order_id, new_order_id, price: 2_00_000_000, qty: 1, outside_rth: false,
                             })).unwrap();
                             modify_sent = true;
                         }
@@ -459,7 +459,7 @@ pub(super) fn phase_modify_qty(conns: Conns) -> Conns {
                         } else if !order_acked {
                             order_acked = true;
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 1_00_000_000, qty: 2,
+                                order_id, new_order_id, price: 1_00_000_000, qty: 2, outside_rth: false,
                             })).unwrap();
                             modify_sent = true;
                         }
@@ -1729,7 +1729,7 @@ pub(super) fn phase_modify_price_and_qty(conns: Conns) -> Conns {
                             order_acked = true;
                             // Modify BOTH price ($1→$2) and qty (1→3) in a single Modify
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 3,
+                                order_id, new_order_id, price: 2_00_000_000, qty: 3, outside_rth: false,
                             })).unwrap();
                             modify_sent = true;
                         }
@@ -1797,14 +1797,14 @@ pub(super) fn phase_double_modify(conns: Conns) -> Conns {
                             0 => {
                                 // Original order acked → modify to $2
                                 control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                    order_id, new_order_id: modify_id_1, price: 2_00_000_000, qty: 1,
+                                    order_id, new_order_id: modify_id_1, price: 2_00_000_000, qty: 1, outside_rth: false,
                                 })).unwrap();
                                 phase = 1;
                             }
                             1 => {
                                 // First modify acked → modify again to $3
                                 control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                    order_id: modify_id_1, new_order_id: modify_id_2, price: 3_00_000_000, qty: 1,
+                                    order_id: modify_id_1, new_order_id: modify_id_2, price: 3_00_000_000, qty: 1, outside_rth: false,
                                 })).unwrap();
                                 phase = 2;
                             }
@@ -1877,7 +1877,7 @@ pub(super) fn phase_cancel_during_modify(conns: Conns) -> Conns {
                             order_acked = true;
                             // Send modify AND cancel back-to-back — no waiting
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 1,
+                                order_id, new_order_id, price: 2_00_000_000, qty: 1, outside_rth: false,
                             })).unwrap();
                             control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id })).unwrap();
                             control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id: new_order_id })).unwrap();

--- a/tests/ib_paper_compat/orders.rs
+++ b/tests/ib_paper_compat/orders.rs
@@ -231,7 +231,7 @@ pub(super) fn phase_modify_order(conns: Conns) -> Conns {
                         } else if !order_acked {
                             order_acked = true;
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 1, outside_rth: false,
+                                order_id, new_order_id, price: 2_00_000_000, qty: 1, outside_rth: false, stop_price: 0,
                             })).unwrap();
                             modify_sent = true;
                         }
@@ -459,7 +459,7 @@ pub(super) fn phase_modify_qty(conns: Conns) -> Conns {
                         } else if !order_acked {
                             order_acked = true;
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 1_00_000_000, qty: 2, outside_rth: false,
+                                order_id, new_order_id, price: 1_00_000_000, qty: 2, outside_rth: false, stop_price: 0,
                             })).unwrap();
                             modify_sent = true;
                         }
@@ -1729,7 +1729,7 @@ pub(super) fn phase_modify_price_and_qty(conns: Conns) -> Conns {
                             order_acked = true;
                             // Modify BOTH price ($1→$2) and qty (1→3) in a single Modify
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 3, outside_rth: false,
+                                order_id, new_order_id, price: 2_00_000_000, qty: 3, outside_rth: false, stop_price: 0,
                             })).unwrap();
                             modify_sent = true;
                         }
@@ -1797,14 +1797,14 @@ pub(super) fn phase_double_modify(conns: Conns) -> Conns {
                             0 => {
                                 // Original order acked → modify to $2
                                 control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                    order_id, new_order_id: modify_id_1, price: 2_00_000_000, qty: 1, outside_rth: false,
+                                    order_id, new_order_id: modify_id_1, price: 2_00_000_000, qty: 1, outside_rth: false, stop_price: 0,
                                 })).unwrap();
                                 phase = 1;
                             }
                             1 => {
                                 // First modify acked → modify again to $3
                                 control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                    order_id: modify_id_1, new_order_id: modify_id_2, price: 3_00_000_000, qty: 1, outside_rth: false,
+                                    order_id: modify_id_1, new_order_id: modify_id_2, price: 3_00_000_000, qty: 1, outside_rth: false, stop_price: 0,
                                 })).unwrap();
                                 phase = 2;
                             }
@@ -1877,7 +1877,7 @@ pub(super) fn phase_cancel_during_modify(conns: Conns) -> Conns {
                             order_acked = true;
                             // Send modify AND cancel back-to-back — no waiting
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 1, outside_rth: false,
+                                order_id, new_order_id, price: 2_00_000_000, qty: 1, outside_rth: false, stop_price: 0,
                             })).unwrap();
                             control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id })).unwrap();
                             control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id: new_order_id })).unwrap();


### PR DESCRIPTION
> Stacked on #319. Review this one from its second commit.

## Summary

- A modify carried one price and the builder always wrote it to tag 44. Tag 99 was filled from the **original** order's stop, so no sequence of calls could move a trigger.
- The public clients made it worse by reading the new price from `lmt_price` alone. A stop order carries its price in `aux_price`, so the field the caller set was discarded and the replace asked for a limit price of zero on an order with no limit leg.

Closes #324.

## The gateway rejects it

Placing a SELL STP at 600, then re-placing the same id with `aux_price: 610.00`:

```
35=D  ...|55=SPY|54=2|38=1|40=3|99=600|59=0|167=STK|100=BEST
35=G  ...|41=9202.0|44=0|6122=c|38=1|54=2|40=3|55=SPY|167=STK|59=0|6008=756733|99=600
```

`44=0` where the caller asked for 610, and `99=600` — the original trigger, unchanged. The answer:

```
[status] oid=9202 Inactive
[error] code=202  Order 9202 cancel/modify rejected (reason: 1)
```

So the trigger does not merely stay put. The stop the caller was repositioning ends up **Inactive** — gone — and the only signal is a rejection code on an order they believe they just moved. For a protective stop that is the entire purpose of the order.

## Change

`Modify` carries the trigger as well as the price, and both clients populate it from `aux_price` the way their submit paths already do.

Each price then goes to the tag its order type uses:

| type | 44 | 99 |
|---|---|---|
| trigger-only — STP, STP PRT, MIT | omitted | the new trigger |
| two-legged — STP LMT, LIT | the limit | the new trigger, or the one it had |
| everything else | the limit | untouched |

Trigger-only types send no 44 at all, which is the shape their own submit has. The two-legged bucket applies only where the order actually has a trigger: `b'K'` is Limit-if-Touched **and** Market-to-Limit, and the tracked trigger is what separates them. Every other type keeps the shape it had, so a stray aux price on a limit, or the offset on a pegged order, cannot arrive as a tag 99.

The replacement records the trigger the modify just asked for rather than the one it replaced, so a second modify restates the current price instead of resurrecting the previous one.

## Limit orders are unchanged

A plain limit modify emits exactly what it did before — same tags, same order, same bytes.

## Tests

Fourteen over the builder, driven through the real send path and reading back what was written. Each of these fails them: dropping MIT or STP PRT from the trigger-only set, ignoring a supplied trigger, shifting a supplied trigger, erasing the replacement's trigger, reverting the client's aux-price propagation, and reverting the routing.

## Not fixed here

A replace still restates almost nothing else about the order — no attribute block at all. Modifying a **trailing** stop drops its trail and the order goes Inactive the same way; that is #334, and it is not addressed by this change, since a trailing stop is a pegged type rather than a trigger type.

---

**Stacked on #249.** The first of the two commits here is that PR; this branch needs its `outside_rth` field on the replace request, and the two edit the same tag list. Review the second commit for this change, and merge #249 first.

## Test plan

- [x] `cargo test --offline --lib` — 811 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.
- [x] Mutation check: reverting the trigger routing fails `modifying_a_stop_moves_its_trigger` and `every_trigger_only_type_moves_its_trigger`; reverting the outside-RTH conditional fails `modify_emits_outside_rth_only_when_the_caller_set_it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

