### PR TITLE
gateway: reconnect to the trading farm the auth server named (ibx#295)

### DIFF
--- a/bench/bench_harness.rs
+++ b/bench/bench_harness.rs
@@ -95,7 +95,13 @@ impl BenchSession {
         let shared = Arc::new(SharedState::new());
         let (event_tx, event_rx) = bounded::<Event>(65536);
         let (mut hot_loop, control_tx) =
-            gw.into_hot_loop(shared.clone(), Some(event_tx), farm_conn, ccp_conn, hmds_conn, None);
+            gw.into_hot_loop(shared.clone(), Some(event_tx), farm_conn, ccp_conn, hmds_conn, None,
+                ibx::gateway::CallerAuth {
+                    host: gw_config.host.clone(),
+                    username: gw_config.username.clone(),
+                    password: gw_config.password.clone(),
+                    paper: gw_config.paper,
+                });
 
         let join = std::thread::spawn(move || {
             hot_loop.run();

--- a/examples/ex151_srp_fallback.rs
+++ b/examples/ex151_srp_fallback.rs
@@ -53,6 +53,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         encoded: gw.encoded.clone(),
         hmds_host: gw.hmds_host.clone(),
         hmds_farm: gw.hmds_farm.clone(),
+        trading_host: String::new(),
+        trading_farm: String::new(),
     };
 
     drop(ccp);

--- a/src/api/client/mod.rs
+++ b/src/api/client/mod.rs
@@ -196,6 +196,12 @@ impl EClient {
 
         let (hot_loop, control_tx) = gw.into_hot_loop_with_farms(
             shared.clone(), event_tx, farm_conn, ccp_conn, hmds_conn, config.core_id,
+            crate::gateway::CallerAuth {
+                host: config.host.clone(),
+                username: config.username.clone(),
+                password: zeroize::Zeroizing::new(config.password.clone()),
+                paper: config.paper,
+            },
         );
 
         let handle = thread::Builder::new()

--- a/src/bin/benchmark.rs
+++ b/src/bin/benchmark.rs
@@ -185,6 +185,12 @@ fn main() {
     let (event_tx, event_rx) = bounded::<Event>(65536);
     let (mut hot_loop, control_tx) = gw.into_hot_loop(
         shared, Some(event_tx), farm_conn, ccp_conn, hmds_conn, None,
+        ibx::gateway::CallerAuth {
+            host: config.host.clone(),
+            username: config.username.clone(),
+            password: config.password.clone(),
+            paper: config.paper,
+        },
     );
 
     // Subscribe to instrument

--- a/src/engine/hot_loop/mod.rs
+++ b/src/engine/hot_loop/mod.rs
@@ -792,21 +792,6 @@ impl HotLoop {
         self.reconnect_auth = Some(auth);
     }
 
-    /// Update caller-specific fields on the reconnect auth (host, username, password, paper).
-    pub fn update_reconnect_auth(
-        &mut self,
-        host: String,
-        username: String,
-        password: zeroize::Zeroizing<String>,
-        paper: bool,
-    ) {
-        if let Some(auth) = self.reconnect_auth.as_mut() {
-            auth.host = host;
-            auth.username = username;
-            auth.password = password;
-            auth.paper = paper;
-        }
-    }
 
     /// Schedule-then-spawn farm reconnects on the jittered backoff ladder
     /// (ibx#218). Called every loop iteration; no-op while connected or an
@@ -878,8 +863,10 @@ impl HotLoop {
         std::thread::Builder::new()
             .name(format!("farm-reconnect-{}", attempt))
             .spawn(move || {
+                let (farm_host, farm_name) =
+                    crate::gateway::reconnect_trading_route(&auth);
                 let result = connect_farm(
-                    &auth.host, "usfarm",
+                    &farm_host, &farm_name,
                     &auth.username, &auth.password, auth.paper,
                     &auth.server_session_id, &auth.session_key,
                     &auth.hw_info, &auth.encoded, 18,

--- a/src/gateway.rs
+++ b/src/gateway.rs
@@ -55,6 +55,8 @@ pub fn parse_misc_urls(s: &str) -> std::collections::HashMap<String, String> {
     }
     out
 }
+/// Farm name used when the auth server states no trading route.
+pub(crate) const DEFAULT_TRADING_FARM: &str = "usfarm";
 
 /// Parse a farm-route string from the auth-server's routing tags.
 ///
@@ -72,6 +74,27 @@ pub fn parse_farm_route(route: &str) -> Option<(String, String)> {
     let farm = parts.next()?.to_string();
     if host.is_empty() || farm.is_empty() { return None; }
     Some((host, farm))
+}
+
+/// The trading route a reconnect should use.
+///
+/// The auth server states one per account, and the reconnect used to ignore it
+/// — announcing the literal `usfarm` and connecting to the host the caller
+/// configured, so a regional account reconnected under a farm it is not on
+/// (ibx#295). Empty means no route was parsed, which is the case the literals
+/// were there for; the initial connect falls back the same way.
+pub(crate) fn reconnect_trading_route(auth: &ReconnectAuth) -> (String, String) {
+    let host = if auth.trading_host.is_empty() {
+        auth.host.clone()
+    } else {
+        auth.trading_host.clone()
+    };
+    let farm = if auth.trading_farm.is_empty() {
+        DEFAULT_TRADING_FARM.to_string()
+    } else {
+        auth.trading_farm.clone()
+    };
+    (host, farm)
 }
 
 /// Returns true if `buf` contains at least one complete `8=O` (binary) or
@@ -384,6 +407,20 @@ fn try_frame_farm_msg(buf: &[u8]) -> Option<(Vec<u8>, usize)> {
     Some((buf[..total].to_vec(), total))
 }
 
+/// The connect-time credentials a reconnect needs, supplied by whichever
+/// binding built the session.
+///
+/// A constructor parameter rather than a setter called afterwards: leaving
+/// these blank for the caller to fill meant one binding filled them and the
+/// other did not, and every reconnect scheduler silently refused to run on the
+/// empty host (ibx#378). The compiler asks for them now.
+pub struct CallerAuth {
+    pub host: String,
+    pub username: String,
+    pub password: Zeroizing<String>,
+    pub paper: bool,
+}
+
 /// Credentials cached for auto-reconnect (no SRP needed).
 #[derive(Clone)]
 pub struct ReconnectAuth {
@@ -401,6 +438,13 @@ pub struct ReconnectAuth {
     /// Used by HMDS reconnect (ibx#187) — empty when no HMDS route was parsed.
     pub hmds_host: String,
     pub hmds_farm: String,
+    /// Trading farm routing exactly as parsed from the same response — empty
+    /// when the auth server stated none, rather than carrying the fallback the
+    /// initial connect materializes. The distinction matters: an empty host
+    /// lets the reconnect use whatever host the session has now, which a
+    /// redirect may have changed since (ibx#295).
+    pub trading_host: String,
+    pub trading_farm: String,
 }
 
 /// Full gateway connection.
@@ -436,6 +480,10 @@ pub struct Gateway {
     /// retained for HMDS reconnect (ibx#187).
     pub hmds_host: String,
     pub hmds_farm: String,
+    /// Trading farm routing from the same response, retained so the trading
+    /// reconnect uses the route the auth server gave rather than a literal.
+    pub trading_host: String,
+    pub trading_farm: String,
 }
 
 /// Connect to a data farm: key exchange → encrypted logon → token auth → routing → Connection.
@@ -1610,8 +1658,14 @@ impl Gateway {
         //   trading (6145):  "<host>/<farm>"            (port from tag 6146, default 4000)
         //   mktdata (6171):  "<host>/<farm>/<port>"
         //   secdef  (8008):  "<host>/<farm>/<port>"
-        let (trading_host, trading_farm) = parse_farm_route(&trading_route)
-            .unwrap_or_else(|| (host.to_string(), "usfarm".to_string()));
+        // Kept as parsed, before the fallback below materializes one. Storing
+        // the materialized pair would make "no route was given" indistinguishable
+        // from "the route happens to match the connect host", and the reconnect
+        // would then prefer a stale host over one the caller has since updated
+        // through a redirect.
+        let parsed_trading = parse_farm_route(&trading_route);
+        let (trading_host, trading_farm) = parsed_trading.clone()
+            .unwrap_or_else(|| (host.to_string(), DEFAULT_TRADING_FARM.to_string()));
         let (mktdata_host, mktdata_farm) = parse_farm_route(&mktdata_route)
             .map(|(h, f)| (h, f))
             .unwrap_or_else(|| (host.to_string(), "ushmds".to_string()));
@@ -1622,6 +1676,8 @@ impl Gateway {
         // below are moved into the thread::scope closures.
         let hmds_host_for_gw = mktdata_host.clone();
         let hmds_farm_for_gw = mktdata_farm.clone();
+        let (trading_host_for_gw, trading_farm_for_gw) =
+            parsed_trading.unwrap_or_default();
 
         // Parallel farm logons: validated against paper and live (each farm
         // logon is ~6 s sequentially; running them in parallel halves the
@@ -1670,6 +1726,8 @@ impl Gateway {
             ccp_sign_iv,
             hmds_host: hmds_host_for_gw,
             hmds_farm: hmds_farm_for_gw,
+            trading_host: trading_host_for_gw,
+            trading_farm: trading_farm_for_gw,
         };
         Ok((gw, farm_conn, ccp_conn, hmds_conn))
     }
@@ -1789,8 +1847,9 @@ impl Gateway {
         ccp_conn: Connection,
         hmds_conn: Option<Connection>,
         core_id: Option<usize>,
+        caller: CallerAuth,
     ) -> (HotLoop, Sender<ControlCommand>) {
-        self.into_hot_loop_with_farms(shared, event_tx, farm_conn, ccp_conn, hmds_conn, core_id)
+        self.into_hot_loop_with_farms(shared, event_tx, farm_conn, ccp_conn, hmds_conn, core_id, caller)
     }
 
     /// Create the control channel and build a HotLoop with farm connections.
@@ -1802,13 +1861,14 @@ impl Gateway {
         ccp_conn: Connection,
         hmds_conn: Option<Connection>,
         core_id: Option<usize>,
+        caller: CallerAuth,
     ) -> (HotLoop, Sender<ControlCommand>) {
         let (tx, rx) = bounded(64);
         let reconnect_auth = ReconnectAuth {
-            host: String::new(), // Filled by caller (Python EClient or Rust API)
-            username: String::new(), // Filled by caller
-            password: Zeroizing::new(String::new()), // Filled by caller
-            paper: false, // Filled by caller
+            host: caller.host,
+            username: caller.username,
+            password: caller.password,
+            paper: caller.paper,
             session_key: self.session_token.clone(),
             session_token: self.session_token.clone(),
             server_session_id: self.server_session_id.clone(),
@@ -1816,6 +1876,8 @@ impl Gateway {
             encoded: self.encoded.clone(),
             hmds_host: self.hmds_host.clone(),
             hmds_farm: self.hmds_farm.clone(),
+            trading_host: self.trading_host.clone(),
+            trading_farm: self.trading_farm.clone(),
         };
         if let Some(tx) = event_tx.as_ref() {
             let _ = tx.send(Event::GatewayLogon {
@@ -2204,5 +2266,63 @@ mod tests {
         };
         assert_eq!(config.username, "user");
         assert!(config.paper);
+    }
+
+    fn auth_with(host: &str, trading_host: &str, trading_farm: &str) -> ReconnectAuth {
+        ReconnectAuth {
+            host: host.to_string(),
+            username: String::new(),
+            password: zeroize::Zeroizing::new(String::new()),
+            paper: true,
+            session_key: num_bigint::BigUint::from(0u32),
+            session_token: num_bigint::BigUint::from(0u32),
+            server_session_id: String::new(),
+            hw_info: String::new(),
+            encoded: String::new(),
+            hmds_host: String::new(),
+            hmds_farm: String::new(),
+            trading_host: trading_host.to_string(),
+            trading_farm: trading_farm.to_string(),
+        }
+    }
+
+    /// ibx#295: the reconnect announced the literal `usfarm` and dialled the
+    /// configured host, ignoring the route the auth server gave for the
+    /// account. The historical-data reconnect beside it has always carried both
+    /// — this is the trading side catching up.
+    #[test]
+    fn a_reconnect_uses_the_route_the_auth_server_gave() {
+        assert_eq!(
+            reconnect_trading_route(&auth_with("cdc1.ibllc.com", "cdc2.ibllc.com", "euhard")),
+            ("cdc2.ibllc.com".to_string(), "euhard".to_string()),
+        );
+
+        // No route parsed: the literals it fell back to are still the answer,
+        // so an account that reconnected correctly before still does.
+        assert_eq!(
+            reconnect_trading_route(&auth_with("cdc1.ibllc.com", "", "")),
+            ("cdc1.ibllc.com".to_string(), "usfarm".to_string()),
+        );
+
+        // And each half falls back independently.
+        assert_eq!(
+            reconnect_trading_route(&auth_with("cdc1.ibllc.com", "", "euhard")),
+            ("cdc1.ibllc.com".to_string(), "euhard".to_string()),
+        );
+        assert_eq!(
+            reconnect_trading_route(&auth_with("cdc1.ibllc.com", "cdc2.ibllc.com", "")),
+            ("cdc2.ibllc.com".to_string(), "usfarm".to_string()),
+        );
+
+        // The reason the parsed route is stored raw rather than after the
+        // initial connect's fallback: with no route stated, the reconnect has
+        // to use whatever host the session holds now. Storing the materialized
+        // pair would pin the host as it was at connect time and ignore a
+        // redirect that has moved it since.
+        assert_eq!(
+            reconnect_trading_route(&auth_with("cdc3.ibllc.com", "", "")),
+            ("cdc3.ibllc.com".to_string(), "usfarm".to_string()),
+            "an updated host wins when the server stated no route",
+        );
     }
 }

--- a/src/python/compat/client/mod.rs
+++ b/src/python/compat/client/mod.rs
@@ -150,8 +150,15 @@ impl EClient {
         let connect_password = config.password.clone();
         let connect_paper = config.paper;
         let (event_tx, event_rx) = crossbeam_channel::bounded(256);
-        let (mut hot_loop, control_tx) = gw.into_hot_loop_with_farms(shared.clone(), Some(event_tx), farm_conn, ccp_conn, hmds_conn, core_id);
-        hot_loop.update_reconnect_auth(connect_host, connect_username, connect_password, connect_paper);
+        let (hot_loop, control_tx) = gw.into_hot_loop_with_farms(
+            shared.clone(), Some(event_tx), farm_conn, ccp_conn, hmds_conn, core_id,
+            crate::gateway::CallerAuth {
+                host: connect_host,
+                username: connect_username,
+                password: connect_password,
+                paper: connect_paper,
+            },
+        );
 
         let start_id = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)

--- a/tests/farm_reconnect_poc.rs
+++ b/tests/farm_reconnect_poc.rs
@@ -70,8 +70,13 @@ fn hotloop_auto_reconnect_on_farm_disconnect() {
     let (mut hot_loop, _control_tx) = gw.into_hot_loop_with_farms(
         shared.clone(), Some(event_tx),
         farm_conn, ccp_conn, hmds, None,
+        ibx::gateway::CallerAuth {
+            host: cfg.host.clone(),
+            username: cfg.username.clone(),
+            password: cfg.password.clone(),
+            paper: cfg.paper,
+        },
     );
-    hot_loop.update_reconnect_auth(cfg.host.clone(), cfg.username.clone(), cfg.password.clone(), cfg.paper);
     println!("Reconnect auth set: host={}, user={}, paper={}", cfg.host, cfg.username, cfg.paper);
 
     assert!(!hot_loop.is_farm_disconnected());
@@ -131,6 +136,8 @@ fn ccp_reconnect_with_cached_credentials() {
         encoded: gw.encoded.clone(),
         hmds_host: gw.hmds_host.clone(),
         hmds_farm: gw.hmds_farm.clone(),
+        trading_host: String::new(),
+        trading_farm: String::new(),
     };
 
     println!("Full auth: {}ms | session_id={}", full_auth_ms, auth.server_session_id);


### PR DESCRIPTION
## Problem

The auth server names the trading farm to use, and the reconnect path re-derived one instead of keeping it — so a session routed to a regional farm reconnected somewhere else.

## What this changes

`ReconnectAuth` carries the trading host and farm as the auth response gave them, and the reconnect selects that route rather than re-deriving one.

## The routing was unreachable

Nothing selected it. The reconnect credentials were left blank at construction for the caller to fill, and only the Python binding filled them:

```rust
host: String::new(), // Filled by caller (Python EClient or Rust API)
```

`EClient::connect_inner` never did. Every scheduler gates on a non-empty `auth.host`, so **no Rust caller reconnected on any transport** — farm, CCP or HMDS. The jittered backoff of #218 and the warm-up suppression of #219 were dead code for Rust callers.

The credentials are now a constructor parameter rather than a field set afterwards. `into_hot_loop_with_farms` takes a `CallerAuth`, both bindings pass one, and the setter that could be forgotten is gone — a binding that omits them does not compile. That is what closes the class rather than the instance; the compiler found two further construction sites in the bench harnesses while this was applied.

## Breaking change to the low-level API

`Gateway::into_hot_loop` and `into_hot_loop_with_farms` take a `CallerAuth`. `HotLoop::update_reconnect_auth` is removed — pass the values at construction instead. `Client`/`EClient` and the Python surface are unchanged.

Closes #295. Closes #378.


## Test plan

- [x] The credentials being a constructor parameter is enforced by the compiler, not by a test: it found two further construction sites in the bench harnesses while this was applied.
- [x] `tests/farm_reconnect_poc` updated to the new signature and checks clean.
- [x] `cargo check --offline` clean on `--lib`, `--lib --features python`, `--bins`, `--examples`, and each integration target individually.
- [x] `tests/ib_paper_compat` compared against a clean checkout of the base commit — identical sorted diagnostic sets.
- [x] `cargo test --offline --lib` — only the two known `config::expiry_tests` failures, which fail on the base commit for missing legacy tzdata (fixed separately in #336).
