### PR TITLE
orders: put the extended attributes on the tags the gateway reads (ibx#338, ibx#339, ibx#327)

### DIFF
--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -31,6 +31,71 @@ fn spy() -> Contract {
 //  Algo parsing
 // ═══════════════════════════════════════════════════════════════════
 
+/// No tag in this dialect carries a minimum quantity. It used to go out on one
+/// the gateway rejects, which left the order Inactive with its quantity
+/// reported as zero — refusing says why, without the round trip.
+#[test]
+fn min_qty_is_refused_rather_than_sent() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "BUY".into(), total_quantity: 200.0, order_type: "LMT".into(),
+        lmt_price: 100.0, tif: "DAY".into(), min_qty: 50, ..Default::default()
+    };
+    let err = client.place_order(9001, &spy(), &order).expect_err("must be refused");
+    assert!(format!("{err}").contains("min_qty"), "the error names the field: {err}");
+    assert!(rx.try_recv().is_err(), "and nothing reaches the wire");
+}
+
+/// A percentage that quantises to zero basis points would rest as a trailing
+/// stop that never trails.
+#[test]
+fn a_trailing_percent_below_the_wire_resolution_is_refused() {
+    let (client, _rx, _shared) = test_client();
+    let order = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "TRAIL".into(),
+        trailing_percent: 0.004, tif: "DAY".into(), ..Default::default()
+    };
+    let err = client.place_order(9002, &spy(), &order).expect_err("must be refused");
+    assert!(format!("{err}").contains("0.01%"), "the error names the limit: {err}");
+}
+
+/// A percentage that is not a number cannot become one by casting. `as u32`
+/// turns NaN into 0 and infinity into `u32::MAX`, either of which would reach
+/// the wire as a trail nobody asked for.
+#[test]
+fn a_non_finite_trailing_percent_is_refused() {
+    for pct in [f64::NAN, f64::INFINITY] {
+        let (client, _rx, _shared) = test_client();
+        let order = Order {
+            action: "SELL".into(), total_quantity: 1.0, order_type: "TRAIL".into(),
+            trailing_percent: pct, tif: "DAY".into(), ..Default::default()
+        };
+        let err = client.place_order(9004, &spy(), &order)
+            .expect_err("a non-finite percentage must be refused");
+        assert!(
+            format!("{err}").contains("finite") || format!("{err}").contains("0.01%"),
+            "the error explains itself: {err}",
+        );
+    }
+}
+
+/// Basis points are rounded, not truncated: 0.29% is 28.999... in floating
+/// point and would otherwise reach the gateway as 0.28%.
+#[test]
+fn a_trailing_percent_rounds_to_the_nearest_basis_point() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "TRAIL".into(),
+        trailing_percent: 0.29, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9003, &spy(), &order).unwrap();
+    match rx.try_recv().expect("the submit") {
+        ControlCommand::Order(OrderRequest::SubmitTrailingStopPct { trail_pct, .. }) =>
+            assert_eq!(trail_pct, 29, "0.29% is 29 basis points, not 28"),
+        other => panic!("expected a trailing-percent submit, got {other:?}"),
+    }
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1304,6 +1304,13 @@ impl ClientCore {
             ));
         }
 
+        // No tag in this dialect carries a minimum quantity. It used to go out
+        // on one the gateway rejects, which left the order Inactive; refusing
+        // it is the same outcome without the round trip, and says why.
+        if order.min_qty > 0 {
+            return Err("min_qty is not supported".to_string());
+        }
+
         if order.algo_strategy.eq_ignore_ascii_case("Adaptive") {
             return Ok(());
         }
@@ -1336,6 +1343,17 @@ impl ClientCore {
             "STP LMT" | "LIT" if order.aux_price == 0.0 => {
                 return Err(format!(
                     "{} order requires aux_price (stop/trigger price) but got 0.0",
+                    order.order_type
+                ));
+            }
+            // NaN compares false against everything, so it slips past both the
+            // zero check below and the `> 0.0` branch that picks the percent
+            // path — it has to be rejected on its own terms.
+            "TRAIL" | "TRAIL LIMIT"
+                if !order.trailing_percent.is_finite() || !order.aux_price.is_finite() =>
+            {
+                return Err(format!(
+                    "{} order requires finite trailing_percent and aux_price",
                     order.order_type
                 ));
             }
@@ -1525,7 +1543,16 @@ impl ClientCore {
                 // Optional initial stop trigger (tag 6117); default f64::MAX = unset.
                 let trail_stop = if order.trail_stop_price == f64::MAX { 0 } else { (order.trail_stop_price * PRICE_SCALE_F) as i64 };
                 if order.trailing_percent > 0.0 {
-                    let pct = (order.trailing_percent * 100.0) as u32;
+                    // Basis points, rounded rather than truncated: 0.29% is
+                    // 28.999... in floating point and would otherwise reach the
+                    // gateway as 0.28%.
+                    let pct = (order.trailing_percent * 100.0).round() as u32;
+                    if pct == 0 {
+                        return Err(format!(
+                            "trailing_percent {} is below the smallest the wire carries (0.01%)",
+                            order.trailing_percent
+                        ));
+                    }
                     if extended {
                         OrderRequest::SubmitTrailingStopPctEx {
                             order_id, instrument, side, qty, trail_pct: pct,

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -1151,6 +1151,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         };
         ctx.insert_order(order);
         assert!(ctx.order(1).is_some());
@@ -1171,6 +1172,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 2,
@@ -1183,6 +1185,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
 
         let inst0_orders = ctx.open_orders_for(0);
@@ -1204,6 +1207,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         ctx.update_order_status(1, OrderStatus::Cancelled);
         assert_eq!(ctx.order(1).unwrap().status, OrderStatus::Cancelled);
@@ -1219,6 +1223,7 @@ mod tests {
             order_id: oid, instrument: 0, side: Side::Buy, price: 100,
             qty: 100, filled: 0, status: OrderStatus::Submitted,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
     }
 
@@ -1297,6 +1302,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         ctx.remove_order(1);
         assert!(ctx.order(1).is_none());
@@ -1465,18 +1471,21 @@ mod tests {
             price: 150 * PRICE_SCALE, qty: 100, filled: 0,
             status: OrderStatus::Submitted,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 2, instrument: 0, side: Side::Sell,
             price: 155 * PRICE_SCALE, qty: 50, filled: 0,
             status: OrderStatus::Submitted,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 3, instrument: 0, side: Side::Buy,
             price: 149 * PRICE_SCALE, qty: 200, filled: 0,
             status: OrderStatus::Filled,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
 
         // open_orders_for only returns Submitted
@@ -1526,6 +1535,7 @@ mod tests {
             price: PRICE_SCALE, qty: 100, filled: 0,
             status: OrderStatus::PendingSubmit,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.update_order_filled(1, 30);
         assert_eq!(ctx.order(1).unwrap().filled, 30);
@@ -1541,18 +1551,21 @@ mod tests {
             price: PRICE_SCALE, qty: 100, filled: 0,
             status: OrderStatus::PendingSubmit,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 2, instrument: 0, side: Side::Buy,
             price: PRICE_SCALE, qty: 100, filled: 50,
             status: OrderStatus::PartiallyFilled,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         ctx.insert_order(Order {
             order_id: 3, instrument: 0, side: Side::Buy,
             price: PRICE_SCALE, qty: 100, filled: 100,
             status: OrderStatus::Filled,
             ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         });
         let open = ctx.open_orders_for(0);
         // PendingSubmit and PartiallyFilled count as open; Filled does not

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -715,6 +715,10 @@ impl CcpState {
                     ord_type: ord_type_byte,
                     tif: tif_byte,
                     stop_price: stop_price_i64,
+                    // The recovery record restates the order, so take the flag
+                    // from it rather than defaulting — a later modify restates
+                    // it in turn.
+                    outside_rth: parsed.get(&6433).map(|v| v == "1").unwrap_or(false),
                 });
                 log::info!("CCP recovery: inserted orderId={} sym={:?} side={:?} qty={} px={}",
                     clord_id, parsed.get(&55), side, qty,
@@ -2073,6 +2077,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         });
         (CcpState::new(), context, SharedState::new())
     }

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -107,7 +107,7 @@ pub(crate) fn drain_and_send_orders(
             OrderRequest::SubmitLimitGtc { order_id, instrument, side, qty, price, outside_rth } => {
                 context.insert_order(crate::types::Order::new(
                     order_id, instrument, side, qty, price, b'2', b'1', 0,
-                ));
+                ).with_outside_rth(outside_rth));
                 let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
@@ -215,7 +215,7 @@ pub(crate) fn drain_and_send_orders(
             OrderRequest::SubmitStopGtc { order_id, instrument, side, qty, stop_price, outside_rth } => {
                 context.insert_order(crate::types::Order::new(
                     order_id, instrument, side, qty, stop_price, b'3', b'1', stop_price,
-                ));
+                ).with_outside_rth(outside_rth));
                 let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
@@ -251,7 +251,7 @@ pub(crate) fn drain_and_send_orders(
             OrderRequest::SubmitStopLimitGtc { order_id, instrument, side, qty, price, stop_price, outside_rth } => {
                 context.insert_order(crate::types::Order::new(
                     order_id, instrument, side, qty, price, b'4', b'1', stop_price,
-                ));
+                ).with_outside_rth(outside_rth));
                 let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
@@ -1449,10 +1449,13 @@ pub(crate) fn drain_and_send_orders(
                 let price = orig.map_or(price, |o| crate::types::snap_to_tick(
                     price, context.market.min_tick_scaled(o.instrument)));
                 if let Some(orig) = orig {
+                    // Carried like every other attribute of the original: a
+                    // replace that dropped it would leave the next modify
+                    // restating a flag the order no longer records.
                     context.insert_order(crate::types::Order::new(
                         new_order_id, orig.instrument, orig.side, qty, price,
                         orig.ord_type, orig.tif, orig.stop_price,
-                    ));
+                    ).with_outside_rth(orig.outside_rth));
                 }
                 // Versioned ClOrdID chaining: orderId.0 → .1 → .2
                 let prev_ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
@@ -1482,36 +1485,20 @@ pub(crate) fn drain_and_send_orders(
                 let con_id_str = orig.and_then(|o| context.market.con_id(o.instrument))
                     .map(|c| c.to_string()).unwrap_or_default();
 
-                // Lean modify message — omit identity tags (6121, 6119, 231, 100, 15, 204)
-                let mut fields: Vec<(u32, &str)> = vec![
-                    (fix::TAG_MSG_TYPE, fix::MSG_ORDER_REPLACE),
-                    (fix::TAG_SENDING_TIME, &now),
-                    (11, &clord_str),    // ClOrdID (versioned)
-                    (41, &orig_clord),   // OrigClOrdID (previous version)
-                    (44, &price_str),    // Price
-                    (1, account_id),     // Account
-                    (6122, "c"),         // Client version
-                    (6433, "1"),         // OutsideRTH (preserve from original)
-                    (38, &qty_str),      // OrderQty
-                    (54, side_str),      // Side
-                    (40, &ord_type_str), // OrdType
-                    (55, &symbol),       // Symbol
-                    (167, &sec_type_str),        // SecurityType
-                    (6035, &symbol),     // LocalSymbol echo
-                    (59, &tif_str),      // TIF
-                    (6008, &con_id_str), // ConId
-                    (6088, "Socket"),    // Connection type
-                    (6211, ""),          // Empty (matches reference)
-                    (6238, ""),          // Empty (matches reference)
-                ];
                 // Include stop price for order types that need it
                 let stop_str;
-                if let Some(o) = orig {
-                    if o.stop_price != 0 {
+                let stop = match orig {
+                    Some(o) if o.stop_price != 0 => {
                         stop_str = format_price(o.stop_price);
-                        fields.push((99, &stop_str));
+                        Some(&*stop_str)
                     }
-                }
+                    _ => None,
+                };
+                let fields = build_replace_fields(
+                    &now, &clord_str, &orig_clord, &price_str, account_id, &qty_str,
+                    side_str, &ord_type_str, &symbol, &sec_type_str, &tif_str,
+                    &con_id_str, orig.map(|o| o.outside_rth).unwrap_or(false), stop,
+                );
                 conn.send_fix(&fields)
             }
         };
@@ -1588,6 +1575,61 @@ fn oca_type_str(oca_type: u8) -> &'static str {
     }
 }
 
+/// Build the 35=G replace tag list. Lean by design — identity tags (6121,
+/// 6119, 231, 100, 15, 204) are omitted.
+///
+/// Kept pure so the wire shape stays testable without a connection. OutsideRTH
+/// (6433) is restated from the tracked order and is present only when the order
+/// carries it, matching the submit path: a literal here would widen every
+/// RTH-only order to the extended session the first time it was modified.
+#[allow(clippy::too_many_arguments)]
+fn build_replace_fields<'a>(
+    now: &'a str,
+    clord: &'a str,
+    orig_clord: &'a str,
+    price: &'a str,
+    account_id: &'a str,
+    qty: &'a str,
+    side: &'a str,
+    ord_type: &'a str,
+    symbol: &'a str,
+    sec_type: &'a str,
+    tif: &'a str,
+    con_id: &'a str,
+    outside_rth: bool,
+    stop: Option<&'a str>,
+) -> Vec<(u32, &'a str)> {
+    let mut fields: Vec<(u32, &str)> = vec![
+        (fix::TAG_MSG_TYPE, fix::MSG_ORDER_REPLACE),
+        (fix::TAG_SENDING_TIME, now),
+        (11, clord),         // ClOrdID (versioned)
+        (41, orig_clord),    // OrigClOrdID (previous version)
+        (44, price),         // Price
+        (1, account_id),     // Account
+        (6122, "c"),         // Client version
+    ];
+    if outside_rth {
+        fields.push((6433, "1")); // OutsideRTH
+    }
+    fields.extend_from_slice(&[
+        (38, qty),           // OrderQty
+        (54, side),          // Side
+        (40, ord_type),      // OrdType
+        (55, symbol),        // Symbol
+        (167, sec_type),     // SecurityType
+        (6035, symbol),      // LocalSymbol echo
+        (59, tif),           // TIF
+        (6008, con_id),      // ConId
+        (6088, "Socket"),    // Connection type
+        (6211, ""),          // Empty (matches reference)
+        (6238, ""),          // Empty (matches reference)
+    ]);
+    if let Some(stop) = stop {
+        fields.push((99, stop));
+    }
+    fields
+}
+
 /// One shared encoder for every extended order submission (ibx#224): the
 /// order-type-specific tags come from `kind`; the TIF and the full
 /// `OrderAttrs` block are emitted identically for all kinds.
@@ -1635,7 +1677,7 @@ fn send_order_ex(
     };
     context.insert_order(crate::types::Order::new(
         order_id, instrument, side, qty, track_price, ord_type_byte, tif, track_stop,
-    ));
+    ).with_outside_rth(attrs.outside_rth));
 
     let ver = *context.modify_versions.get(&order_id).unwrap_or(&0);
     let symbol = context.market.symbol(instrument).to_string();
@@ -2022,6 +2064,7 @@ mod tests {
         Order {
             order_id: oid, instrument: 0, side: Side::Buy, price: 100,
             qty: 10, filled, status, ord_type: b'2', tif: b'0', stop_price: 0,
+            outside_rth: false,
         }
     }
 
@@ -2055,5 +2098,133 @@ mod tests {
 
         assert_eq!(context.order(8).unwrap().status, OrderStatus::Filled);
         assert!(shared.orders.drain_order_updates().is_empty());
+    }
+
+    /// Drive the real send path and inspect what it recorded. The peer is held
+    /// open for the call so the send succeeds — a failed send unwinds the
+    /// order, which would mask what these tests are checking.
+    fn drain(context: &mut Context) -> String {
+        use std::io::Read;
+        let shared = Arc::new(SharedState::new());
+        let (c, mut peer) = crate::protocol::connection::Connection::paired_for_test();
+        let mut conn = Some(c);
+        let mut hb = HeartbeatState::new();
+        drain_and_send_orders(&mut conn, context, "ACC", &mut hb, false, &shared);
+
+        peer.set_read_timeout(Some(std::time::Duration::from_millis(250))).unwrap();
+        let mut sent = Vec::new();
+        let mut chunk = [0u8; 8192];
+        while let Ok(n) = peer.read(&mut chunk) {
+            if n == 0 {
+                break;
+            }
+            sent.extend_from_slice(&chunk[..n]);
+        }
+        String::from_utf8_lossy(&sent).replace('\x01', "|")
+    }
+
+    /// The flag has to survive being modified, not just being submitted. A
+    /// replace builds a fresh tracked order from the original; dropping the
+    /// flag there leaves the first replace correct and every later one wrong,
+    /// which is the shape that hides in testing.
+    #[test]
+    fn an_order_keeps_outside_rth_across_repeated_modifies() {
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.insert_order(
+            crate::types::Order::new(7, instrument, Side::Buy, 10, 100 * crate::types::PRICE_SCALE, b'2', b'1', 0)
+                .with_outside_rth(true),
+        );
+
+        let second = context.modify(7, 101 * crate::types::PRICE_SCALE, 10);
+        let first_replace = drain(&mut context);
+        assert!(first_replace.contains("|6433=1|"), "first replace restates the flag: {first_replace}");
+        assert!(
+            context.order(second).expect("replacement tracked").outside_rth,
+            "the replacement order must carry the flag forward",
+        );
+
+        let third = context.modify(second, 102 * crate::types::PRICE_SCALE, 10);
+        let second_replace = drain(&mut context);
+        assert!(
+            second_replace.contains("|6433=1|"),
+            "and the next replace restates it too: {second_replace}",
+        );
+        assert!(
+            context.order(third).expect("second replacement tracked").outside_rth,
+            "and keeps carrying it",
+        );
+    }
+
+    /// A submit that offers the flag has to record it, or the replace has
+    /// nothing truthful to restate.
+    #[test]
+    fn a_submit_records_the_flag_it_was_given() {
+        for requested in [true, false] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            let id = context.submit_limit_gtc(instrument, Side::Buy, 10, 100 * crate::types::PRICE_SCALE, requested);
+            let sent = drain(&mut context);
+            assert_eq!(
+                sent.contains("|6433=1|"), requested,
+                "the submit itself only carries 6433 when asked: {sent}",
+            );
+            assert_eq!(
+                context.order(id).expect("order tracked").outside_rth, requested,
+                "submitted with outside_rth={requested}",
+            );
+        }
+    }
+
+    fn replace(outside_rth: bool, stop: Option<&str>) -> Vec<(u32, &str)> {
+        build_replace_fields(
+            "T", "7.1", "7.0", "101.00", "ACC", "10", "1", "2", "SPY", "CS", "0",
+            "756733", outside_rth, stop,
+        )
+    }
+
+    /// A replace restates the order, so OutsideRTH must come from the order.
+    /// Sending it unconditionally widens an RTH-only order to the extended
+    /// session the first time it is modified, and nothing reports the change.
+    #[test]
+    fn replace_carries_outside_rth_only_when_the_order_has_it() {
+        let rth_only = replace(false, None);
+        assert!(
+            !rth_only.iter().any(|(tag, _)| *tag == 6433),
+            "an RTH-only order must not acquire 6433 by being modified",
+        );
+
+        let extended = replace(true, None);
+        assert_eq!(
+            extended.iter().filter(|(tag, _)| *tag == 6433).map(|(_, v)| *v).collect::<Vec<_>>(),
+            ["1"],
+            "an order submitted outside RTH must keep the flag across a modify",
+        );
+    }
+
+    /// Setting the flag must not disturb the rest of the message.
+    #[test]
+    fn outside_rth_is_the_only_difference_between_the_two_shapes() {
+        let without = replace(false, None);
+        let with: Vec<_> = replace(true, None).into_iter().filter(|(tag, _)| *tag != 6433).collect();
+        assert_eq!(without, with);
+    }
+
+    /// The flag sits between the client version and the quantity, where the
+    /// submit path puts it.
+    #[test]
+    fn outside_rth_keeps_its_position() {
+        let tags: Vec<u32> = replace(true, None).iter().map(|(tag, _)| *tag).collect();
+        let at = tags.iter().position(|t| *t == 6433).expect("6433 present");
+        assert_eq!(tags[at - 1], 6122);
+        assert_eq!(tags[at + 1], 38);
+    }
+
+    /// The stop price is appended only for order types that carry one.
+    #[test]
+    fn replace_appends_the_stop_price_when_there_is_one() {
+        assert!(!replace(false, None).iter().any(|(tag, _)| *tag == 99));
+        let stopped = replace(false, Some("99.50"));
+        assert_eq!(stopped.last(), Some(&(99u32, "99.50")));
     }
 }

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -444,12 +444,13 @@ pub(crate) fn drain_and_send_orders(
                 let clord_str = format!("{}.{}", order_id, ver);
                 let side_str = fix_side(side);
                 let qty_str = format_uint(qty as u64);
-                let pct_str = trail_pct.to_string(); // basis points: 100 = 1%
-                // Per ib-agent#156 capture: percent-trail mirrors 99/211 as the
-                // percent in decimal form (1.00 for 1%), alongside 6268 in basis
-                // points and 18=a (ExecInst=TrailingStop). Without 99/211/18 the
-                // gateway rejects with "Invalid value in field # 18".
+                // 99/211 mirror the percent in decimal form (1.00 for 1%) and
+                // 18=a marks it trailing; without those three the gateway
+                // rejects with "Invalid value in field # 18". The percentage
+                // itself rides on 9822 as a fraction, and 6268 is the unit it
+                // is expressed in rather than a value.
                 let pct_decimal = format!("{:.2}", trail_pct as f64 / 100.0);
+                let pct_fraction = format!("{:.4}", trail_pct as f64 / 10000.0);
                 let trail_stop_str = format_price(trail_stop_price);
                 let symbol = context.market.symbol(instrument).to_string();
                 let (sec_type_str, destination) = context.market.order_routing(instrument);
@@ -467,7 +468,8 @@ pub(crate) fn drain_and_send_orders(
                     (99, &pct_decimal),     // StopPx = percent as decimal
                     (211, &pct_decimal),    // PegOffset = percent as decimal (mirror of 99)
                     (18, "a"),              // ExecInst = TrailingStop
-                    (6268, &pct_str),       // TrailingPercent (basis points)
+                    (9822, &pct_fraction), // PercentOffset = percentage as a fraction
+                    (6268, "100"),          // TrailingAmtUnit: 100 = percent
                     (59, "0"),              // TIF = DAY
                     (60, &now),
                     (167, &sec_type_str),
@@ -1743,15 +1745,16 @@ fn send_order_ex(
             if trail_stop_price > 0 { fields.push((6117, format_price(trail_stop_price).to_string())); }
         }
         K::TrailPct { trail_pct, trail_stop_price } => {
-            // Per ib-agent#156 capture: percent-trail mirrors 99/211 as the
-            // percent in decimal form (1.00 for 1%), alongside 6268 in
-            // basis points and 18=a.
+            // 99/211 mirror the percent in decimal form (1.00 for 1%) and
+            // 18=a marks it trailing. The percentage itself rides on 9822 as a
+            // fraction, and 6268 is the unit it is expressed in.
             let pct_decimal = format!("{:.2}", trail_pct as f64 / 100.0);
             fields.push((40, "P".to_string()));
             fields.push((99, pct_decimal.clone()));
             fields.push((211, pct_decimal));
             fields.push((18, "a".to_string()));
-            fields.push((6268, trail_pct.to_string()));
+            fields.push((9822, format!("{:.4}", trail_pct as f64 / 10000.0)));
+            fields.push((6268, "100".to_string()));
             if trail_stop_price > 0 { fields.push((6117, format_price(trail_stop_price).to_string())); }
             has_base_exec_inst = true;
         }
@@ -1828,10 +1831,12 @@ fn send_order_ex(
     // Extended attributes — same tag order as the historical SubmitLimitEx
     // block.
     if attrs.display_size > 0 {
-        fields.push((111, format_uint(attrs.display_size as u64).to_string()));
+        fields.push((6103, format_uint(attrs.display_size as u64).to_string()));
     }
     if attrs.min_qty > 0 {
-        fields.push((110, format_uint(attrs.min_qty as u64).to_string()));
+        // Refused at the API boundary; a caller reaching the engine directly
+        // gets a word rather than an attribute that quietly does nothing.
+        log::warn!("min_qty is not carried on the wire and is being ignored");
     }
     if attrs.outside_rth {
         fields.push((6433, "1".to_string()));
@@ -1885,10 +1890,10 @@ fn send_order_ex(
         let cond_strs = build_condition_strings(&attrs.conditions);
         fields.push((6136, cond_strs[0].clone())); // first element is count
         if attrs.conditions_cancel_order {
-            fields.push((6128, "1".to_string()));
+            fields.push((6579, "1".to_string()));
         }
         if attrs.conditions_ignore_rth {
-            fields.push((6151, "1".to_string()));
+            fields.push((6128, "1".to_string()));
         }
         // Per-condition tags start at index 1, 11 strings per condition
         for i in 0..attrs.conditions.len() {
@@ -2154,6 +2159,106 @@ mod tests {
             context.order(third).expect("second replacement tracked").outside_rth,
             "and keeps carrying it",
         );
+    }
+
+    /// Every one of these tags was rejected by the gateway or landed on a
+    /// field that means something else. The values are what a live session
+    /// accepts; the point of the test is that the tag numbers do not drift
+    /// back.
+    #[test]
+    fn the_extended_attributes_go_on_the_tags_the_gateway_reads() {
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.submit_limit_ex(
+            instrument, Side::Buy, 1000, 100 * crate::types::PRICE_SCALE, b'0',
+            crate::types::OrderAttrs {
+                display_size: 200,
+                conditions_cancel_order: true,
+                conditions_ignore_rth: true,
+                conditions: vec![crate::types::OrderCondition::Time {
+                    time: "20260311-09:30:00".into(),
+                    is_more: true,
+                }],
+                ..Default::default()
+            },
+        );
+        let sent = drain(&mut context);
+
+        assert!(sent.contains("|6103=200|"), "display size rides on 6103: {sent}");
+        assert!(!sent.contains("|111="), "and never on 111: {sent}");
+        assert!(sent.contains("|6579=1|"), "cancel-on-condition rides on 6579: {sent}");
+        assert!(sent.contains("|6128=1|"), "ignore-RTH rides on 6128: {sent}");
+        assert!(!sent.contains("|6151="), "and neither lands on the price field: {sent}");
+    }
+
+    /// The percentage is a fraction on its own tag; 6268 states the unit it is
+    /// in. Putting the percentage on 6268 made every value except 1% invalid,
+    /// because 100 basis points collides with the code for "percent".
+    ///
+    /// Both encoders are checked: the plain one and the shared extended one,
+    /// which carried the same wrong assignment and would otherwise be pinned by
+    /// nothing.
+    #[test]
+    fn a_trailing_percent_states_its_unit_and_its_value_separately() {
+        for extended in [false, true] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            if extended {
+                context.pending_orders.push(crate::types::OrderRequest::SubmitEx {
+                    order_id: 11,
+                    instrument,
+                    side: Side::Sell,
+                    qty: 1,
+                    kind: crate::types::OrderKind::TrailPct {
+                        trail_pct: 250,
+                        trail_stop_price: 0,
+                    },
+                    tif: b'0',
+                    attrs: crate::types::OrderAttrs::default(),
+                });
+            } else {
+                context.submit_trailing_stop_pct(instrument, Side::Sell, 1, 250);
+            }
+            let sent = drain(&mut context);
+
+            assert!(sent.contains("|6268=100|"), "extended={extended}: 6268 is the unit: {sent}");
+            assert!(
+                sent.contains("|9822=0.0250|"),
+                "extended={extended}: 9822 is 2.5% as a fraction: {sent}",
+            );
+            assert!(sent.contains("|18=a|"), "extended={extended}: still trailing: {sent}");
+        }
+    }
+
+    /// Each condition flag must drive its own tag. Setting both at once cannot
+    /// tell the two apart, so they are submitted one at a time and the other
+    /// tag is asserted absent.
+    #[test]
+    fn each_condition_flag_drives_only_its_own_tag() {
+        let condition = || crate::types::OrderCondition::Time {
+            time: "20260311-09:30:00".into(),
+            is_more: true,
+        };
+        for (cancel, ignore_rth, present, absent) in [
+            (true, false, "|6579=1|", "|6128=1|"),
+            (false, true, "|6128=1|", "|6579=1|"),
+        ] {
+            let mut context = Context::new();
+            let instrument = context.register_instrument(756733);
+            context.submit_limit_ex(
+                instrument, Side::Buy, 1, 100 * crate::types::PRICE_SCALE, b'0',
+                crate::types::OrderAttrs {
+                    conditions: vec![condition()],
+                    conditions_cancel_order: cancel,
+                    conditions_ignore_rth: ignore_rth,
+                    ..Default::default()
+                },
+            );
+            let sent = drain(&mut context);
+
+            assert!(sent.contains(present), "cancel={cancel}: expected {present}: {sent}");
+            assert!(!sent.contains(absent), "cancel={cancel}: {absent} must be absent: {sent}");
+        }
     }
 
     /// A submit that offers the flag has to record it, or the replace has

--- a/src/protocol/connection.rs
+++ b/src/protocol/connection.rs
@@ -314,6 +314,27 @@ impl Connection {
     /// Uses seq=0 (separate seq space from heartbeats).
     ///
     /// State (sign_iv) is committed only after `write_all` returns Ok.
+    /// Test-only connection over a loopback pair. The peer is returned so the
+    /// caller can hold it open: sends have to succeed for the send paths to
+    /// behave as they do in production, where a write error unwinds the order.
+    #[cfg(test)]
+    pub(crate) fn paired_for_test() -> (Self, std::net::TcpStream) {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stream = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (peer, _) = listener.accept().unwrap();
+        stream.set_nonblocking(true).unwrap();
+        let conn = Self {
+            stream: Stream::Raw(stream),
+            buf: Vec::new(),
+            seq: 0,
+            sign_key: Vec::new(),
+            sign_iv: Vec::new(),
+            read_key: Vec::new(),
+            read_iv: Vec::new(),
+        };
+        (conn, peer)
+    }
+
     pub fn send_fixcomp(&mut self, fields: &[(u32, &str)]) -> io::Result<()> {
         let msg = fix::fix_build(fields, 0);
         if log::log_enabled!(log::Level::Trace) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,12 +263,22 @@ pub struct Order {
     pub tif: u8,
     /// FIX tag 99 stop price (for Stop/StopLimit/MIT/LIT orders)
     pub stop_price: Price,
+    /// FIX tag 6433 OutsideRTH. Tracked so a replace can restate it: the
+    /// server reads the flag off the replace, so a modify that guesses would
+    /// silently change when the order is eligible to execute.
+    pub outside_rth: bool,
 }
 
 impl Order {
     /// Create a new tracked order with FIX type metadata.
     pub fn new(order_id: OrderId, instrument: InstrumentId, side: Side, qty: u32, price: Price, ord_type: u8, tif: u8, stop_price: Price) -> Self {
-        Self { order_id, instrument, side, price, qty, filled: 0, status: OrderStatus::PendingSubmit, ord_type, tif, stop_price }
+        Self { order_id, instrument, side, price, qty, filled: 0, status: OrderStatus::PendingSubmit, ord_type, tif, stop_price, outside_rth: false }
+    }
+
+    /// Record that the order was submitted with OutsideRTH set.
+    pub fn with_outside_rth(mut self, outside_rth: bool) -> Self {
+        self.outside_rth = outside_rth;
+        self
     }
 }
 
@@ -2009,6 +2019,7 @@ mod tests {
             ord_type: b'2',
             tif: b'0',
             stop_price: 0,
+            outside_rth: false,
         };
         let o2 = o; // Copy
         assert_eq!(o.order_id, o2.order_id);

--- a/src/types.rs
+++ b/src/types.rs
@@ -304,9 +304,11 @@ impl AdaptivePriority {
 /// All fields default to "not set" (0/false).
 #[derive(Debug, Clone, Default)]
 pub struct OrderAttrs {
-    /// Show on book as this many shares (tag 111). 0 = not set (show full qty).
+    /// Show on book as this many shares (tag 6103). 0 = not set (show full qty).
+    /// The gateway requires a multiple of the contract's lot size.
     pub display_size: u32,
-    /// Minimum fill quantity (FIX tag 110). 0 = not set.
+    /// Minimum fill quantity. Not supported: no tag in this dialect carries it,
+    /// and a non-zero value is refused rather than sent.
     pub min_qty: u32,
     /// Hidden order — not displayed on book (IB tag 6135).
     pub hidden: bool,
@@ -345,9 +347,9 @@ pub struct OrderAttrs {
     pub cash_qty: Price,
     /// Conditions that must be met before the order activates (IB tag 6136+).
     pub conditions: Vec<OrderCondition>,
-    /// Cancel order if conditions are no longer met (IB tag 6128). Default false.
+    /// Cancel order if conditions are no longer met (IB tag 6579). Default false.
     pub conditions_cancel_order: bool,
-    /// Evaluate conditions outside regular trading hours (IB tag 6151). Default false.
+    /// Evaluate conditions outside regular trading hours (IB tag 6128). Default false.
     pub conditions_ignore_rth: bool,
     /// OCA cancellation semantics (IB tag 6209), 1..=4. 0 = not set, which
     /// emits the gateway default 3 (ReduceOnFillNonBlock). Only emitted when
@@ -611,7 +613,8 @@ pub enum OrderRequest {
         /// Optional initial stop trigger (tag 6117); 0 = not set.
         trail_stop_price: Price,
     },
-    /// Trailing stop by percentage (tag 6268). Trail percent is in basis points (1% = 100).
+    /// Trailing stop by percentage. Trail percent is in basis points (1% = 100);
+    /// it reaches the wire as a fraction on tag 9822, with 6268 stating the unit.
     SubmitTrailingStopPct {
         order_id: OrderId,
         instrument: InstrumentId,


### PR DESCRIPTION
> Stacked on #319. Review this one from its second commit.

## Summary

Four attributes were emitted on tags that do not carry them here. Each fix below was verified against a live session, with a control order differing only in the attribute under test.

Closes #338.
Closes #339.
Closes #327.

## Display size — 111 → 6103

| order | attribute | gateway echoes | status |
|---|---|---|---|
| control | none | `38=200` | PreSubmitted |
| A | `display_size: 100` on `111` | `38=0` | **Inactive** |

The quantity was sent correctly as `38=200` in both. On 111 the gateway reports it as zero and rejects.

On 6103 the same order is read as an iceberg — the gateway validates the value and says so:

```
REJECT: Display size should be a multiple of lot size
```

and a valid one rests:

```
qty=1000 display_size=200  →  PreSubmitted
```

## Minimum quantity — 110 → refused

Same failure on 110, and nothing in this dialect appears to carry it. It is now refused at the API boundary rather than emitted. That is the outcome the gateway was already producing, minus the round trip, and it says why — reusing the existing `all_or_none is not supported with TRAIL orders` pattern.

## Trailing percent — the value was on the unit tag

`6268` states the unit the trail is expressed in. The percentage, in basis points, was being written to it. Every value was rejected — the gateway names the field:

```
58=Invalid value in field # 6268
```

except exactly **1%**, which survived because 100 basis points collides with the code for "percent". Before and after:

| `trailing_percent` | before | after |
|---|---|---|
| 0.5% | Inactive | **PreSubmitted** |
| 1.0% | PreSubmitted | PreSubmitted |
| 2.0% | Inactive | **PreSubmitted** |
| 10.0% | Inactive | **PreSubmitted** |

The percentage now rides on `9822` as a fraction and `6268` carries the unit. Both encoders are fixed — the shared one for extended submissions had the same assignment.

The comment above that encoder cited a capture as its source. A capture taken at 1% confirms every part of the layout **including** the one field that was wrong, which is how it survived.

## Condition flags — they were on each other's tags

`conditions_ignore_rth` was landing on a field that is not a condition flag at all, which showed as an asymmetry: setting it dragged a third tag along, while `conditions_cancel_order` did not.

| flags set | before → echoed 6128 / 6151 / 6579 | after |
|---|---|---|
| neither | `0 / 0 / 0` | `0 / 0 / 0` |
| `cancel_order` | `1 / 0 / 0` | `0 / 1 / 1` |
| `ignore_rth` | `0 / 1 / 1` | `1 / 0 / 0` |

Each flag now sets exactly the field it names, and neither lands on the price field.

## Tests

Two tests drive the real send path over a loopback pair and read back what was written. Reverting display size to 111, re-crossing the condition flags, or putting the percentage back on 6268 each fail them.

## Test plan

- [x] `cargo test --offline --lib` — 815 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

