### PR TITLE
orders: a modify states the type, time-in-force and trigger it carries (ibx#349, ibx#372)

### DIFF
--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -44,6 +44,9 @@ impl EClient {
                 order_id: oid,
                 price,
                 qty,
+                ord_type: order.ord_type_byte(),
+                tif: order.tif_byte(),
+                stop_price: (order.aux_price * PRICE_SCALE_F) as i64,
             })
         } else {
             ClientCore::build_order_request(order, oid, instrument)?

--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -31,6 +31,17 @@ impl EClient {
 
         // If orderId is already tracked, this is a modification — emit Modify instead of Submit.
         let cmd = if self.core.is_order_tracked(oid) {
+            // A replace states the order type, the limit price and the trigger.
+            // An order defined by anything else cannot survive one, so refuse
+            // rather than send a message that destroys it.
+            if let Some(tracked) = self.core.tracked_order(oid) {
+                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
+                    return Err(format!(
+                        "{why} cannot be modified: the replace does not carry the fields that \
+                         define it, and sending one would cancel the order"
+                    ));
+                }
+            }
             let price = (order.lmt_price * PRICE_SCALE_F) as i64;
             let qty = order.total_quantity as u32;
             ControlCommand::Order(OrderRequest::Modify {

--- a/src/api/client/orders.rs
+++ b/src/api/client/orders.rs
@@ -34,13 +34,8 @@ impl EClient {
             // A replace states the order type, the limit price and the trigger.
             // An order defined by anything else cannot survive one, so refuse
             // rather than send a message that destroys it.
-            if let Some(tracked) = self.core.tracked_order(oid) {
-                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
-                    return Err(format!(
-                        "{why} cannot be modified: the replace does not carry the fields that \
-                         define it, and sending one would cancel the order"
-                    ));
-                }
+            if let Some(refusal) = self.core.modify_refusal(oid, order) {
+                return Err(refusal);
             }
             let price = (order.lmt_price * PRICE_SCALE_F) as i64;
             let qty = order.total_quantity as u32;

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -76,6 +76,19 @@ fn an_order_defined_by_more_than_its_type_is_not_modified() {
         ("conditional", |o| o.conditions.push(
             crate::types::OrderCondition::Time { time: "20260311-09:30:00".into(), is_more: true },
         )),
+        // Every attribute below rides a tag the replace does not carry, so a
+        // modify would state the order without it (ibx#248). The bracket links
+        // are the costly pair: a child sent without its parent or OCA group
+        // rests alone, and a fill on the sibling no longer cancels it.
+        ("bracket child", |o| o.parent_id = 4242),
+        ("OCA member", |o| o.oca_group = "bracket_1".into()),
+        ("good-till expiry", |o| o.good_till_date = "20260311 16:00:00".into()),
+        ("good-after time", |o| o.good_after_time = "20260311 09:30:00".into()),
+        ("iceberg", |o| o.display_size = 100),
+        ("minimum quantity", |o| o.min_qty = 50),
+        ("discretionary", |o| o.discretionary_amt = 0.05),
+        ("sweep to fill", |o| o.sweep_to_fill = true),
+        ("trigger method", |o| o.trigger_method = 2),
     ];
     for (name, set) in cases {
         let (client, rx, _shared) = test_client();
@@ -111,10 +124,42 @@ fn a_limit_if_touched_is_not_modified() {
     let _ = client.place_order(9302, &spy(), &order);
     while rx.try_recv().is_ok() {}
 
-    if client.core.is_order_tracked(9302) {
-        let err = client.place_order(9302, &spy(), &order)
-            .expect_err("a LIT modify must be refused");
-        assert!(err.contains("cannot be modified"), "{err}");
+    assert!(
+        client.core.is_order_tracked(9302),
+        "the LIT must submit and be tracked, or the refusal below proves nothing",
+    );
+    let err = client.place_order(9302, &spy(), &order)
+        .expect_err("a LIT modify must be refused");
+    assert!(err.contains("cannot be modified"), "{err}");
+}
+
+/// The refusal has to read the order the caller is asking for, not only the one
+/// on the book. A modify that *adds* a bracket link or an OCA group states an
+/// order that has neither — so a gate looking only at the resting record lets
+/// the attribute through on the very message that was supposed to carry it.
+#[test]
+fn an_attribute_added_by_the_modify_is_refused_too() {
+    let cases: Vec<(&str, fn(&mut Order))> = vec![
+        ("bracket child", |o| o.parent_id = 4242),
+        ("OCA member", |o| o.oca_group = "bracket_1".into()),
+        ("iceberg", |o| o.display_size = 100),
+        ("all-or-none", |o| o.all_or_none = true),
+    ];
+    for (name, set) in cases {
+        let (client, rx, _shared) = test_client();
+        let plain = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+            lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+        };
+        client.place_order(9303, &spy(), &plain).expect("a plain limit submits");
+        while rx.try_recv().is_ok() {}
+
+        let mut attributed = plain.clone();
+        set(&mut attributed);
+        let err = client.place_order(9303, &spy(), &attributed)
+            .expect_err("adding it by modify must be refused");
+        assert!(err.contains("cannot be modified"), "{name}: {err}");
+        assert!(rx.try_recv().is_err(), "{name}: nothing reaches the wire");
     }
 }
 
@@ -131,6 +176,11 @@ fn every_restatable_type_still_modifies() {
         ("LOC", 100.0, 0.0),
         ("MIT", 0.0, 90.0),
         ("STP PRT", 0.0, 90.0),
+        // Regression guard: these three were modifiable before the gate and
+        // the replace renders the same byte they were submitted under.
+        ("MTL", 0.0, 0.0),
+        ("BOX TOP", 0.0, 0.0),
+        ("MKT PRT", 0.0, 0.0),
     ] {
         let (client, rx, _shared) = test_client();
         let order = Order {

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -31,6 +31,167 @@ fn spy() -> Contract {
 //  Algo parsing
 // ═══════════════════════════════════════════════════════════════════
 
+/// A replace carries the order type, the limit price and the trigger — not the
+/// peg offset, the trailing amount or the execution instruction. Sent for a
+/// trailing stop it describes a pegged order with no offset, the gateway
+/// rejects it, and the caller is left with no stop at all. Refusing keeps the
+/// order they already have.
+#[test]
+fn a_type_the_replace_cannot_restate_is_not_modified() {
+    for order_type in ["TRAIL", "TRAIL LIMIT", "REL", "PEG MID", "MIDPX", "SNAP MID"] {
+        let (client, rx, _shared) = test_client();
+        let submit = Order {
+            action: "SELL".into(), total_quantity: 1.0, order_type: order_type.into(),
+            aux_price: 1.0, trailing_percent: 0.0, tif: "DAY".into(), ..Default::default()
+        };
+        // Submitting is fine; it is the replace that cannot express it.
+        let _ = client.place_order(9201, &spy(), &submit);
+        while rx.try_recv().is_ok() {}
+
+        // Skipping when tracking did not happen would let this pass without
+        // testing anything, which is how the modify gate went unnoticed.
+        assert!(
+            client.core.is_order_tracked(9201),
+            "{order_type} must submit and be tracked, or the refusal below proves nothing",
+        );
+        let err = client.place_order(9201, &spy(), &submit)
+            .expect_err("modifying it must be refused");
+        assert!(err.contains("cannot be modified"), "{order_type}: {err}");
+        assert!(rx.try_recv().is_err(), "{order_type}: nothing reaches the wire");
+    }
+}
+
+/// The order type alone does not decide this. An adaptive or algo order is an
+/// ordinary LMT defined by its algo tags; an adjustable stop is an ordinary STP
+/// defined by its conversion; a conditional order rides submit-only tags. A
+/// replace states none of those, so each is destroyed by one just as surely as
+/// a trailing stop is — and each would have passed a gate that looked only at
+/// the type.
+#[test]
+fn an_order_defined_by_more_than_its_type_is_not_modified() {
+    let cases: Vec<(&str, fn(&mut Order))> = vec![
+        ("adaptive", |o| o.algo_strategy = "Adaptive".into()),
+        ("algo", |o| o.algo_strategy = "Vwap".into()),
+        ("adjustable stop", |o| o.adjusted_order_type = "TRAIL".into()),
+        ("conditional", |o| o.conditions.push(
+            crate::types::OrderCondition::Time { time: "20260311-09:30:00".into(), is_more: true },
+        )),
+    ];
+    for (name, set) in cases {
+        let (client, rx, _shared) = test_client();
+        let mut order = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+            lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+        };
+        set(&mut order);
+        let _ = client.place_order(9301, &spy(), &order);
+        while rx.try_recv().is_ok() {}
+
+        assert!(
+            client.core.is_order_tracked(9301),
+            "{name} must submit and be tracked, or the refusal below proves nothing",
+        );
+        let err = client.place_order(9301, &spy(), &order)
+            .expect_err("modifying it must be refused");
+        assert!(err.contains("cannot be modified"), "{name}: {err}");
+        assert!(rx.try_recv().is_err(), "{name}: nothing reaches the wire");
+    }
+}
+
+/// Limit-if-touched is submitted as `LT` but tracked under a byte the replace
+/// renders as `K`, which is market-to-limit here — so a replace would describe
+/// a different order type entirely.
+#[test]
+fn a_limit_if_touched_is_not_modified() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "LIT".into(),
+        lmt_price: 100.0, aux_price: 101.0, tif: "DAY".into(), ..Default::default()
+    };
+    let _ = client.place_order(9302, &spy(), &order);
+    while rx.try_recv().is_ok() {}
+
+    if client.core.is_order_tracked(9302) {
+        let err = client.place_order(9302, &spy(), &order)
+            .expect_err("a LIT modify must be refused");
+        assert!(err.contains("cannot be modified"), "{err}");
+    }
+}
+
+/// Every allowed type must still modify, not just the one. Excluding any of
+/// them costs a working modify, and only `LMT` was covered.
+#[test]
+fn every_restatable_type_still_modifies() {
+    for (order_type, lmt, aux) in [
+        ("MKT", 0.0, 0.0),
+        ("LMT", 100.0, 0.0),
+        ("STP", 0.0, 90.0),
+        ("STP LMT", 100.0, 90.0),
+        ("MOC", 0.0, 0.0),
+        ("LOC", 100.0, 0.0),
+        ("MIT", 0.0, 90.0),
+        ("STP PRT", 0.0, 90.0),
+    ] {
+        let (client, rx, _shared) = test_client();
+        let order = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: order_type.into(),
+            lmt_price: lmt, aux_price: aux, tif: "DAY".into(), ..Default::default()
+        };
+        client.place_order(9701, &spy(), &order)
+            .unwrap_or_else(|e| panic!("{order_type} must submit: {e}"));
+        while rx.try_recv().is_ok() {}
+
+        client.place_order(9701, &spy(), &order)
+            .unwrap_or_else(|e| panic!("{order_type} must still modify: {e}"));
+        match rx.try_recv().expect("the modify") {
+            ControlCommand::Order(OrderRequest::Modify { .. }) => {}
+            other => panic!("{order_type}: expected a Modify, got {other:?}"),
+        }
+    }
+}
+
+/// The decision is read from the order as it was submitted, not from the one
+/// handed to the modify — a caller cannot make a trailing stop modifiable by
+/// describing it as a limit on the way in.
+#[test]
+fn the_refusal_reads_the_tracked_order_not_the_incoming_one() {
+    let (client, rx, _shared) = test_client();
+    let trail = Order {
+        action: "SELL".into(), total_quantity: 1.0, order_type: "TRAIL".into(),
+        aux_price: 1.0, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9702, &spy(), &trail).expect("the trailing stop submits");
+    while rx.try_recv().is_ok() {}
+
+    let disguised = Order {
+        action: "SELL".into(), total_quantity: 2.0, order_type: "LMT".into(),
+        lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+    };
+    let err = client.place_order(9702, &spy(), &disguised)
+        .expect_err("the tracked type decides, so this is still refused");
+    assert!(err.contains("cannot be modified"), "{err}");
+    assert!(rx.try_recv().is_err(), "and nothing reaches the wire");
+}
+
+/// The ordinary types still modify.
+#[test]
+fn a_limit_order_still_modifies() {
+    let (client, rx, _shared) = test_client();
+    let order = Order {
+        action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+        lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+    };
+    client.place_order(9202, &spy(), &order).unwrap();
+    while rx.try_recv().is_ok() {}
+
+    let moved = Order { lmt_price: 101.0, ..order };
+    client.place_order(9202, &spy(), &moved).expect("a limit modify still goes through");
+    match rx.try_recv().expect("the modify") {
+        ControlCommand::Order(OrderRequest::Modify { .. }) => {}
+        other => panic!("expected a Modify, got {other:?}"),
+    }
+}
+
 #[test]
 fn parse_algo_vwap() {
     let params = vec![

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -2615,9 +2615,12 @@ fn modify_tif_day_to_gtc_via_resubmit() {
 
     let mut found_modify = false;
     while let Ok(cmd) = rx.try_recv() {
-        if let ControlCommand::Order(OrderRequest::Modify { order_id: 88, price, qty, .. }) = cmd {
+        if let ControlCommand::Order(OrderRequest::Modify { order_id: 88, price, qty, tif, .. }) = cmd {
             assert_eq!(price, (150.0 * PRICE_SCALE_F) as i64);
             assert_eq!(qty, 100);
+            // The change the test is named for. Asserting only that a Modify
+            // was emitted passed for as long as the time-in-force was dropped.
+            assert_eq!(tif, b'1', "the modify must carry GTC, not restate DAY");
             found_modify = true;
         }
     }
@@ -2652,6 +2655,32 @@ fn modify_price_and_qty_simultaneously() {
     assert!(found, "Resubmit with same orderId should emit Modify with new price and qty");
 }
 
+/// A zero order-type states nothing and keeps the resting type, so a modify to
+/// a type the replace cannot express must be refused rather than reaching the
+/// encoder — otherwise the caller's new type is silently restated as the old
+/// one and the client caches an order the gateway does not have.
+#[test]
+fn a_modify_to_an_unrepresentable_type_is_refused() {
+    for order_type in ["REL", "TRAIL", "LIT", "MIDPX", "SNAP MKT"] {
+        let (client, rx, shared) = test_client();
+        shared.market.set_instrument_count(1);
+        let plain = Order {
+            action: "BUY".into(), total_quantity: 1.0, order_type: "LMT".into(),
+            lmt_price: 100.0, tif: "DAY".into(), ..Default::default()
+        };
+        client.place_order(9401, &spy(), &plain).expect("a plain limit submits");
+        while rx.try_recv().is_ok() {}
+
+        let converted = Order {
+            order_type: order_type.into(), aux_price: 99.0, ..plain.clone()
+        };
+        let err = client.place_order(9401, &spy(), &converted)
+            .expect_err("converting to a type the replace cannot express must be refused");
+        assert!(err.contains("cannot be modified"), "{order_type}: {err}");
+        assert!(rx.try_recv().is_err(), "{order_type}: nothing reaches the wire");
+    }
+}
+
 #[test]
 fn modify_order_type_lmt_to_stp() {
     let (client, rx, shared) = test_client();
@@ -2671,7 +2700,14 @@ fn modify_order_type_lmt_to_stp() {
 
     let mut found_modify = false;
     while let Ok(cmd) = rx.try_recv() {
-        if matches!(cmd, ControlCommand::Order(OrderRequest::Modify { order_id: 66, .. })) {
+        if let ControlCommand::Order(OrderRequest::Modify {
+            order_id: 66, ord_type, stop_price, ..
+        }) = cmd {
+            // The change the test is named for. Asserting only that a Modify
+            // was emitted passed for as long as the order type was dropped.
+            assert_eq!(ord_type, b'3', "the modify must carry STP, not restate LMT");
+            assert_eq!(stop_price, (149.0 * PRICE_SCALE_F) as i64,
+                "and the trigger the caller set");
             found_modify = true;
         }
     }

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -394,6 +394,28 @@ impl Order {
     }
 
     /// Parse the TIF string to FIX byte.
+    /// The order-type byte this order tracks under, or 0 when the type is one
+    /// a replace cannot state.
+    ///
+    /// Only the types a modify is accepted for are mapped; everything else is
+    /// refused before it reaches a replace, and 0 tells the encoder to keep
+    /// whatever the resting order holds (ibx#349).
+    pub fn ord_type_byte(&self) -> u8 {
+        match self.order_type.to_uppercase().as_str() {
+            "MKT" => b'1',
+            "LMT" => b'2',
+            "STP" => b'3',
+            "STP LMT" => b'4',
+            "MOC" => b'5',
+            "LOC" => b'B',
+            "MIT" => b'J',
+            "MTL" | "BOX TOP" => b'K',
+            "MKT PRT" => b'U',
+            "STP PRT" => crate::types::ORD_STP_PRT,
+            _ => 0,
+        }
+    }
+
     pub fn tif_byte(&self) -> u8 {
         match self.tif.as_str() {
             "GTC" => b'1',

--- a/src/bin/bench_order_modify.rs
+++ b/src/bin/bench_order_modify.rs
@@ -110,8 +110,7 @@ fn main() {
             new_order_id,
             order_id: current_order_id,
             price: new_price,
-            qty: 1,
-        });
+            qty: 1, ord_type: 0, tif: 0, stop_price: 0 });
 
         // Wait for ack on new_order_id
         let deadline = Instant::now() + Duration::from_secs(30);

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -809,17 +809,81 @@ impl ClientCore {
         if order.what_if {
             return Some("a what-if order".to_string());
         }
+        // The replace is rebuilt from the tracked record, which holds side,
+        // price, quantity, order type, time-in-force and trigger — and nothing
+        // else. Every attribute below rides a tag the replace does not carry,
+        // so a modify would state the order without it (ibx#248).
+        //
+        // The bracket links are the costly pair. A replace that omits the
+        // parent link or the OCA group leaves a child resting alone: a fill on
+        // one leg no longer cancels the other, and the position is left with a
+        // naked order against it. Whether the gateway reads an omitted 583 or
+        // 6107 as unchanged or as cleared is not established here, and the
+        // difference between "latent" and "detached" is the whole risk — so
+        // the modify is refused rather than sent and hoped for.
+        if !order.oca_group.is_empty() {
+            return Some("an order in an OCA group".to_string());
+        }
+        if order.parent_id != 0 {
+            return Some("a bracket child".to_string());
+        }
+        if !order.good_till_date.is_empty() {
+            return Some("an order with a good-till expiry".to_string());
+        }
+        if !order.good_after_time.is_empty() {
+            return Some("an order with a good-after time".to_string());
+        }
+        if order.display_size > 0 {
+            return Some("an iceberg order".to_string());
+        }
+        if order.min_qty > 0 {
+            return Some("an order with a minimum quantity".to_string());
+        }
+        if order.discretionary_amt > 0.0 {
+            return Some("a discretionary order".to_string());
+        }
+        if order.sweep_to_fill {
+            return Some("a sweep-to-fill order".to_string());
+        }
+        if order.trigger_method != 0 {
+            return Some("an order with a non-default trigger method".to_string());
+        }
         let ty = order.order_type.to_uppercase();
         // `LIT` is submitted as `LT` but tracked under a byte the replace
         // renders as `K`, which is market-to-limit in this dialect — so a
         // replace would describe a different order type entirely.
+        //
+        // `MTL`, `BOX TOP` and `MKT PRT` are here because the replace renders
+        // the same byte they were submitted under, so it restates them as
+        // themselves — which is the whole test for membership.
         if matches!(
             ty.as_str(),
             "MKT" | "LMT" | "STP" | "STP LMT" | "MOC" | "LOC" | "MIT" | "STP PRT"
+                | "MTL" | "BOX TOP" | "MKT PRT"
         ) {
             return None;
         }
         Some(format!("a {ty} order"))
+    }
+
+    /// Why a modify of `order_id` cannot be sent, if it cannot.
+    ///
+    /// Both sides are checked. The resting order is the one the replace has to
+    /// restate, and the incoming order is what the caller is asking it to
+    /// become — a modify that *adds* a bracket link or an OCA group states an
+    /// order that has neither, so examining only the record on the book lets
+    /// the attribute through on the very message that was supposed to carry it.
+    ///
+    /// One place, so the two bindings cannot diverge on either the rule or the
+    /// wording (ibx#248).
+    pub fn modify_refusal(&self, order_id: u64, incoming: &ApiOrder) -> Option<String> {
+        let why = self.tracked_order(order_id)
+            .and_then(|tracked| Self::replace_cannot_restate(&tracked))
+            .or_else(|| Self::replace_cannot_restate(incoming))?;
+        Some(format!(
+            "{why} cannot be modified: the replace does not carry the fields that \
+             define it, and sending one would cancel the order"
+        ))
     }
 
     /// Track a newly placed order.

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -764,6 +764,64 @@ impl ClientCore {
         self.open_orders.lock().unwrap().contains_key(&order_id)
     }
 
+    /// The order a tracked id was submitted with, if it is tracked.
+    pub fn tracked_order(&self, order_id: u64) -> Option<ApiOrder> {
+        self.open_orders.lock().unwrap().get(&order_id).map(|t| t.order.clone())
+    }
+
+    /// Why a replace cannot restate this order, or `None` if it can.
+    ///
+    /// The replace message carries the order type, the limit price and the
+    /// trigger, and nothing else — no peg offset, no trailing amount, no
+    /// execution instruction, no algo block. For an order defined by any of
+    /// those, the replace describes something other than the order being
+    /// replaced: a trailing stop arrives as a pegged order with no offset, and
+    /// the gateway rejects it, leaving the caller with no stop at all.
+    ///
+    /// The order type alone does not decide this. An adaptive or algo order is
+    /// an ordinary `LMT` that is defined by its algo tags, and an adjustable
+    /// stop is an ordinary `STP` that is defined by its conversion — both are
+    /// destroyed by a replace that states only the type.
+    pub fn replace_cannot_restate(order: &ApiOrder) -> Option<String> {
+        if !order.algo_strategy.is_empty() {
+            return Some(format!("an order running the {} algo", order.algo_strategy));
+        }
+        if !order.adjusted_order_type.is_empty() {
+            return Some(format!("an order that adjusts to {}", order.adjusted_order_type));
+        }
+        if !order.conditions.is_empty() {
+            return Some("a conditional order".to_string());
+        }
+        // These ride tags the replace does not carry either — hidden on 6135,
+        // all-or-none as an execution instruction, and the cash quantity on
+        // 5920 — so a replace states an order without them.
+        if order.hidden {
+            return Some("a hidden order".to_string());
+        }
+        if order.all_or_none {
+            return Some("an all-or-none order".to_string());
+        }
+        if order.cash_qty > 0.0 {
+            return Some("a cash-quantity order".to_string());
+        }
+        // A what-if is a margin preview, not a resting order, so there is
+        // nothing on the book for a replace to act on.
+        if order.what_if {
+            return Some("a what-if order".to_string());
+        }
+        let ty = order.order_type.to_uppercase();
+        // `LIT` is submitted as `LT` but tracked under a byte the replace
+        // renders as `K`, which is market-to-limit in this dialect — so a
+        // replace would describe a different order type entirely.
+        if matches!(
+            ty.as_str(),
+            "MKT" | "LMT" | "STP" | "STP LMT" | "MOC" | "LOC" | "MIT" | "STP PRT"
+        ) {
+            return None;
+        }
+        Some(format!("a {ty} order"))
+    }
+
     /// Track a newly placed order.
     pub fn track_order(&self, order_id: u64, contract: ApiContract, order: ApiOrder, instrument: InstrumentId) {
         let remaining = order.total_quantity;

--- a/src/engine/context.rs
+++ b/src/engine/context.rs
@@ -853,7 +853,26 @@ impl Context {
             .push(OrderRequest::CancelAll { instrument });
     }
 
+    /// Replace a working order's price and quantity, keeping everything else
+    /// the resting order holds. Use `modify_ex` to change the order type, the
+    /// time-in-force or the trigger.
     pub fn modify(&mut self, order_id: OrderId, price: Price, qty: u32) -> OrderId {
+        self.modify_ex(order_id, price, qty, 0, 0, 0)
+    }
+
+    /// Replace a working order, stating what the replace should carry.
+    ///
+    /// A zero `ord_type`, `tif` or `stop_price` states nothing and leaves what
+    /// the resting order holds in force (ibx#349, ibx#372).
+    pub fn modify_ex(
+        &mut self,
+        order_id: OrderId,
+        price: Price,
+        qty: u32,
+        ord_type: u8,
+        tif: u8,
+        stop_price: Price,
+    ) -> OrderId {
         let new_id = self.next_order_id;
         self.next_order_id += 1;
         self.pending_orders.push(OrderRequest::Modify {
@@ -861,6 +880,9 @@ impl Context {
             order_id,
             price,
             qty,
+            ord_type,
+            tif,
+            stop_price,
         });
         new_id
     }

--- a/src/engine/hot_loop/order_builder.rs
+++ b/src/engine/hot_loop/order_builder.rs
@@ -1442,16 +1442,34 @@ pub(crate) fn drain_and_send_orders(
                 }
                 last_result
             }
-            OrderRequest::Modify { new_order_id, order_id, price, qty } => {
+            OrderRequest::Modify {
+                new_order_id, order_id, price, qty, ord_type, tif, stop_price,
+            } => {
                 let orig = context.order(order_id).copied();
-                // Modify carries no instrument; resolve it from the tracked
-                // order to snap the new price to the tick grid (ibx#216).
-                let price = orig.map_or(price, |o| crate::types::snap_to_tick(
-                    price, context.market.min_tick_scaled(o.instrument)));
+                // What the replace states. A zero field states nothing, so the
+                // resting order's value stays in force — which is what the
+                // encoder used to do for every field, so a caller changing the
+                // order type, the time-in-force or the trigger had the change
+                // accepted, acknowledged, and dropped (ibx#349, ibx#372).
+                let ord_type = if ord_type != 0 { ord_type } else { orig.map_or(b'2', |o| o.ord_type) };
+                let tif = if tif != 0 { tif } else { orig.map_or(b'0', |o| o.tif) };
+                let stop_price = if stop_price != 0 { stop_price } else { orig.map_or(0, |o| o.stop_price) };
+                // Modify carries no instrument, so `snap_prices` cannot reach
+                // it and both price-like fields are snapped here against the
+                // tracked order's grid (ibx#216). The trigger needs it as much
+                // as the limit does — a moved stop off the grid is rejected by
+                // the gateway the same way a limit is.
+                let (price, stop_price) = orig.map_or((price, stop_price), |o| {
+                    let tick = context.market.min_tick_scaled(o.instrument);
+                    (
+                        crate::types::snap_to_tick(price, tick),
+                        if stop_price != 0 { crate::types::snap_to_tick(stop_price, tick) } else { 0 },
+                    )
+                });
                 if let Some(orig) = orig {
                     context.insert_order(crate::types::Order::new(
                         new_order_id, orig.instrument, orig.side, qty, price,
-                        orig.ord_type, orig.tif, orig.stop_price,
+                        ord_type, tif, stop_price,
                     ));
                 }
                 // Versioned ClOrdID chaining: orderId.0 → .1 → .2
@@ -1477,8 +1495,8 @@ pub(crate) fn drain_and_send_orders(
                 let (sec_type_str, _destination) = orig
                     .map(|o| context.market.order_routing(o.instrument))
                     .unwrap_or_else(|| ("STK".to_string(), "SMART".to_string()));
-                let ord_type_str = crate::types::ord_type_fix_str(orig.map(|o| o.ord_type).unwrap_or(b'2')).to_string();
-                let tif_str = std::str::from_utf8(&[orig.map(|o| o.tif).unwrap_or(b'0')]).unwrap_or("0").to_string();
+                let ord_type_str = crate::types::ord_type_fix_str(ord_type).to_string();
+                let tif_str = std::str::from_utf8(&[tif]).unwrap_or("0").to_string();
                 let con_id_str = orig.and_then(|o| context.market.con_id(o.instrument))
                     .map(|c| c.to_string()).unwrap_or_default();
 
@@ -1506,11 +1524,9 @@ pub(crate) fn drain_and_send_orders(
                 ];
                 // Include stop price for order types that need it
                 let stop_str;
-                if let Some(o) = orig {
-                    if o.stop_price != 0 {
-                        stop_str = format_price(o.stop_price);
-                        fields.push((99, &stop_str));
-                    }
+                if stop_price != 0 {
+                    stop_str = format_price(stop_price);
+                    fields.push((99, &stop_str));
                 }
                 conn.send_fix(&fields)
             }
@@ -2015,6 +2031,116 @@ fn build_condition_strings(conditions: &[OrderCondition]) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+
+    /// ibx#349, ibx#372: the replace restated the tracked order's type,
+    /// time-in-force and trigger, so a caller changing any of them had the
+    /// change accepted, acknowledged and dropped. Asserted on the bytes,
+    /// because the request-level tests passed throughout.
+    #[test]
+    fn a_modify_states_the_type_tif_and_trigger_it_carries() {
+        use std::io::Read;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stream = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        let mut conn = Some(crate::protocol::connection::Connection::new_raw(stream).unwrap());
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.set_symbol(instrument, "SPY".to_string());
+        // Resting: a DAY limit with no trigger.
+        context.insert_order(crate::types::Order::new(
+            42, instrument, Side::Buy, 100, 150 * crate::types::PRICE_SCALE, b'2', b'0', 0,
+        ));
+
+        // Modified to a GTC stop at 149.
+        context.modify_ex(
+            42, 150 * crate::types::PRICE_SCALE, 100,
+            b'3', b'1', 149 * crate::types::PRICE_SCALE,
+        );
+        let mut hb = crate::engine::hot_loop::HeartbeatState::new();
+        let shared = std::sync::Arc::new(SharedState::new());
+        drain_and_send_orders(&mut conn, &mut context, "DU1", &mut hb, false, &shared);
+
+        let mut buf = [0u8; 4096];
+        let n = peer.read(&mut buf).unwrap();
+        let msg = String::from_utf8_lossy(&buf[..n]);
+        let tag = |t: &str| msg.split('\u{1}').find_map(|f| f.strip_prefix(t).map(str::to_string));
+
+        assert_eq!(tag("35=").as_deref(), Some("G"), "a replace was sent: {}", msg);
+        assert_eq!(tag("40=").as_deref(), Some("3"), "the type the caller stated: {}", msg);
+        assert_eq!(tag("59=").as_deref(), Some("1"), "the tif the caller stated: {}", msg);
+        assert_eq!(tag("99="), Some(format_price(149 * crate::types::PRICE_SCALE).to_string()),
+            "the trigger the caller stated: {}", msg);
+    }
+
+    /// The trigger is a price and lands on the instrument's grid like any
+    /// other. `Modify` carries no instrument, so the generic snapping cannot
+    /// reach it and both fields are snapped against the tracked order instead.
+    #[test]
+    fn a_moved_trigger_is_snapped_to_the_tick_grid() {
+        use std::io::Read;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stream = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        let mut conn = Some(crate::protocol::connection::Connection::new_raw(stream).unwrap());
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.set_symbol(instrument, "SPY".to_string());
+        context.market.set_min_tick(instrument, 0.05);
+        context.insert_order(crate::types::Order::new(
+            42, instrument, Side::Sell, 100, 150 * crate::types::PRICE_SCALE,
+            b'3', b'0', 149 * crate::types::PRICE_SCALE,
+        ));
+
+        // 149.03 is off a five-cent grid.
+        let off_grid = 149 * crate::types::PRICE_SCALE + 3 * crate::types::PRICE_SCALE / 100;
+        context.modify_ex(42, 150 * crate::types::PRICE_SCALE, 100, b'3', b'0', off_grid);
+        let mut hb = crate::engine::hot_loop::HeartbeatState::new();
+        let shared = std::sync::Arc::new(SharedState::new());
+        drain_and_send_orders(&mut conn, &mut context, "DU1", &mut hb, false, &shared);
+
+        let mut buf = [0u8; 4096];
+        let n = peer.read(&mut buf).unwrap();
+        let msg = String::from_utf8_lossy(&buf[..n]);
+        let tag = |t: &str| msg.split('\u{1}').find_map(|f| f.strip_prefix(t).map(str::to_string));
+        assert_eq!(
+            tag("99="),
+            Some(format_price(149 * crate::types::PRICE_SCALE + 5 * crate::types::PRICE_SCALE / 100).to_string()),
+            "the trigger must be on the grid: {}", msg,
+        );
+    }
+
+    /// A modify that states none of them leaves what the resting order holds in
+    /// force, which is every caller that only moves a price or a quantity.
+    #[test]
+    fn a_modify_that_states_nothing_keeps_the_resting_values() {
+        use std::io::Read;
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let stream = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut peer, _) = listener.accept().unwrap();
+        let mut conn = Some(crate::protocol::connection::Connection::new_raw(stream).unwrap());
+        let mut context = Context::new();
+        let instrument = context.register_instrument(756733);
+        context.set_symbol(instrument, "SPY".to_string());
+        context.insert_order(crate::types::Order::new(
+            42, instrument, Side::Sell, 100, 150 * crate::types::PRICE_SCALE,
+            b'3', b'1', 149 * crate::types::PRICE_SCALE,
+        ));
+
+        context.modify(42, 151 * crate::types::PRICE_SCALE, 100);
+        let mut hb = crate::engine::hot_loop::HeartbeatState::new();
+        let shared = std::sync::Arc::new(SharedState::new());
+        drain_and_send_orders(&mut conn, &mut context, "DU1", &mut hb, false, &shared);
+
+        let mut buf = [0u8; 4096];
+        let n = peer.read(&mut buf).unwrap();
+        let msg = String::from_utf8_lossy(&buf[..n]);
+        let tag = |t: &str| msg.split('\u{1}').find_map(|f| f.strip_prefix(t).map(str::to_string));
+
+        assert_eq!(tag("40=").as_deref(), Some("3"), "the resting type: {}", msg);
+        assert_eq!(tag("59=").as_deref(), Some("1"), "the resting tif: {}", msg);
+        assert_eq!(tag("99="), Some(format_price(149 * crate::types::PRICE_SCALE).to_string()),
+            "the resting trigger: {}", msg);
+    }
     use super::*;
     use crate::types::Order;
 

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -37,6 +37,16 @@ impl EClient {
 
         // If orderId is already tracked, this is a modification — emit Modify instead of Submit.
         let cmd = if self.core.is_order_tracked(oid) {
+            // A replace states the order type, the limit price and the trigger.
+            // An order defined by anything else cannot survive one.
+            if let Some(tracked) = self.core.tracked_order(oid) {
+                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
+                    return Err(PyRuntimeError::new_err(format!(
+                        "{why} cannot be modified: the replace does not carry the fields that \
+                         define it, and sending one would cancel the order"
+                    )));
+                }
+            }
             let price = (api_order.lmt_price * crate::api::types::PRICE_SCALE_F) as i64;
             let qty = api_order.total_quantity as u32;
             ControlCommand::Order(OrderRequest::Modify {

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -49,6 +49,9 @@ impl EClient {
                 order_id: oid,
                 price,
                 qty,
+                ord_type: api_order.ord_type_byte(),
+                tif: api_order.tif_byte(),
+                stop_price: (api_order.aux_price * crate::api::types::PRICE_SCALE_F) as i64,
             })
         } else {
             ClientCore::build_order_request(&api_order, oid, instrument)

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -39,13 +39,8 @@ impl EClient {
         let cmd = if self.core.is_order_tracked(oid) {
             // A replace states the order type, the limit price and the trigger.
             // An order defined by anything else cannot survive one.
-            if let Some(tracked) = self.core.tracked_order(oid) {
-                if let Some(why) = ClientCore::replace_cannot_restate(&tracked) {
-                    return Err(PyRuntimeError::new_err(format!(
-                        "{why} cannot be modified: the replace does not carry the fields that \
-                         define it, and sending one would cancel the order"
-                    )));
-                }
+            if let Some(refusal) = self.core.modify_refusal(oid, &api_order) {
+                return Err(PyRuntimeError::new_err(refusal));
             }
             let price = (api_order.lmt_price * crate::api::types::PRICE_SCALE_F) as i64;
             let qty = api_order.total_quantity as u32;

--- a/src/types.rs
+++ b/src/types.rs
@@ -860,11 +860,22 @@ pub enum OrderRequest {
     CancelAll {
         instrument: InstrumentId,
     },
+    /// Replace a working order.
+    ///
+    /// Carries what the replace message states rather than restating the
+    /// tracked original, so a caller changing the order type, the time-in-force
+    /// or the trigger has the change reach the gateway (ibx#349, ibx#372).
+    /// A zero `tif` states none and leaves the resting value in force.
     Modify {
         new_order_id: OrderId,
         order_id: OrderId,
         price: Price,
         qty: u32,
+        /// Order-type byte, as `Order::ord_type`.
+        ord_type: u8,
+        tif: u8,
+        /// Trigger for the types defined by one; 0 = none.
+        stop_price: Price,
     },
 }
 
@@ -983,7 +994,7 @@ impl OrderRequest {
             | Self::SubmitMtl { .. } | Self::SubmitMktPrt { .. }
             | Self::SubmitSnapMkt { .. } | Self::SubmitSnapMid { .. }
             | Self::SubmitSnapPri { .. } | Self::SubmitMtlAuc { .. } => {}
-            Self::Modify { price, .. } => s(price),
+            Self::Modify { price, stop_price, .. } => { s(price); s(stop_price); }
             Self::SubmitLimit { price, .. }
             | Self::SubmitLimitGtc { price, .. }
             | Self::SubmitLimitIoc { price, .. }
@@ -1619,8 +1630,7 @@ mod tests {
             new_order_id: 2,
             order_id: 1,
             price: 100 * PRICE_SCALE,
-            qty: 200,
-        };
+            qty: 200, ord_type: 0, tif: 0, stop_price: 0 };
         let req2 = req.clone();
         match (req, req2) {
             (
@@ -1868,7 +1878,7 @@ mod tests {
         assert_eq!(req.instrument(), Some(7));
         assert_eq!(OrderRequest::Cancel { order_id: 1 }.instrument(), None);
         assert_eq!(
-            OrderRequest::Modify { new_order_id: 2, order_id: 1, price: 0, qty: 1 }.instrument(),
+            OrderRequest::Modify { new_order_id: 2, order_id: 1, price: 0, qty: 1, ord_type: 0, tif: 0, stop_price: 0 }.instrument(),
             None
         );
     }
@@ -1893,7 +1903,7 @@ mod tests {
 
     #[test]
     fn order_request_modify_fields() {
-        let req = OrderRequest::Modify { new_order_id: 100, order_id: 99, price: 200 * PRICE_SCALE, qty: 10 };
+        let req = OrderRequest::Modify { new_order_id: 100, order_id: 99, price: 200 * PRICE_SCALE, qty: 10, ord_type: 0, tif: 0, stop_price: 0 };
         match req {
             OrderRequest::Modify { order_id, price, qty, .. } => {
                 assert_eq!(order_id, 99);

--- a/tests/ib_paper_compat/orders.rs
+++ b/tests/ib_paper_compat/orders.rs
@@ -231,8 +231,7 @@ pub(super) fn phase_modify_order(conns: Conns) -> Conns {
                         } else if !order_acked {
                             order_acked = true;
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 1,
-                            })).unwrap();
+                                order_id, new_order_id, price: 2_00_000_000, qty: 1, ord_type: 0, tif: 0, stop_price: 0 })).unwrap();
                             modify_sent = true;
                         }
                     }
@@ -459,8 +458,7 @@ pub(super) fn phase_modify_qty(conns: Conns) -> Conns {
                         } else if !order_acked {
                             order_acked = true;
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 1_00_000_000, qty: 2,
-                            })).unwrap();
+                                order_id, new_order_id, price: 1_00_000_000, qty: 2, ord_type: 0, tif: 0, stop_price: 0 })).unwrap();
                             modify_sent = true;
                         }
                     }
@@ -1729,8 +1727,7 @@ pub(super) fn phase_modify_price_and_qty(conns: Conns) -> Conns {
                             order_acked = true;
                             // Modify BOTH price ($1→$2) and qty (1→3) in a single Modify
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 3,
-                            })).unwrap();
+                                order_id, new_order_id, price: 2_00_000_000, qty: 3, ord_type: 0, tif: 0, stop_price: 0 })).unwrap();
                             modify_sent = true;
                         }
                     }
@@ -1797,15 +1794,13 @@ pub(super) fn phase_double_modify(conns: Conns) -> Conns {
                             0 => {
                                 // Original order acked → modify to $2
                                 control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                    order_id, new_order_id: modify_id_1, price: 2_00_000_000, qty: 1,
-                                })).unwrap();
+                                    order_id, new_order_id: modify_id_1, price: 2_00_000_000, qty: 1, ord_type: 0, tif: 0, stop_price: 0 })).unwrap();
                                 phase = 1;
                             }
                             1 => {
                                 // First modify acked → modify again to $3
                                 control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                    order_id: modify_id_1, new_order_id: modify_id_2, price: 3_00_000_000, qty: 1,
-                                })).unwrap();
+                                    order_id: modify_id_1, new_order_id: modify_id_2, price: 3_00_000_000, qty: 1, ord_type: 0, tif: 0, stop_price: 0 })).unwrap();
                                 phase = 2;
                             }
                             2 => {
@@ -1877,8 +1872,7 @@ pub(super) fn phase_cancel_during_modify(conns: Conns) -> Conns {
                             order_acked = true;
                             // Send modify AND cancel back-to-back — no waiting
                             control_tx.send(ControlCommand::Order(OrderRequest::Modify {
-                                order_id, new_order_id, price: 2_00_000_000, qty: 1,
-                            })).unwrap();
+                                order_id, new_order_id, price: 2_00_000_000, qty: 1, ord_type: 0, tif: 0, stop_price: 0 })).unwrap();
                             control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id })).unwrap();
                             control_tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id: new_order_id })).unwrap();
                             race_sent = true;


### PR DESCRIPTION
> Stacked on #373 — review the tip commit only.

## Problem

`OrderRequest::Modify` carried a price and a quantity. It carried neither the order type, the time-in-force nor the trigger, and the encoder re-asserted whatever the tracked original held.

So re-placing a tracked order id with a different time-in-force, a different order type, or a moved stop was accepted and acknowledged, and none of it reached the gateway:

- a caller converting a DAY order to GTC got an order that still expired at the close;
- a caller moving a protective stop got the original trigger, and a zero limit price alongside it — the price the request does carry is read from `lmt_price`, which a stop does not have.

## What this changes

The request carries the three fields and the encoder emits them. **A zero states nothing** and leaves the resting order's value in force, which is every caller that only moves a price or a quantity — `Context::modify` keeps its signature and passes zeroes; `modify_ex` states the rest.

`Order::ord_type_byte` maps the order-type string to the byte the order tracks under, and only the types a replace can express are mapped. Everything else states nothing, which is safe because the gate in #373 refuses those modifies before they reach the encoder — otherwise a type the replace cannot express would be restated as the resting one while the client cached the new one.

**Both price-like fields are snapped to the instrument's grid.** `Modify` carries no instrument so `snap_prices` cannot reach it, and only the limit was being snapped here; a moved trigger off the grid is rejected by the gateway the same way a limit is.

## Tests

The two tests named for this behaviour asserted only that a `Modify` was emitted, so both passed for as long as the change was dropped. They now assert the value that was being dropped.

- `modify_tif_day_to_gtc_via_resubmit`, `modify_order_type_lmt_to_stp` — the request carries the change.
- `a_modify_states_the_type_tif_and_trigger_it_carries` — tags 40, 59 and 99 on the wire.
- `a_modify_that_states_nothing_keeps_the_resting_values` — the other direction.
- `a_moved_trigger_is_snapped_to_the_tick_grid` — `149.03` on a five-cent grid goes out as `149.05`.
- `a_modify_to_an_unrepresentable_type_is_refused` — `REL`, `TRAIL`, `LIT`, `MIDPX`, `SNAP MKT`.

Each fails by name against a compiling reversion of the production change it covers.

Closes #349. Closes #372.


## Test plan

- [x] Mutation: restating the tracked type, tif or trigger instead of the request's fails `a_modify_states_the_type_tif_and_trigger_it_carries` by name — one mutation per field.
- [x] Mutation: dropping the type at the API boundary fails `modify_order_type_lmt_to_stp`.
- [x] Mutation: leaving the trigger unsnapped fails `a_moved_trigger_is_snapped_to_the_tick_grid`.
- [x] `a_modify_that_states_nothing_keeps_the_resting_values` covers the other direction, which is every caller that only moves a price or a quantity.
- [x] `a_modify_to_an_unrepresentable_type_is_refused` covers `REL`, `TRAIL`, `LIT`, `MIDPX` and `SNAP MKT`, so the zero-means-unstated convention cannot silently restate a type.
- [x] `cargo check --offline` clean on `--lib`, `--lib --features python`, `--bins`, `--examples`, and each integration target individually.
- [x] `tests/ib_paper_compat` compared against a clean checkout of the base commit — identical sorted diagnostic sets.
- [x] `cargo test --offline --lib` — only the two known `config::expiry_tests` failures, which fail on the base commit for missing legacy tzdata (fixed separately in #336).
