### PR TITLE
orders: refuse a quantity the wire cannot carry, rather than truncating it (ibx#313)

### DIFF
--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -31,6 +31,98 @@ fn spy() -> Contract {
 //  Algo parsing
 // ═══════════════════════════════════════════════════════════════════
 
+/// The quantity reaches the wire through `as u32`, which truncates. Asking for
+/// 1.5 shares sent an order for 1 and reported nothing — the fill, the status
+/// and the position were all consistent with an order that was never placed.
+#[test]
+fn a_fractional_quantity_is_refused_rather_than_truncated() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "BUY".into(), total_quantity: 1.5, order_type: "MKT".into(),
+        tif: "DAY".into(), ..Default::default()
+    };
+    let err = client.place_order(9101, &spy(), &order).expect_err("must be refused");
+    assert!(format!("{err}").contains("whole number"), "the error says why: {err}");
+    assert!(rx.try_recv().is_err(), "and nothing reaches the wire");
+}
+
+/// A quantity that is not a number, or is negative, or overflows the wire
+/// type, all reach `as u32` and become something the caller did not ask for.
+#[test]
+fn an_unusable_quantity_is_refused() {
+    for (qty, expect) in [
+        (f64::NAN, "finite"),
+        (f64::INFINITY, "finite"),
+        (-5.0, "negative"),
+        (5e9, "too large"),
+    ] {
+        let (client, _rx, _shared) = test_client();
+        let order = Order {
+            action: "BUY".into(), total_quantity: qty, order_type: "MKT".into(),
+            tif: "DAY".into(), ..Default::default()
+        };
+        let err = client.place_order(9102, &spy(), &order)
+            .expect_err("must be refused").to_string();
+        assert!(err.contains(expect), "quantity {qty}: expected {expect:?}, got: {err}");
+    }
+}
+
+/// The boundaries, exactly. Each of these was reachable by a mutation that the
+/// round-number cases above could not see: rejecting the valid maximum,
+/// admitting one past it, admitting a small negative, admitting a fraction
+/// near a half, and misclassifying negative infinity.
+#[test]
+fn the_quantity_boundaries_are_exact() {
+    let place = |qty: f64| {
+        let (client, _rx, _shared) = test_client();
+        let order = Order {
+            action: "BUY".into(), total_quantity: qty, order_type: "MKT".into(),
+            tif: "DAY".into(), ..Default::default()
+        };
+        client.place_order(9601, &spy(), &order)
+    };
+
+    assert!(place(u32::MAX as f64).is_ok(), "the largest carryable quantity still places");
+    assert!(place(u32::MAX as f64 + 1.0).is_err(), "one past it does not");
+    assert!(place(-1.0).is_err(), "a small negative is refused, not just a large one");
+    assert!(place(1.25).is_err(), "a fraction below a half is refused too");
+    assert!(place(f64::NEG_INFINITY).is_err(), "negative infinity is not finite either");
+}
+
+/// A cash-quantity order states its size in currency and carries no shares, so
+/// zero is only wrong when nothing else says how much to buy.
+#[test]
+fn zero_shares_is_refused_unless_the_order_is_cash_sized() {
+    let (client, rx, _shared) = test_client();
+    let bare = Order {
+        action: "BUY".into(), total_quantity: 0.0, order_type: "MKT".into(),
+        tif: "DAY".into(), ..Default::default()
+    };
+    assert!(
+        client.place_order(9602, &spy(), &bare).is_err(),
+        "zero shares with no cash quantity is not an order",
+    );
+    assert!(rx.try_recv().is_err(), "and nothing reaches the wire");
+
+    let cash = Order {
+        action: "BUY".into(), total_quantity: 0.0, order_type: "LMT".into(),
+        lmt_price: 100.0, cash_qty: 1000.0, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9603, &spy(), &cash).expect("a cash-sized order still places");
+}
+
+/// Whole quantities are unaffected.
+#[test]
+fn a_whole_quantity_still_places() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "BUY".into(), total_quantity: 200.0, order_type: "MKT".into(),
+        tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9103, &spy(), &order).expect("a whole quantity places");
+    assert!(rx.try_recv().is_ok(), "and reaches the wire");
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -1266,6 +1266,33 @@ impl ClientCore {
     pub fn validate_order(order: &ApiOrder) -> Result<(), String> {
         order.side()?;
 
+        // The quantity reaches the wire through `as u32`, which truncates. A
+        // caller asking for 1.5 was sent an order for 1 and told nothing —
+        // the fill, the status and the position were all consistent with an
+        // order they never placed. Fractional quantities are not carried on
+        // this path, so say so rather than rounding someone's size down.
+        if !order.total_quantity.is_finite() {
+            return Err("total_quantity must be a finite number".to_string());
+        }
+        if order.total_quantity < 0.0 {
+            return Err(format!("total_quantity {} is negative", order.total_quantity));
+        }
+        if order.total_quantity.fract() != 0.0 {
+            return Err(format!(
+                "total_quantity {} is not a whole number of shares, which this path cannot carry",
+                order.total_quantity
+            ));
+        }
+        if order.total_quantity > u32::MAX as f64 {
+            return Err(format!("total_quantity {} is too large", order.total_quantity));
+        }
+        // A cash-quantity order legitimately carries no shares — the size is
+        // stated in currency instead — so zero is only wrong when nothing else
+        // says how much to buy.
+        if order.total_quantity == 0.0 && order.cash_qty <= 0.0 {
+            return Err("total_quantity is zero and no cash_qty was supplied".to_string());
+        }
+
         // transmit=false cannot be honoured: every order is sent to the
         // broker immediately when place_order is called; there is no
         // staging concept. Accepting it would send a "staged" bracket


### PR DESCRIPTION
## Summary

- The order quantity reaches the wire through `as u32`, which truncates. A caller asking for **1.5 shares sent an order for 1**, and was told nothing.
- Observed on paper: `total_quantity: 1.5` goes out as `38=1` and fills one share. The fill, the status and the position are all internally consistent — with an order that was never placed.

```
35=D ... 55=SPY|54=1|38=1|40=1 ...
[status] oid=9021 Filled filled=1 remaining=0
```

Closes #313.

## Why the dangerous case is the quiet one

Below one share it fails loudly — `0.5` goes out as `38=0` and the order comes back Inactive. It is the values **above** one that cost money, because they look like they worked. Position sizing built on the requested quantity is wrong by the discarded fraction, and everything downstream inherits it.

The same cast also turns a non-finite quantity into zero or the maximum, and a negative one into a very large positive.

## Change

Refuse a quantity this path cannot carry, and say which one it is: not a whole number, not finite, negative, or larger than the wire type.

The encoder does have the pieces for fractional orders — a fixed-point scale, a quantity formatter, and a variant that puts `38=0.5` on the wire correctly — but nothing routes from the public API to them. Until something does, refusing is the honest answer; rounding a caller's size down in silence is not.

Whole quantities are unaffected, and there is a test pinning that.

## Tests

Four cases, each mutation-checked: dropping any one of the four guards fails them.

## Test plan

- [x] `cargo test --offline --lib` — 807 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

