### PR TITLE
python: let KeyboardInterrupt and SystemExit out of a callback (ibx#270)

### DIFF
--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -18,14 +18,18 @@ use super::super::contract::{Contract, ContractDescription, ContractDetails, Bar
 use super::super::tick_types::*;
 use super::super::super::types::PRICE_SCALE_F;
 
-/// Call a Python wrapper method, catching and logging any exception instead of propagating.
-/// This prevents user callback exceptions from killing the dispatch loop.
+/// Call a Python wrapper method, catching and logging an ordinary exception instead of
+/// propagating it so one bad callback cannot kill the dispatch loop. `KeyboardInterrupt`,
+/// `SystemExit`, and any other exception deriving from `BaseException` rather than
+/// `Exception` are re-raised so Ctrl-C during a callback still stops `run()` and a
+/// callback-raised `SystemExit` still terminates it, matching ibapi.
 macro_rules! call_wrapper {
     ($wrapper:expr, $py:expr, $method:expr, $args:expr) => {
         if let Err(e) = $wrapper.call_method($py, $method, $args, None) {
+            if !e.is_instance_of::<pyo3::exceptions::PyException>($py) {
+                return Err(e);
+            }
             log::error!("Python callback {}() raised: {}", $method, e);
-            e.restore($py);
-            unsafe { pyo3::ffi::PyErr_Clear(); }
         }
     };
 }


### PR DESCRIPTION
## Problem

Every Python callback was invoked through a macro that caught whatever it raised, logged it, and carried on. That is right for an ordinary exception — one bad callback should not kill the dispatch loop — but it applied to `KeyboardInterrupt` and `SystemExit` too.

So Ctrl-C pressed while a callback was running was logged and discarded, and a callback raising `SystemExit` could not stop `run()`.

## What this changes

An exception that derives from `BaseException` but not `Exception` is re-raised instead of logged. That is exactly the set Python reserves for control flow — `KeyboardInterrupt`, `SystemExit`, `GeneratorExit` — and it is the same line ibapi draws. Ordinary exceptions are still caught and logged, unchanged.

Every call site sits directly in `dispatch_once`'s body, so the re-raise unwinds through its `PyResult<()>`, through `run()`'s `?`, and back to the Python caller as the original exception. Verified by walking the brace structure of the function rather than by grep: the function contains ten closure bodies, and no call site is inside one — a `return` in a closure would have exited the closure and swallowed the interrupt anyway.

The `restore`-then-`PyErr_Clear` pair on the swallow path is removed. It nets out to dropping the error, which is what letting it fall out of scope does.

## Verification

`cargo check --offline --lib --features python` is clean, and the full gate passes.

Not run: `cargo test --lib --features python`, which does not link in this tree — a stale test blocks compilation and libpython is then missing (#381). The propagation path is therefore established by reading the call-site placement, the return-type plumbing, and pyo3's exception hierarchy rather than by executing it.

Closes #270.
