### PR TITLE
orders: assert that outside-RTH is absent when it was not asked for (ibx#352)

### DIFF
--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -2057,3 +2057,68 @@ mod tests {
         assert!(shared.orders.drain_order_updates().is_empty());
     }
 }
+
+#[cfg(test)]
+mod outside_rth_polarity_tests {
+    use super::*;
+    use crate::protocol::connection::Connection;
+    use std::io::Read;
+
+    /// Drive the queued orders and read what actually reaches the socket.
+    fn drain(context: &mut Context) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = std::net::TcpStream::connect(addr).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(5))).unwrap();
+        let mut conn = Some(Connection::new_raw(client).unwrap());
+
+        let shared = std::sync::Arc::new(SharedState::new());
+        let mut hb = HeartbeatState::new();
+        drain_and_send_orders(&mut conn, context, "DU111111", &mut hb, false, &shared);
+
+        let mut buf = vec![0u8; 8192];
+        let n = peer.read(&mut buf).unwrap();
+        String::from_utf8_lossy(&buf[..n]).replace('\u{1}', "|")
+    }
+
+    /// Every submit path guards tag 6433, and nothing asserted the guard: the
+    /// assertions checked that the flag is present when the caller asked for
+    /// it, never that it is absent when they did not. Making every encoder emit
+    /// it unconditionally therefore failed no test.
+    ///
+    /// That is the shape ibx#247 took on the replace path, where a hard-coded
+    /// 6433 opted every modified order into the extended session. An order
+    /// widened to outside regular hours fills at prices the caller never meant
+    /// to trade at, and no callback distinguishes it (ibx#352).
+    #[test]
+    fn every_submit_path_emits_outside_rth_only_when_it_was_asked_for() {
+        let cases: Vec<(&str, fn(&mut Context, u32, bool) -> crate::types::OrderId)> = vec![
+            ("limit gtc", |c, i, o| c.submit_limit_gtc(i, Side::Buy, 1, 100 * crate::types::PRICE_SCALE, o)),
+            ("stop gtc", |c, i, o| c.submit_stop_gtc(i, Side::Sell, 1, 90 * crate::types::PRICE_SCALE, o)),
+            ("stop limit gtc", |c, i, o| {
+                c.submit_stop_limit_gtc(i, Side::Sell, 1, 89 * crate::types::PRICE_SCALE, 90 * crate::types::PRICE_SCALE, o)
+            }),
+            ("extended encoder", |c, i, o| {
+                c.submit_limit_ex(
+                    i, Side::Buy, 1, 100 * crate::types::PRICE_SCALE, b'0',
+                    crate::types::OrderAttrs { outside_rth: o, ..Default::default() },
+                )
+            }),
+        ];
+
+        for (label, submit) in cases {
+            for asked in [true, false] {
+                let mut context = Context::new();
+                let instrument = context.register_instrument(756733);
+                submit(&mut context, instrument, asked);
+                let sent = drain(&mut context);
+
+                assert_eq!(
+                    sent.contains("|6433=1|"), asked,
+                    "{label}, outside_rth={asked}: {sent}",
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Every submit encoder guards tag 6433, and nothing asserted the guard. The tests checked that the flag is present when the caller set it, never that it is absent when they did not — so making all four paths emit it unconditionally failed no test at all.
- One test, both polarities, across all four paths that emit the tag: the three GTC variants and the shared extended encoder every attributed order routes through.

## Why

This is the shape #247 took on the replace path, where a hard-coded `6433=1` opted every modified order into the extended session. It survived because the coverage could not express the direction it broke in — and the same blind spot is still on the submit side.

An order silently widened to outside regular hours fills at prices the caller never meant to trade at, and nothing in the callbacks distinguishes it from one they asked for.

The test reads the bytes off a socket rather than inspecting the request enum, because the enum is not where the tag is decided.

**No production change**: the guards were already correct. This is the assertion that keeps them so.

Closes #352.

## Test plan

- [x] `cargo test --offline --lib` — 803 passed. The 2 failures are `config::expiry_tests::{named_zone_converts_with_dst, instant_round_trips_to_wire}`, which fail on the base commit too (fixed separately in #336).
- [x] `cargo check --offline` clean on every target: `--lib`, `--features python`, `--bins`, `--examples`, and each of the eight `tests/*.rs` targets individually.
- [x] Mutation check: making all four paths emit `6433` unconditionally fails `every_submit_path_emits_outside_rth_only_when_it_was_asked_for` by name — and so does mutating **only** the shared extended encoder, so the test is not passing on the strength of one path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
