### PR TITLE
orders: refuse a modify that would strip the order's attributes (ibx#248)

### DIFF
--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -31,6 +31,17 @@ impl EClient {
 
         // If orderId is already tracked, this is a modification — emit Modify instead of Submit.
         let cmd = if self.core.is_order_tracked(oid) {
+            // A replace states the order type, the limit price and the trigger.
+            // An order defined by anything else cannot survive one, so refuse
+            // rather than send a message that destroys it.
+            if let Some(tracked) = self.core.tracked_order(oid) {
+                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
+                    return Err(format!(
+                        "{why} cannot be modified: the replace does not carry the fields that \
+                         define it, and sending one would cancel the order"
+                    ));
+                }
+            }
             let price = (order.lmt_price * PRICE_SCALE_F) as i64;
             let qty = order.total_quantity as u32;
             ControlCommand::Order(OrderRequest::Modify {

--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -34,13 +34,8 @@ impl EClient {
             // A replace states the order type, the limit price and the trigger.
             // An order defined by anything else cannot survive one, so refuse
             // rather than send a message that destroys it.
-            if let Some(tracked) = self.core.tracked_order(oid) {
-                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
-                    return Err(format!(
-                        "{why} cannot be modified: the replace does not carry the fields that \
-                         define it, and sending one would cancel the order"
-                    ));
-                }
+            if let Some(refusal) = self.core.modify_refusal(oid, order) {
+                return Err(refusal);
             }
             let price = (order.lmt_price * PRICE_SCALE_F) as i64;
             let qty = order.total_quantity as u32;

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -76,6 +76,19 @@ fn an_order_defined_by_more_than_its_type_is_not_modified() {
         ("conditional", |o| o.conditions.push(
             crate::types::OrderCondition::Time { time: "20260311-09:30:00".into(), is_more: true },
         )),
+        // Every attribute below rides a tag the replace does not carry, so a
+        // modify would state the order without it (ibx#248). The bracket links
+        // are the costly pair: a child sent without its parent or OCA group
+        // rests alone, and a fill on the sibling no longer cancels it.
+        ("bracket child", |o| o.parent_id = 4242),
+        ("OCA member", |o| o.oca_group = "bracket_1".into()),
+        ("good-till expiry", |o| o.good_till_date = "20260311 16:00:00".into()),
+        ("good-after time", |o| o.good_after_time = "20260311 09:30:00".into()),
+        ("iceberg", |o| o.display_size = 100),
+        ("minimum quantity", |o| o.min_qty = 50),
+        ("discretionary", |o| o.discretionary_amt = 0.05),
+        ("sweep to fill", |o| o.sweep_to_fill = true),
+        ("trigger method", |o| o.trigger_method = 2),
     ];
     for (name, set) in cases {
         let (client, rx, _shared) = test_client();
@@ -111,10 +124,42 @@ fn a_limit_if_touched_is_not_modified() {
     let _ = client.place_order(9302, &spy(), &order);
     while rx.try_recv().is_ok() {}
 
-    if client.core.is_order_tracked(9302) {
-        let err = client.place_order(9302, &spy(), &order)
-            .expect_err("a LIT modify must be refused");
-        assert!(err.contains("cannot be modified"), "{err}");
+    assert!(
+        client.core.is_order_tracked(9302),
+        "the LIT must submit and be tracked, or the refusal below proves nothing",
+    );
+    let err = client.place_order(9302, &spy(), &order)
+        .expect_err("a LIT modify must be refused");
+    assert!(err.contains("cannot be modified"), "{err}");
+}
+
+/// The refusal has to read the order the caller is asking for, not only the one
+/// on the book. A modify that *adds* a bracket link or an OCA group states an
+/// order that has neither — so a gate looking only at the resting record lets
+/// the attribute through on the very message that was supposed to carry it.
+#[test]
+fn an_attribute_added_by_the_modify_is_refused_too() {
+    let cases: Vec<(&str, fn(&mut Order))> = vec![
+        ("bracket child", |o| o.parent_id = 4242),
+        ("OCA member", |o| o.oca_group = "bracket_1".into()),
+        ("iceberg", |o| o.display_size = 100),
+        ("all-or-none", |o| o.all_or_none = true),
+    ];
+    for (name, set) in cases {
+        let (client, rx, _shared) = test_client();
+        let plain = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+            lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+        };
+        client.place_order(9303, &spy(), &plain).expect("a plain limit submits");
+        while rx.try_recv().is_ok() {}
+
+        let mut attributed = plain.clone();
+        set(&mut attributed);
+        let err = client.place_order(9303, &spy(), &attributed)
+            .expect_err("adding it by modify must be refused");
+        assert!(err.contains("cannot be modified"), "{name}: {err}");
+        assert!(rx.try_recv().is_err(), "{name}: nothing reaches the wire");
     }
 }
 
@@ -131,6 +176,11 @@ fn every_restatable_type_still_modifies() {
         ("LOC", 100.0, 0.0),
         ("MIT", 0.0, 90.0),
         ("STP PRT", 0.0, 90.0),
+        // Regression guard: these three were modifiable before the gate and
+        // the replace renders the same byte they were submitted under.
+        ("MTL", 0.0, 0.0),
+        ("BOX TOP", 0.0, 0.0),
+        ("MKT PRT", 0.0, 0.0),
     ] {
         let (client, rx, _shared) = test_client();
         let order = Order {

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -31,6 +31,167 @@ fn spy() -> Contract {
 //  Algo parsing
 // ═══════════════════════════════════════════════════════════════════
 
+/// A replace carries the order type, the limit price and the trigger — not the
+/// peg offset, the trailing amount or the execution instruction. Sent for a
+/// trailing stop it describes a pegged order with no offset, the gateway
+/// rejects it, and the caller is left with no stop at all. Refusing keeps the
+/// order they already have.
+#[test]
+fn a_type_the_replace_cannot_restate_is_not_modified() {
+    for order_type in ["TRAIL", "TRAIL LIMIT", "REL", "PEG MID", "MIDPX", "SNAP MID"] {
+        let (client, rx, _shared) = test_client();
+        let submit = Order {
+            action: "SELL".into(), total_quantity: 1.0, order_type: order_type.into(),
+            aux_price: 1.0, trailing_percent: 0.0, tif: "DAY".into(), ..Default::default()
+        };
+        // Submitting is fine; it is the replace that cannot express it.
+        let _ = client.place_order(9201, &spy(), &submit);
+        while rx.try_recv().is_ok() {}
+
+        // Skipping when tracking did not happen would let this pass without
+        // testing anything, which is how the modify gate went unnoticed.
+        assert!(
+            client.core.is_order_tracked(9201),
+            "{order_type} must submit and be tracked, or the refusal below proves nothing",
+        );
+        let err = client.place_order(9201, &spy(), &submit)
+            .expect_err("modifying it must be refused");
+        assert!(err.contains("cannot be modified"), "{order_type}: {err}");
+        assert!(rx.try_recv().is_err(), "{order_type}: nothing reaches the wire");
+    }
+}
+
+/// The order type alone does not decide this. An adaptive or algo order is an
+/// ordinary LMT defined by its algo tags; an adjustable stop is an ordinary STP
+/// defined by its conversion; a conditional order rides submit-only tags. A
+/// replace states none of those, so each is destroyed by one just as surely as
+/// a trailing stop is — and each would have passed a gate that looked only at
+/// the type.
+#[test]
+fn an_order_defined_by_more_than_its_type_is_not_modified() {
+    let cases: Vec<(&str, fn(&mut Order))> = vec![
+        ("adaptive", |o| o.algo_strategy = "Adaptive".into()),
+        ("algo", |o| o.algo_strategy = "Vwap".into()),
+        ("adjustable stop", |o| o.adjusted_order_type = "TRAIL".into()),
+        ("conditional", |o| o.conditions.push(
+            crate::types::OrderCondition::Time { time: "20260311-09:30:00".into(), is_more: true },
+        )),
+    ];
+    for (name, set) in cases {
+        let (client, rx, _shared) = test_client();
+        let mut order = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+            lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+        };
+        set(&mut order);
+        let _ = client.place_order(9301, &spy(), &order);
+        while rx.try_recv().is_ok() {}
+
+        assert!(
+            client.core.is_order_tracked(9301),
+            "{name} must submit and be tracked, or the refusal below proves nothing",
+        );
+        let err = client.place_order(9301, &spy(), &order)
+            .expect_err("modifying it must be refused");
+        assert!(err.contains("cannot be modified"), "{name}: {err}");
+        assert!(rx.try_recv().is_err(), "{name}: nothing reaches the wire");
+    }
+}
+
+/// Limit-if-touched is submitted as `LT` but tracked under a byte the replace
+/// renders as `K`, which is market-to-limit here — so a replace would describe
+/// a different order type entirely.
+#[test]
+fn a_limit_if_touched_is_not_modified() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "LIT".into(),
+        lmt_price: 100.0, aux_price: 101.0, tif: "DAY".into(), ..Default::default()
+    };
+    let _ = client.place_order(9302, &spy(), &order);
+    while rx.try_recv().is_ok() {}
+
+    if client.core.is_order_tracked(9302) {
+        let err = client.place_order(9302, &spy(), &order)
+            .expect_err("a LIT modify must be refused");
+        assert!(err.contains("cannot be modified"), "{err}");
+    }
+}
+
+/// Every allowed type must still modify, not just the one. Excluding any of
+/// them costs a working modify, and only `LMT` was covered.
+#[test]
+fn every_restatable_type_still_modifies() {
+    for (order_type, lmt, aux) in [
+        ("MKT", 0.0, 0.0),
+        ("LMT", 100.0, 0.0),
+        ("STP", 0.0, 90.0),
+        ("STP LMT", 100.0, 90.0),
+        ("MOC", 0.0, 0.0),
+        ("LOC", 100.0, 0.0),
+        ("MIT", 0.0, 90.0),
+        ("STP PRT", 0.0, 90.0),
+    ] {
+        let (client, rx, _shared) = test_client();
+        let order = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: order_type.into(),
+            lmt_price: lmt, aux_price: aux, tif: "DAY".into(), ..Default::default()
+        };
+        client.place_order(9701, &spy(), &order)
+            .unwrap_or_else(|e| panic!("{order_type} must submit: {e}"));
+        while rx.try_recv().is_ok() {}
+
+        client.place_order(9701, &spy(), &order)
+            .unwrap_or_else(|e| panic!("{order_type} must still modify: {e}"));
+        match rx.try_recv().expect("the modify") {
+            ControlCommand::Order(OrderRequest::Modify { .. }) => {}
+            other => panic!("{order_type}: expected a Modify, got {other:?}"),
+        }
+    }
+}
+
+/// The decision is read from the order as it was submitted, not from the one
+/// handed to the modify — a caller cannot make a trailing stop modifiable by
+/// describing it as a limit on the way in.
+#[test]
+fn the_refusal_reads_the_tracked_order_not_the_incoming_one() {
+    let (client, rx, _shared) = test_client();
+    let trail = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "TRAIL".into(),
+        aux_price: 1.0, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9702, &spy(), &trail).expect("the trailing stop submits");
+    while rx.try_recv().is_ok() {}
+
+    let disguised = Order {
+        action: "SELL".into(), total_quantity: 2.0, order_type: "LMT".into(),
+        lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+    };
+    let err = client.place_order(9702, &spy(), &disguised)
+        .expect_err("the tracked type decides, so this is still refused");
+    assert!(err.contains("cannot be modified"), "{err}");
+    assert!(rx.try_recv().is_err(), "and nothing reaches the wire");
+}
+
+/// The ordinary types still modify.
+#[test]
+fn a_limit_order_still_modifies() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+        lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9202, &spy(), &order).unwrap();
+    while rx.try_recv().is_ok() {}
+
+    let moved = Order { lmt_price: 101.0, ..order };
+    client.place_order(9202, &spy(), &moved).expect("a limit modify still goes through");
+    match rx.try_recv().expect("the modify") {
+        ControlCommand::Order(OrderRequest::Modify { .. }) => {}
+        other => panic!("expected a Modify, got {other:?}"),
+    }
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -809,17 +809,81 @@ impl ClientCore {
         if order.what_if {
             return Some("a what-if order".to_string());
         }
+        // The replace is rebuilt from the tracked record, which holds side,
+        // price, quantity, order type, time-in-force and trigger — and nothing
+        // else. Every attribute below rides a tag the replace does not carry,
+        // so a modify would state the order without it (ibx#248).
+        //
+        // The bracket links are the costly pair. A replace that omits the
+        // parent link or the OCA group leaves a child resting alone: a fill on
+        // one leg no longer cancels the other, and the position is left with a
+        // naked order against it. Whether the gateway reads an omitted 583 or
+        // 6107 as unchanged or as cleared is not established here, and the
+        // difference between "latent" and "detached" is the whole risk — so
+        // the modify is refused rather than sent and hoped for.
+        if !order.oca_group.is_empty() {
+            return Some("an order in an OCA group".to_string());
+        }
+        if order.parent_id != 0 {
+            return Some("a bracket child".to_string());
+        }
+        if !order.good_till_date.is_empty() {
+            return Some("an order with a good-till expiry".to_string());
+        }
+        if !order.good_after_time.is_empty() {
+            return Some("an order with a good-after time".to_string());
+        }
+        if order.display_size > 0 {
+            return Some("an iceberg order".to_string());
+        }
+        if order.min_qty > 0 {
+            return Some("an order with a minimum quantity".to_string());
+        }
+        if order.discretionary_amt > 0.0 {
+            return Some("a discretionary order".to_string());
+        }
+        if order.sweep_to_fill {
+            return Some("a sweep-to-fill order".to_string());
+        }
+        if order.trigger_method != 0 {
+            return Some("an order with a non-default trigger method".to_string());
+        }
         let ty = order.order_type.to_uppercase();
         // `LIT` is submitted as `LT` but tracked under a byte the replace
         // renders as `K`, which is market-to-limit in this dialect — so a
         // replace would describe a different order type entirely.
+        //
+        // `MTL`, `BOX TOP` and `MKT PRT` are here because the replace renders
+        // the same byte they were submitted under, so it restates them as
+        // themselves — which is the whole test for membership.
         if matches!(
             ty.as_str(),
             "MKT" | "LMT" | "STP" | "STP LMT" | "MOC" | "LOC" | "MIT" | "STP PRT"
+                | "MTL" | "BOX TOP" | "MKT PRT"
         ) {
             return None;
         }
         Some(format!("a {ty} order"))
+    }
+
+    /// Why a modify of `order_id` cannot be sent, if it cannot.
+    ///
+    /// Both sides are checked. The resting order is the one the replace has to
+    /// restate, and the incoming order is what the caller is asking it to
+    /// become — a modify that *adds* a bracket link or an OCA group states an
+    /// order that has neither, so examining only the record on the book lets
+    /// the attribute through on the very message that was supposed to carry it.
+    ///
+    /// One place, so the two bindings cannot diverge on either the rule or the
+    /// wording (ibx#248).
+    pub fn modify_refusal(&self, order_id: u64, incoming: &ApiOrder) -> Option<String> {
+        let why = self.tracked_order(order_id)
+            .and_then(|tracked| Self::replace_cannot_restate(&tracked))
+            .or_else(|| Self::replace_cannot_restate(incoming))?;
+        Some(format!(
+            "{why} cannot be modified: the replace does not carry the fields that \
+             define it, and sending one would cancel the order"
+        ))
     }
 
     /// Track a newly placed order.

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -764,6 +764,64 @@ impl ClientCore {
         self.open_orders.lock().unwrap().contains_key(&order_id)
     }
 
+    /// The order a tracked id was submitted with, if it is tracked.
+    pub fn tracked_order(&self, order_id: u64) -> Option<ApiOrder> {
+        self.open_orders.lock().unwrap().get(&order_id).map(|t| t.order.clone())
+    }
+
+    /// Why a replace cannot restate this order, or `None` if it can.
+    ///
+    /// The replace message carries the order type, the limit price and the
+    /// trigger, and nothing else — no peg offset, no trailing amount, no
+    /// execution instruction, no algo block. For an order defined by any of
+    /// those, the replace describes something other than the order being
+    /// replaced: a trailing stop arrives as a pegged order with no offset, and
+    /// the gateway rejects it, leaving the caller with no stop at all.
+    ///
+    /// The order type alone does not decide this. An adaptive or algo order is
+    /// an ordinary `LMT` that is defined by its algo tags, and an adjustable
+    /// stop is an ordinary `STP` that is defined by its conversion — both are
+    /// destroyed by a replace that states only the type.
+    pub fn replace_cannot_restate(order: &ApiOrder) -> Option<String> {
+        if !order.algo_strategy.is_empty() {
+            return Some(format!("an order running the {} algo", order.algo_strategy));
+        }
+        if !order.adjusted_order_type.is_empty() {
+            return Some(format!("an order that adjusts to {}", order.adjusted_order_type));
+        }
+        if !order.conditions.is_empty() {
+            return Some("a conditional order".to_string());
+        }
+        // These ride tags the replace does not carry either — hidden on 6135,
+        // all-or-none as an execution instruction, and the cash quantity on
+        // 5920 — so a replace states an order without them.
+        if order.hidden {
+            return Some("a hidden order".to_string());
+        }
+        if order.all_or_none {
+            return Some("an all-or-none order".to_string());
+        }
+        if order.cash_qty > 0.0 {
+            return Some("a cash-quantity order".to_string());
+        }
+        // A what-if is a margin preview, not a resting order, so there is
+        // nothing on the book for a replace to act on.
+        if order.what_if {
+            return Some("a what-if order".to_string());
+        }
+        let ty = order.order_type.to_uppercase();
+        // `LIT` is submitted as `LT` but tracked under a byte the replace
+        // renders as `K`, which is market-to-limit in this dialect — so a
+        // replace would describe a different order type entirely.
+        if matches!(
+            ty.as_str(),
+            "MKT" | "LMT" | "STP" | "STP LMT" | "MOC" | "LOC" | "MIT" | "STP PRT"
+        ) {
+            return None;
+        }
+        Some(format!("a {ty} order"))
+    }
+
     /// Track a newly placed order.
     pub fn track_order(&self, order_id: u64, contract: ApiContract, order: ApiOrder, instrument: InstrumentId) {
         let remaining = order.total_quantity;

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -37,6 +37,16 @@ impl EClient {
 
         // If orderId is already tracked, this is a modification — emit Modify instead of Submit.
         let cmd = if self.core.is_order_tracked(oid) {
+            // A replace states the order type, the limit price and the trigger.
+            // An order defined by anything else cannot survive one.
+            if let Some(tracked) = self.core.tracked_order(oid) {
+                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
+                    return Err(PyRuntimeError::new_err(format!(
+                        "{why} cannot be modified: the replace does not carry the fields that \
+                         define it, and sending one would cancel the order"
+                    )));
+                }
+            }
             let price = (api_order.lmt_price * crate::api::types::PRICE_SCALE_F) as i64;
             let qty = api_order.total_quantity as u32;
             ControlCommand::Order(OrderRequest::Modify {

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -39,13 +39,8 @@ impl EClient {
         let cmd = if self.core.is_order_tracked(oid) {
             // A replace states the order type, the limit price and the trigger.
             // An order defined by anything else cannot survive one.
-            if let Some(tracked) = self.core.tracked_order(oid) {
-                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
-                    return Err(PyRuntimeError::new_err(format!(
-                        "{why} cannot be modified: the replace does not carry the fields that \
-                         define it, and sending one would cancel the order"
-                    )));
-                }
+            if let Some(refusal) = self.core.modify_refusal(oid, &api_order) {
+                return Err(PyRuntimeError::new_err(refusal));
             }
             let price = (api_order.lmt_price * crate::api::types::PRICE_SCALE_F) as i64;
             let qty = api_order.total_quantity as u32;


### PR DESCRIPTION
## Problem

The replace is rebuilt from the tracked record, which holds side, price, quantity, order type, time-in-force and trigger — and nothing else. Every other attribute rides a tag the replace does not carry, so a modify states the order without it.

The bracket links are the costly pair. A replace that omits the parent link or the OCA group leaves a child resting alone: a fill on one leg no longer cancels the other, and the position is left with a naked order against it.

## What this changes

The modify is refused for an order defined by any attribute the replace cannot restate:

- OCA group, parent link
- good-till expiry, good-after time
- iceberg display size, minimum quantity
- discretionary amount, sweep-to-fill
- non-default trigger method

**Refused, not carried.** Whether the gateway reads an omitted `583` or `6107` as unchanged or as cleared is not established, and the difference between latent and detached is the whole risk.

**Both sides are checked.** The resting order is the one the replace has to restate; the incoming order is what the caller is asking it to become. A modify that *adds* a bracket link or an OCA group states an order that has neither, so examining only the record on the book let the attribute through on the very message that was supposed to carry it. The check and its wording now live in one place, so the two bindings cannot diverge on either.

**`MTL`, `BOX TOP` and `MKT PRT` stay restatable.** The replace renders the same byte they were submitted under, which is the whole test for membership.

## Not reached here

Two defects on the ordinary modify path, neither a matter of dropped attributes:

- the replace asserts `6433=1` unconditionally, so any modify makes a regular-hours order eligible outside them (#371);
- it carries no trigger, so a modify of a stop sends a zero limit price and restates the old trigger (#372).

## Tests

- `an_order_defined_by_more_than_its_type_is_not_modified` — every protected attribute, each submitting first so the refusal proves something.
- `an_attribute_added_by_the_modify_is_refused_too` — adding one on the modify, not just holding one.
- `every_restatable_type_still_modifies` — including the three that were modifiable before this gate.
- `a_limit_if_touched_is_not_modified` — asserts tracking rather than skipping when untracked.

Each fails by name against a compiling reversion of the production change it covers.

Closes #248.


## Test plan

- [x] Mutation: dropping the incoming-order check fails `an_attribute_added_by_the_modify_is_refused_too` by name.
- [x] Mutation: removing the `min_qty` guard fails `an_order_defined_by_more_than_its_type_is_not_modified`.
- [x] Mutation: refusing `MTL`/`BOX TOP`/`MKT PRT` again fails `every_restatable_type_still_modifies` — the regression guard for the three that were modifiable before this gate.
- [x] `a_limit_if_touched_is_not_modified` asserts the order is tracked first, so the refusal proves something rather than passing on an untracked id.
- [x] `cargo check --offline` clean on `--lib`, `--lib --features python`, `--bins`, `--examples`, and each integration target individually.
- [x] `tests/ib_paper_compat` compared against a clean checkout of the base commit — identical sorted diagnostic sets.
- [x] `cargo test --offline --lib` — only the two known `config::expiry_tests` failures, which fail on the base commit for missing legacy tzdata (fixed separately in #336).
