### PR TITLE
ccp: stop reporting the OCA group as an order's parent (ibx#329)

### DIFF
--- a/src/api/client/dispatch.rs
+++ b/src/api/client/dispatch.rs
@@ -108,9 +108,15 @@ impl EClient {
         // Order updates → order_status
         for update in self.shared.orders.drain_order_updates() {
             let status = order_status_str(update.status);
+            // The engine cannot know the parent — nothing on the execution
+            // report carries one — but this client placed the order and was
+            // told. Prefer what it recorded; an order it did not place keeps
+            // the engine's answer of none.
+            let parent_id = self.core.tracked_parent_id(update.order_id)
+                .unwrap_or(update.parent_id);
             wrapper.order_status(
                 update.order_id as i64, status, update.filled_qty as f64,
-                update.remaining_qty as f64, 0.0, update.perm_id, update.parent_id, 0.0, 0, "", 0.0,
+                update.remaining_qty as f64, 0.0, update.perm_id, parent_id, 0.0, 0, "", 0.0,
             );
             self.core.update_order_status(update.order_id, status, update.filled_qty as f64, update.remaining_qty as f64);
         }

--- a/src/api/client/dispatch.rs
+++ b/src/api/client/dispatch.rs
@@ -51,9 +51,13 @@ impl EClient {
             let price_f = fill.price as f64 / PRICE_SCALE_F;
             let commission_and_fees_f = fill.commission as f64 / PRICE_SCALE_F;
             let status = if fill.remaining == 0 { "Filled" } else { "PartiallyFilled" };
-            let (perm_id, parent_id) = self.shared.orders.get_order_info(fill.order_id)
+            // A fill emits its own order_status and never reaches the branch
+            // below, so the client's record has to be preferred here too.
+            let (perm_id, engine_parent) = self.shared.orders.get_order_info(fill.order_id)
                 .map(|info| (info.order.perm_id, info.order.parent_id))
                 .unwrap_or((0, 0));
+            let parent_id = self.core.tracked_parent_id(fill.order_id)
+                .unwrap_or(engine_parent);
             wrapper.order_status(
                 fill.order_id as i64, status, fill.qty as f64, fill.remaining as f64,
                 price_f, perm_id, parent_id, price_f, 0, "", 0.0,
@@ -108,10 +112,9 @@ impl EClient {
         // Order updates → order_status
         for update in self.shared.orders.drain_order_updates() {
             let status = order_status_str(update.status);
-            // The engine cannot know the parent — nothing on the execution
-            // report carries one — but this client placed the order and was
-            // told. Prefer what it recorded; an order it did not place keeps
-            // the engine's answer of none.
+            // The engine reads no parent from the report, but this client
+            // placed the order and was told. Prefer what it recorded; an order
+            // it did not place keeps the engine's answer of none.
             let parent_id = self.core.tracked_parent_id(update.order_id)
                 .unwrap_or(update.parent_id);
             wrapper.order_status(
@@ -150,8 +153,9 @@ impl EClient {
                 .map(|t| (t.contract, t.order))
                 .unwrap_or_else(|| (Contract::default(), ApiOrder::default()));
             wrapper.open_order(wi.order_id as i64, &contract, &order, &state);
+            let parent_id = self.core.tracked_parent_id(wi.order_id).unwrap_or(0);
             wrapper.order_status(
-                wi.order_id as i64, "PreSubmitted", 0.0, 0.0, 0.0, 0, 0, 0.0, 0, "", 0.0,
+                wi.order_id as i64, "PreSubmitted", 0.0, 0.0, 0.0, 0, parent_id, 0.0, 0, "", 0.0,
             );
             self.core.open_orders.lock().unwrap().remove(&wi.order_id);
         }

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -31,6 +31,44 @@ fn spy() -> Contract {
 //  Algo parsing
 // ═══════════════════════════════════════════════════════════════════
 
+/// Nothing on an execution report carries a parent order id, so the engine
+/// reports none. This client placed the order and was told the parent, so it
+/// can answer where the engine cannot — and an order it did not place keeps
+/// the engine's answer rather than borrowing someone else's.
+#[test]
+fn a_locally_placed_child_reports_the_parent_it_was_given() {
+    let (client, rx, shared) = test_client();
+    let child = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "LMT".into(),
+        lmt_price: 110.0, tif: "DAY".into(), parent_id: 4242, ..Default::default()
+    };
+    client.place_order(9401, &spy(), &child).unwrap();
+    while rx.try_recv().is_ok() {}
+
+    shared.orders.push_order_update(OrderUpdate {
+        order_id: 9401, instrument: 0, status: OrderStatus::Submitted,
+        filled_qty: 0, remaining_qty: 1, perm_id: 0, parent_id: 0, timestamp_ns: 0,
+    });
+    let mut w = RecordingWrapper::default();
+    client.process_msgs(&mut w);
+    let status = w.events.iter().find(|e| e.starts_with("order_status:9401:"))
+        .expect("the status was dispatched");
+    assert!(status.contains(":9401:"), "{status}");
+    assert_eq!(
+        w.parent_ids.last().copied(), Some(4242),
+        "the parent this client recorded is reported: {:?}", w.events,
+    );
+
+    // An order this client never placed keeps the engine's answer.
+    shared.orders.push_order_update(OrderUpdate {
+        order_id: 9999, instrument: 0, status: OrderStatus::Submitted,
+        filled_qty: 0, remaining_qty: 1, perm_id: 0, parent_id: 0, timestamp_ns: 0,
+    });
+    let mut w2 = RecordingWrapper::default();
+    client.process_msgs(&mut w2);
+    assert_eq!(w2.parent_ids.last().copied(), Some(0), "no parent is invented");
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -69,6 +69,59 @@ fn a_locally_placed_child_reports_the_parent_it_was_given() {
     assert_eq!(w2.parent_ids.last().copied(), Some(0), "no parent is invented");
 }
 
+/// A fill emits its own order_status from a different branch, so the parent
+/// has to be preferred there as well. Before this it reported zero on every
+/// fill of a bracket child — the callback a caller is most likely to act on.
+#[test]
+fn a_fill_reports_the_parent_the_child_was_given() {
+    let (client, rx, shared) = test_client();
+    let child = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "LMT".into(),
+        lmt_price: 110.0, tif: "DAY".into(), parent_id: 4242, ..Default::default()
+    };
+    client.place_order(9402, &spy(), &child).unwrap();
+    while rx.try_recv().is_ok() {}
+
+    shared.orders.push_fill(Fill {
+        order_id: 9402, instrument: 0, side: Side::Sell, qty: 1, remaining: 0,
+        price: 110 * crate::types::PRICE_SCALE, commission: 0, timestamp_ns: 0,
+    });
+    let mut w = RecordingWrapper::default();
+    client.process_msgs(&mut w);
+    assert_eq!(
+        w.parent_ids.first().copied(), Some(4242),
+        "the fill's order_status carries the recorded parent: {:?}", w.events,
+    );
+}
+
+/// The margin preview reports its own status too, and hard-coded a zero
+/// parent. A preview of a bracket child that disowns it is the same wrong
+/// answer as the other two paths gave.
+#[test]
+fn a_what_if_preview_reports_the_parent_the_child_was_given() {
+    let (client, rx, shared) = test_client();
+    let child = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "LMT".into(),
+        lmt_price: 110.0, tif: "DAY".into(), parent_id: 4242, what_if: true,
+        ..Default::default()
+    };
+    client.place_order(9403, &spy(), &child).unwrap();
+    while rx.try_recv().is_ok() {}
+
+    shared.orders.push_what_if(WhatIfResponse {
+        order_id: 9403, instrument: 0,
+        init_margin_before: 0, maint_margin_before: 0, equity_with_loan_before: 0,
+        init_margin_after: 0, maint_margin_after: 0, equity_with_loan_after: 0,
+        commission: 0,
+    });
+    let mut w = RecordingWrapper::default();
+    client.process_msgs(&mut w);
+    assert_eq!(
+        w.parent_ids.first().copied(), Some(4242),
+        "the preview carries the recorded parent: {:?}", w.events,
+    );
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/api/wrapper.rs
+++ b/src/api/wrapper.rs
@@ -220,6 +220,8 @@ pub mod tests {
     /// A Wrapper impl that records all callback invocations for testing.
     #[derive(Default)]
     pub struct RecordingWrapper {
+        /// Parent ids seen on `order_status`, in order.
+        pub parent_ids: Vec<i64>,
         pub events: Vec<String>,
     }
 
@@ -244,9 +246,10 @@ pub mod tests {
         }
         fn order_status(
             &mut self, order_id: i64, status: &str, filled: f64, remaining: f64,
-            avg_fill_price: f64, _: i64, _: i64, _: f64, _: i64, _: &str, _: f64,
+            avg_fill_price: f64, _: i64, parent_id: i64, _: f64, _: i64, _: &str, _: f64,
         ) {
             self.events.push(format!("order_status:{order_id}:{status}:{filled}:{remaining}:{avg_fill_price}"));
+            self.parent_ids.push(parent_id);
         }
         fn open_order(&mut self, order_id: i64, _contract: &Contract, _order: &Order, state: &OrderState) {
             self.events.push(format!(

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -759,18 +759,19 @@ impl ClientCore {
 
     // ── Open order tracking ──
 
-    /// Check if an order with this ID is currently tracked (for modify detection).
     /// The parent this client recorded when it placed the order, if any.
     ///
-    /// Nothing on an execution report carries a parent order id, so this is the
-    /// only place one is known — and only for orders this client placed.
-    pub fn tracked_parent_id(&self, order_id: u64) -> Option<i64> {
+    /// The engine reads no parent from an execution report, so for an order
+    /// this client placed its own record is the only source. An order placed
+    /// elsewhere keeps whatever the engine reports.
+    pub(crate) fn tracked_parent_id(&self, order_id: u64) -> Option<i64> {
         self.open_orders.lock().unwrap()
             .get(&order_id)
             .map(|t| t.order.parent_id)
             .filter(|p| *p > 0)
     }
 
+    /// Check if an order with this ID is currently tracked (for modify detection).
     pub fn is_order_tracked(&self, order_id: u64) -> bool {
         self.open_orders.lock().unwrap().contains_key(&order_id)
     }

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -760,6 +760,17 @@ impl ClientCore {
     // ── Open order tracking ──
 
     /// Check if an order with this ID is currently tracked (for modify detection).
+    /// The parent this client recorded when it placed the order, if any.
+    ///
+    /// Nothing on an execution report carries a parent order id, so this is the
+    /// only place one is known — and only for orders this client placed.
+    pub fn tracked_parent_id(&self, order_id: u64) -> Option<i64> {
+        self.open_orders.lock().unwrap()
+            .get(&order_id)
+            .map(|t| t.order.parent_id)
+            .filter(|p| *p > 0)
+    }
+
     pub fn is_order_tracked(&self, order_id: u64) -> bool {
         self.open_orders.lock().unwrap().contains_key(&order_id)
     }

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -2207,12 +2207,17 @@ mod tests {
                     (583, group),
                 ]);
                 ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
-                for update in shared.orders.drain_order_updates() {
-                    assert_eq!(
-                        update.parent_id, 0,
-                        "group {group:?} at status {ord_status} must not become a parent",
-                    );
-                }
+                let updates = shared.orders.drain_order_updates();
+                // Without this a case that produced no update at all would
+                // pass the loop below by never entering it.
+                assert_eq!(
+                    updates.len(), 1,
+                    "group {group:?} at status {ord_status} must produce one update",
+                );
+                assert_eq!(
+                    updates[0].parent_id, 0,
+                    "group {group:?} at status {ord_status} must not become a parent",
+                );
             }
         }
     }
@@ -2229,9 +2234,12 @@ mod tests {
         assert_eq!(updates[0].parent_id, 0);
     }
 
-    /// Tag 6107 is what the bracket path *sends* a parent on, and it is a
-    /// client id rather than an order id — reading it back would be the same
-    /// mistake in a new place.
+    /// Tag 6107 is what the bracket path *sends* a parent on. Whether the
+    /// gateway ever echoes it on a report has not been established here, and
+    /// the engine does not read it either way; this pins that, so wiring it up
+    /// becomes a deliberate change with evidence behind it rather than a
+    /// silent one. It passes on the old implementation too — it guards a
+    /// different invariant from the rest of this change.
     #[test]
     fn tag_6107_is_not_read_back_as_a_parent() {
         let (mut ccp, mut context, shared) = ord_status_test_state();

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -880,7 +880,12 @@ impl CcpState {
         if status_changed && !had_fill {
             if let Some(order) = context.order(clord_id).copied() {
                 let perm_id: i64 = parsed.get(&37).map(|s| perm_id_from_fix_order_id(s)).unwrap_or(0);
-                let parent_id: i64 = parsed.get(&583).map(|s| perm_id_from_fix_order_id(s)).unwrap_or(0);
+                // Tag 583 is the link id this engine sends the OCA group on, not
+                // a parent order. Hashing it produced a stable non-zero value
+                // shared by every order in a group, none of which has a parent,
+                // and nothing distinguished it from a real link. Nothing on
+                // this report carries a parent order id, so report none.
+                let parent_id: i64 = 0;
                 let update = crate::types::OrderUpdate {
                     order_id: clord_id,
                     instrument: order.instrument,
@@ -2166,6 +2171,89 @@ mod tests {
             42, instrument, Side::Buy, 1, 100 * PRICE_SCALE, b'2', b'0', 0,
         )); // starts at PendingSubmit
         (CcpState::new(), context, SharedState::new())
+    }
+
+    /// Tag 583 is the link id the engine sends the OCA group on. Reading it
+    /// back as a parent produced a stable non-zero value shared by every order
+    /// in the group — none of which has a parent — and nothing told it apart
+    /// from a real link.
+    #[test]
+    fn an_oca_group_is_not_reported_as_a_parent() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = exec_report_frame(&[
+            (39, "0"), (150, "0"), (100, "ARCA"), (198, "ARCA:1"),
+            (583, "PROBE-OCA-1"),
+        ]);
+
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        let updates = shared.orders.drain_order_updates();
+        assert_eq!(updates.len(), 1, "the status is still reported");
+        assert_eq!(
+            updates[0].parent_id, 0,
+            "an order in an OCA group has no parent, so none is reported",
+        );
+    }
+
+    /// Not just the one group name, and not just one status: any value on 583
+    /// is a link id rather than a parent, at every point in the order's life.
+    #[test]
+    fn no_group_name_or_status_produces_a_parent() {
+        for group in ["PROBE-OCA-1", "G", "12345", "a name with spaces"] {
+            for (ord_status, exec_type) in [("0", "0"), ("1", "2"), ("2", "2"), ("4", "4")] {
+                let (mut ccp, mut context, shared) = ord_status_test_state();
+                let frame = exec_report_frame(&[
+                    (39, ord_status), (150, exec_type), (100, "ARCA"), (198, "ARCA:1"),
+                    (583, group),
+                ]);
+                ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+                for update in shared.orders.drain_order_updates() {
+                    assert_eq!(
+                        update.parent_id, 0,
+                        "group {group:?} at status {ord_status} must not become a parent",
+                    );
+                }
+            }
+        }
+    }
+
+    /// A report carrying no group reported no parent before this change too, so
+    /// that case alone cannot tell the fix from the bug.
+    #[test]
+    fn a_report_without_a_group_still_has_no_parent() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = exec_report_frame(&[(39, "0"), (150, "0"), (100, "ARCA"), (198, "ARCA:1")]);
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+        let updates = shared.orders.drain_order_updates();
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].parent_id, 0);
+    }
+
+    /// Tag 6107 is what the bracket path *sends* a parent on, and it is a
+    /// client id rather than an order id — reading it back would be the same
+    /// mistake in a new place.
+    #[test]
+    fn tag_6107_is_not_read_back_as_a_parent() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = exec_report_frame(&[
+            (39, "0"), (150, "0"), (100, "ARCA"), (198, "ARCA:1"), (6107, "4242"),
+        ]);
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+        let updates = shared.orders.drain_order_updates();
+        assert_eq!(updates[0].parent_id, 0, "6107 is a client id, not a parent order");
+    }
+
+    /// The order id hash on tag 37 is a separate concern and must keep working.
+    #[test]
+    fn the_order_id_still_produces_a_stable_perm_id() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = exec_report_frame(&[
+            (39, "0"), (150, "0"), (100, "ARCA"), (198, "ARCA:1"),
+            (37, "0256d0f1.0001417e.6a6982d2.0001"),
+        ]);
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+        let updates = shared.orders.drain_order_updates();
+        assert_ne!(updates[0].perm_id, 0, "the order id still yields a permId");
     }
 
     fn exec_report_frame(pairs: &[(u32, &str)]) -> std::collections::HashMap<u32, String> {

--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -57,9 +57,13 @@ impl EClient {
             let commission = fill.commission as f64 / PRICE_SCALE_F;
 
             let status = if fill.remaining == 0 { "Filled" } else { "PartiallyFilled" };
-            let (perm_id, parent_id) = shared.orders.get_order_info(fill.order_id)
+            // A fill emits its own order_status and never reaches the branch
+            // below, so the client's record has to be preferred here too.
+            let (perm_id, engine_parent) = shared.orders.get_order_info(fill.order_id)
                 .map(|info| (info.order.perm_id, info.order.parent_id))
                 .unwrap_or((0, 0));
+            let parent_id = self.core.tracked_parent_id(fill.order_id)
+                .unwrap_or(engine_parent);
             call_wrapper!(self.wrapper, py, "order_status", (fill.order_id as i64, status, fill.qty as f64, fill.remaining as f64,
                  price, perm_id, parent_id, price, 0i64, "", 0.0f64));
 
@@ -159,10 +163,9 @@ impl EClient {
         let updates = shared.orders.drain_order_updates();
         for update in updates {
             let status = order_status_str(update.status);
-            // The engine cannot know the parent — nothing on the execution
-            // report carries one — but this client placed the order and was
-            // told. Prefer what it recorded; an order it did not place keeps
-            // the engine's answer of none.
+            // The engine reads no parent from the report, but this client
+            // placed the order and was told. Prefer what it recorded; an order
+            // it did not place keeps the engine's answer of none.
             let parent_id = self.core.tracked_parent_id(update.order_id)
                 .unwrap_or(update.parent_id);
             call_wrapper!(self.wrapper, py, "order_status", (update.order_id as i64, status, update.filled_qty as f64,
@@ -314,8 +317,9 @@ impl EClient {
             let state_py = Py::new(py, state)?.into_any();
             call_wrapper!(self.wrapper, py, "open_order",
                 (wi.order_id as i64, &contract_py, &order_py, &state_py));
+            let parent_id = self.core.tracked_parent_id(wi.order_id).unwrap_or(0);
             call_wrapper!(self.wrapper, py, "order_status", (wi.order_id as i64, "PreSubmitted", 0.0f64, 0.0f64,
-                 0.0f64, 0i64, 0i64, 0.0f64, 0i64, "", 0.0f64));
+                 0.0f64, 0i64, parent_id, 0.0f64, 0i64, "", 0.0f64));
             self.core.open_orders.lock().unwrap().remove(&wi.order_id);
         }
 

--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -159,8 +159,14 @@ impl EClient {
         let updates = shared.orders.drain_order_updates();
         for update in updates {
             let status = order_status_str(update.status);
+            // The engine cannot know the parent — nothing on the execution
+            // report carries one — but this client placed the order and was
+            // told. Prefer what it recorded; an order it did not place keeps
+            // the engine's answer of none.
+            let parent_id = self.core.tracked_parent_id(update.order_id)
+                .unwrap_or(update.parent_id);
             call_wrapper!(self.wrapper, py, "order_status", (update.order_id as i64, status, update.filled_qty as f64,
-                 update.remaining_qty as f64, 0.0f64, update.perm_id, update.parent_id, 0.0f64, 0i64, "", 0.0f64));
+                 update.remaining_qty as f64, 0.0f64, update.perm_id, parent_id, 0.0f64, 0i64, "", 0.0f64));
 
             // Track open orders
             self.core.update_order_status(update.order_id, status, update.filled_qty as f64, update.remaining_qty as f64);

--- a/src/python/compat/client/test_helpers.rs
+++ b/src/python/compat/client/test_helpers.rs
@@ -182,9 +182,13 @@ impl EClient {
 
     /// Track an order locally (for req_open_orders regression tests).
     #[doc(hidden)]
+    #[pyo3(signature = (
+        order_id, instrument, symbol, action, total_quantity, lmt_price, parent_id=0,
+    ))]
     fn _test_track_order(
         &self, order_id: u64, instrument: u32,
         symbol: &str, action: &str, total_quantity: f64, lmt_price: f64,
+        parent_id: i64,
     ) -> PyResult<()> {
         use crate::api::types::{Contract as ApiContract, Order as ApiOrder};
         let contract = ApiContract {
@@ -200,6 +204,7 @@ impl EClient {
             total_quantity,
             order_type: "LMT".into(),
             lmt_price,
+            parent_id,
             ..Default::default()
         };
         self.core.track_order(order_id, contract, order, instrument);

--- a/tests/python/test_issue_329.py
+++ b/tests/python/test_issue_329.py
@@ -1,0 +1,79 @@
+"""IBX Test #329: a bracket child must report the parent it was placed with.
+
+The engine reads no parent from an execution report, so for an order this
+client placed its own record is the only source. The Rust client prefers that
+record on all three callback paths; these cover the two the Python client also
+has, which its own tests did not reach.
+
+Reverting either Python lookup leaves every Rust test passing, which is how
+the gap was found.
+
+Run: pytest tests/python/test_issue_329.py -v
+"""
+
+from ibx import EWrapper, EClient
+
+PARENT_ID = 4242
+CHILD_ID = 9401
+CON_ID = 756733
+
+
+class Recorder(EWrapper):
+    def __init__(self):
+        self.parents = []
+
+    def order_status(self, order_id, status, filled, remaining, avg_fill_price,
+                     perm_id, parent_id, last_fill_price, client_id, why_held,
+                     mkt_cap_price):
+        self.parents.append((order_id, parent_id))
+
+
+def tracked_child():
+    """A connected client with one tracked child of PARENT_ID."""
+    w = Recorder()
+    c = EClient(w)
+    c._test_connect()
+    c._test_map_instrument(1, 0)
+    c._test_track_order(CHILD_ID, 0, "SPY", "SELL", 1.0, 110.0, PARENT_ID)
+    return w, c
+
+
+def test_a_fill_reports_the_parent_the_child_was_given():
+    """A fill emits its own order_status from a separate branch.
+
+    This is the callback a caller is most likely to act on, and it reported
+    zero for every bracket child.
+    """
+    w, c = tracked_child()
+    c._test_push_fill(0, CHILD_ID, "SELL", 110.0, 1, 0, 0.0)
+    c._test_dispatch_once()
+
+    assert w.parents, "a fill must produce an order_status"
+    assert w.parents[0] == (CHILD_ID, PARENT_ID)
+
+
+def test_a_what_if_preview_reports_the_parent_the_child_was_given():
+    """The margin preview emits a third order_status, which hard-coded zero."""
+    w, c = tracked_child()
+    c._test_push_what_if(CHILD_ID, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    c._test_dispatch_once()
+
+    assert w.parents, "a preview must produce an order_status"
+    assert w.parents[0] == (CHILD_ID, PARENT_ID)
+
+
+def test_an_order_this_client_did_not_place_keeps_the_engines_answer():
+    """The positive control for the two above: no parent is invented.
+
+    Without this, both assertions would pass just as well against a client
+    that reported PARENT_ID for everything.
+    """
+    w = Recorder()
+    c = EClient(w)
+    c._test_connect()
+    c._test_map_instrument(1, 0)
+    c._test_push_fill(0, 9999, "SELL", 110.0, 1, 0, 0.0)
+    c._test_dispatch_once()
+
+    assert w.parents, "an untracked fill still produces an order_status"
+    assert w.parents[0] == (9999, 0)


### PR DESCRIPTION
## Summary

The engine writes the OCA group to tag 583 on the way out, in three places, and read the same tag back in as the parent order id — hashed into the `i64` the callback exposes. Both cannot be right.

```rust
(583, &oca_group),         // OCAGroup                          ← outbound
let parent_id = parsed.get(&583).map(perm_id_from_fix_order_id) // ← inbound
```

Closes #329.

## Evidence

583 is the group. Two orders placed in group `PROBE-OCA-1`, then one cancelled — the gateway cancelled the sibling, which is what an OCA group is for:

```
== placing BUY 1 SPY LMT 100 oca=PROBE-OCA-1 (oid=9401)
== placing BUY 1 SPY LMT 101 oca=PROBE-OCA-1 (oid=9402)
== cancelling oid=9401
[status] oid=9402 Cancelled          ← sibling went with it
```

The inbound reports carry the group on 583 for both, with distinct order ids:

```
oid=9401.0   583=PROBE-OCA-1   37=0256d0f1.0001417e.6a698306.0001
oid=9402.0   583=PROBE-OCA-1   37=0256d0f1.0001417e.6a698308.0001
```

and the parent reported for them was:

```
[status] oid=9401 PreSubmitted parent_id=9132926678952268133
[status] oid=9402 PreSubmitted parent_id=9132926678952268133
```

The same non-zero number for two orders that have no parent — the hash of the group name.

## Impact

Anything reconstructing order relationships from the callbacks — a bracket tracker, a position attributor, a UI grouping children under parents — reads that as a real link and builds the wrong tree. It never reads as missing data, which is what would make it easy to notice: a non-OCA order has no 583, reports zero, and looks correct. The wrong value appears exactly when a group is in use.

## Change

Nothing on the execution report carries a parent order id, so none is reported. An unknown parent is a worse answer than a correct one and a much better answer than a confident wrong one.

## Tests

An order carrying an OCA group reports no parent, and its status is still delivered. Restoring the hash fails it.

## Test plan

- [x] `cargo test --offline --lib` — 810 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too: the host has no legacy timezone files (fixed separately in #336).
- [x] `cargo check --offline --features python` — clean.
- [x] Mutation check: reverting the fill-path parent fails `a_fill_reports_the_parent_the_child_was_given`; reverting the preview path fails `a_what_if_preview_reports_the_parent_the_child_was_given`.
- [ ] Not covered: reverting the type-4 dispatch itself fails no test — the route-to-gate step runs inside `connect`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

