### PR TITLE
bridge: fence SeqQuote's payload write inside the odd-version window (ibx#267)

### DIFF
--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -100,10 +100,12 @@ impl SeqQuote {
     /// Write a quote (hot loop side). Never blocks.
     #[inline]
     pub fn write(&self, quote: &Quote) {
-        let v = self.version.load(Ordering::Relaxed);
-        self.version.store(v + 1, Ordering::Release); // odd = writing
+        // AcqRel, not Release: the payload write below must not be reordered
+        // above this store. Release alone only fences what precedes it; the
+        // Acquire half is what pins *following* accesses inside the odd window.
+        self.version.fetch_add(1, Ordering::AcqRel); // odd = writing
         unsafe { *self.data.get() = *quote; }
-        self.version.store(v + 2, Ordering::Release); // even = stable
+        self.version.fetch_add(1, Ordering::Release); // even = stable
     }
 
     /// Read a consistent quote snapshot (reader side). Spins on conflict.
@@ -996,5 +998,58 @@ mod tests {
 
         writer.join().unwrap();
         reader.join().unwrap();
+    }
+
+    #[test]
+    fn seqquote_no_torn_reads() {
+        use std::sync::atomic::AtomicBool;
+        use std::sync::Arc;
+        use std::thread;
+
+        // Every field of a given write carries the same value, so any reader
+        // that ever observes a torn (half-old, half-new) struct will catch a
+        // field disagreeing with `bid` here.
+        fn quote_of(i: i64) -> Quote {
+            Quote {
+                bid: i, ask: i, last: i,
+                bid_size: i, ask_size: i, last_size: i,
+                volume: i, open: i, high: i, low: i, close: i,
+                timestamp_ns: i as u64,
+                bid_exch_mask: i, ask_exch_mask: i, last_exch_mask: i,
+            }
+        }
+
+        let sq = Arc::new(SeqQuote::new());
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let writer = {
+            let sq = sq.clone();
+            thread::spawn(move || {
+                for i in 1..=20_000i64 {
+                    sq.write(&quote_of(i));
+                }
+            })
+        };
+
+        let readers: Vec<_> = (0..4).map(|_| {
+            let sq = sq.clone();
+            let stop = stop.clone();
+            thread::spawn(move || {
+                while !stop.load(Ordering::Relaxed) {
+                    let q = sq.read();
+                    let v = q.bid;
+                    let fields = [
+                        q.ask, q.last, q.bid_size, q.ask_size, q.last_size,
+                        q.volume, q.open, q.high, q.low, q.close,
+                        q.timestamp_ns as i64, q.bid_exch_mask, q.ask_exch_mask, q.last_exch_mask,
+                    ];
+                    assert!(fields.iter().all(|&f| f == v), "torn SeqQuote read: bid={v} fields={fields:?}");
+                }
+            })
+        }).collect();
+
+        writer.join().unwrap();
+        stop.store(true, Ordering::Relaxed);
+        for r in readers { r.join().unwrap(); }
     }
 }


### PR DESCRIPTION
## Problem

`SeqQuote` is a seqlock: the writer makes the version odd, writes the payload, then makes it even, and a reader retries while the version is odd or changed under it. The odd-version transition used a `Release` store.

`Release` orders what comes *before* the store. It places no constraint on what comes after, so nothing stopped the payload write being reordered above the store that was supposed to announce it — a reader could observe an even version and a payload already half-updated, with the retry loop none the wiser.

## What this changes

The odd transition is a `fetch_add` with `AcqRel`. The Acquire half is what pins the following payload write inside the odd window. The closing transition keeps `Release`, which was already correct.

## What the test can and cannot show

`seqquote_no_torn_reads` runs four readers against one writer over twenty thousand quotes, comparing *every* field against a sentinel rather than the two the existing test checked. It is a genuine regression guard on the retry contract and strictly stronger than what was there.

It does **not** fail when the ordering annotation alone is reverted, and no test on this target would. x86 does not reorder a core's own accesses relative to each other, so the defect is real by the Rust abstract machine — where the compiler is free to hoist the payload write — but not something an x86 execution can be expected to expose. Thirty million writes across twelve threads, in debug and release, showed no divergence between the two orderings.

This is stated rather than papered over: the guard here is the reasoning about the memory model, and the test protects the surrounding contract.

## Separately

Miri reports a data race in this type regardless of how the version is ordered: the payload itself is read and written non-atomically, so a torn read is undefined before the version check can reject it. That needs per-field atomic or volatile access and is materially larger than this — filed as #388.

Closes #267.
