### PR TITLE
python: release the GIL around the operations that block (ibx#271)

### DIFF
--- a/src/python/compat/client/account.rs
+++ b/src/python/compat/client/account.rs
@@ -1,6 +1,5 @@
 //! Account-related methods: positions, PnL, account summary/updates.
 
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 use crate::types::*;
@@ -12,21 +11,20 @@ use super::super::super::types::PRICE_SCALE_F;
 impl EClient {
     /// Request P&L updates for the account.
     #[pyo3(signature = (req_id, account, model_code=""))]
-    fn req_pnl(&self, req_id: i64, account: &str, model_code: &str) -> PyResult<()> {
+    fn req_pnl(&self, py: Python<'_>, req_id: i64, account: &str, model_code: &str) -> PyResult<()> {
         self.core.subscribe_pnl(req_id);
         let tx = self.tx()?;
         let acct = if account.is_empty() { self.account() } else { account.to_string() };
-        tx.send(ControlCommand::SubscribePnl { req_id, account: acct })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::SubscribePnl { req_id, account: acct })?;
         let _ = model_code;
         Ok(())
     }
 
     /// Cancel P&L subscription.
-    fn cancel_pnl(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_pnl(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         self.core.unsubscribe_pnl(req_id);
         let tx = self.tx()?;
-        let _ = tx.send(ControlCommand::CancelPnl { req_id });
+        let _ = Self::send_control(py, &tx, ControlCommand::CancelPnl { req_id });
         Ok(())
     }
 

--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -208,7 +208,7 @@ impl EClient {
             }
         }
         for req_id in snapshot_done {
-            self.cancel_mkt_data(req_id)?;
+            self.cancel_mkt_data(py, req_id)?;
         }
 
         // Drain TBT trades -> tickByTickAllLast

--- a/src/python/compat/client/market_data.rs
+++ b/src/python/compat/client/market_data.rs
@@ -19,6 +19,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, generic_tick_list="", snapshot=false, regulatory_snapshot=false, mkt_data_options=Vec::new()))]
     fn req_mkt_data(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         generic_tick_list: &str,
@@ -29,12 +30,25 @@ impl EClient {
         let tx = self.tx()?;
         let shared = self.shared_state()?;
 
-        self.core.register_mkt_data(
+        // The engine can take up to REGISTRATION_TIMEOUT to reply; release
+        // the GIL for the round trip so a slow reply stalls this call, not
+        // every Python thread (ibx#271). Own the contract fields first —
+        // `contract` itself must not cross the detach boundary.
+        let con_id = contract.con_id;
+        let symbol = contract.symbol.clone();
+        let exchange = contract.exchange.clone();
+        let sec_type = contract.sec_type.clone();
+        let last_trade_date = contract.last_trade_date_or_contract_month.clone();
+        let strike = contract.strike;
+        let right = contract.right.clone();
+        let multiplier = contract.multiplier.clone();
+        let generic_tick_list = generic_tick_list.to_string();
+        py.detach(|| self.core.register_mkt_data(
             &shared, &tx, req_id,
-            contract.con_id, &contract.symbol, &contract.exchange, &contract.sec_type,
-            &contract.last_trade_date_or_contract_month, contract.strike, &contract.right, &contract.multiplier,
-            snapshot, generic_tick_list, 0,
-        ).map_err(|e| PyRuntimeError::new_err(e))?;
+            con_id, &symbol, &exchange, &sec_type,
+            &last_trade_date, strike, &right, &multiplier,
+            snapshot, &generic_tick_list, 0,
+        )).map_err(|e| PyRuntimeError::new_err(e))?;
         self.core.cache_contract(contract.con_id, crate::api::types::Contract {
             con_id: contract.con_id,
             symbol: contract.symbol.clone(),
@@ -54,14 +68,13 @@ impl EClient {
     }
 
     /// Cancel market data.
-    pub fn cancel_mkt_data(&self, req_id: i64) -> PyResult<()> {
+    pub fn cancel_mkt_data(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let (instrument, needs_news_unsub) = self.core.unregister_mkt_data(req_id);
         if let Some(instrument) = instrument {
             let tx = self.tx()?;
-            tx.send(ControlCommand::Unsubscribe { instrument })
-                .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+            Self::send_control(py, &tx, ControlCommand::Unsubscribe { instrument })?;
             if needs_news_unsub {
-                let _ = tx.send(ControlCommand::UnsubscribeNews { instrument });
+                let _ = Self::send_control(py, &tx, ControlCommand::UnsubscribeNews { instrument });
             }
         }
         Ok(())
@@ -71,6 +84,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, tick_type, number_of_ticks=0, ignore_size=false))]
     fn req_tick_by_tick_data(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         tick_type: &str,
@@ -86,30 +100,31 @@ impl EClient {
         };
 
         let shared = self.shared_state()?;
-        tx.send(ControlCommand::RegisterInstrument {
+        Self::send_control(py, &tx, ControlCommand::RegisterInstrument {
             con_id: contract.con_id,
             symbol: contract.symbol.clone(),
             sec_type: contract.sec_type.clone(),
             exchange: contract.exchange.clone(),
             reply_tx: None,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
-        self.core.register_tbt(
-            &shared, &tx, req_id,
-            contract.con_id, &contract.symbol, tbt_type,
-        ).map_err(|e| PyRuntimeError::new_err(e))?;
+        })?;
+        // Same registration-wait hazard as req_mkt_data: release the GIL for
+        // the reply round trip (ibx#271).
+        let con_id = contract.con_id;
+        let symbol = contract.symbol.clone();
+        py.detach(|| self.core.register_tbt(&shared, &tx, req_id, con_id, &symbol, tbt_type))
+            .map_err(|e| PyRuntimeError::new_err(e))?;
 
         let _ = (number_of_ticks, ignore_size);
         Ok(())
     }
 
     /// Cancel tick-by-tick data.
-    fn cancel_tick_by_tick_data(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_tick_by_tick_data(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         if let Some(instrument) = self.core.req_to_instrument.lock().unwrap().remove(&req_id) {
             self.core.instrument_to_req.lock().unwrap().remove(&instrument);
             self.core.forget_instrument(instrument);
             let tx = self.tx()?;
-            tx.send(ControlCommand::UnsubscribeTbt { instrument })
-                .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+            Self::send_control(py, &tx, ControlCommand::UnsubscribeTbt { instrument })?;
         }
         Ok(())
     }
@@ -118,10 +133,9 @@ impl EClient {
     /// lightweight liveness probe with no side effects on subscriptions,
     /// contract caches, or pacing budgets. Poll `last_rtt_ms()` after a
     /// moment for the result.
-    fn req_ping(&self) -> PyResult<()> {
+    fn req_ping(&self, py: Python<'_>) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::Ping)
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::Ping)?;
         Ok(())
     }
 
@@ -152,6 +166,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, num_rows=5, is_smart_depth=false, mkt_depth_options=Vec::new()))]
     fn req_mkt_depth(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         num_rows: i32,
@@ -162,24 +177,23 @@ impl EClient {
         let exchange = if contract.exchange.is_empty() { "SMART".to_string() } else { contract.exchange.clone() };
         let sec_type = if contract.sec_type.is_empty() { "STK".to_string() } else { contract.sec_type.clone() };
         let tx = self.tx()?;
-        tx.send(ControlCommand::SubscribeDepth {
+        Self::send_control(py, &tx, ControlCommand::SubscribeDepth {
             req_id: req_id as u32,
             con_id: contract.con_id,
             exchange,
             sec_type,
             num_rows,
             is_smart_depth,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
     /// Cancel market depth.
     #[pyo3(signature = (req_id, is_smart_depth=false))]
-    fn cancel_mkt_depth(&self, req_id: i64, is_smart_depth: bool) -> PyResult<()> {
+    fn cancel_mkt_depth(&self, py: Python<'_>, req_id: i64, is_smart_depth: bool) -> PyResult<()> {
         let _ = is_smart_depth;
         let tx = self.tx()?;
-        tx.send(ControlCommand::UnsubscribeDepth { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::UnsubscribeDepth { req_id: req_id as u32 })?;
         Ok(())
     }
 
@@ -187,6 +201,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, bar_size=5, what_to_show="TRADES", use_rth=0, real_time_bars_options=Vec::new()))]
     fn req_real_time_bars(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         bar_size: i32,
@@ -196,21 +211,20 @@ impl EClient {
     ) -> PyResult<()> {
         let tx = self.tx()?;
         let _ = (bar_size, real_time_bars_options);
-        tx.send(ControlCommand::SubscribeRealTimeBar {
+        Self::send_control(py, &tx, ControlCommand::SubscribeRealTimeBar {
             req_id: req_id as u32,
             con_id: contract.con_id,
             symbol: contract.symbol.clone(),
             what_to_show: what_to_show.to_string(),
             use_rth: use_rth != 0,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
     /// Cancel real-time bars.
-    fn cancel_real_time_bars(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_real_time_bars(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::CancelRealTimeBar { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::CancelRealTimeBar { req_id: req_id as u32 })?;
         Ok(())
     }
 

--- a/src/python/compat/client/mod.rs
+++ b/src/python/compat/client/mod.rs
@@ -68,7 +68,23 @@ impl Drop for EClient {
             let _ = tx.send(ControlCommand::Shutdown);
         }
         if let Some(h) = self._thread.lock().unwrap().take() {
-            let _ = h.join();
+            // A wedged engine (ibx#254) never returns from join(). Detach so
+            // that stall parks this thread, not the whole interpreter
+            // (ibx#271). try_attach, not attach: dealloc also runs during
+            // interpreter shutdown (and `wrapper` commonly points back at
+            // the object embedding this EClient, so the cyclic GC — not
+            // just refcounting — can be the one calling drop), and attach
+            // is unsound there. Fall back to a plain join in that case,
+            // same as before this fix.
+            let mut h = Some(h);
+            Python::try_attach(|py| {
+                if let Some(h) = h.take() {
+                    py.detach(|| { let _ = h.join(); });
+                }
+            });
+            if let Some(h) = h {
+                let _ = h.join();
+            }
         }
     }
 }
@@ -184,12 +200,14 @@ impl EClient {
     }
 
     /// Disconnect from IB.
-    fn disconnect(&self) -> PyResult<()> {
+    fn disconnect(&self, py: Python<'_>) -> PyResult<()> {
         if let Some(tx) = self.control_tx.lock().unwrap().as_ref() {
             let _ = tx.send(ControlCommand::Shutdown);
         }
         if let Some(h) = self._thread.lock().unwrap().take() {
-            let _ = h.join();
+            // Same wedged-engine hazard as Drop (ibx#254): release the GIL
+            // for the join so a stuck engine thread stalls only this call.
+            py.detach(|| { let _ = h.join(); });
         }
         self.connected.store(false, Ordering::Release);
         // Reset per-session state so connect() can be called again.
@@ -250,6 +268,19 @@ impl EClient {
             .ok_or_else(|| PyRuntimeError::new_err("Not connected"))
     }
 
+    /// Send a control command to the engine. `control_tx` is a bounded(64)
+    /// channel: a full queue is normal backpressure (the hot loop is behind,
+    /// not gone) and `send` is meant to wait for it to drain, so the send
+    /// itself stays blocking. What must not happen is waiting with the GIL
+    /// held, stalling every Python thread instead of just this call
+    /// (ibx#271), so the wait runs detached, and only the actual send
+    /// crosses that boundary; `cmd` must already be a plain owned value by
+    /// the time it's built (never touching Python state once detached).
+    pub(crate) fn send_control(py: Python<'_>, tx: &Sender<ControlCommand>, cmd: ControlCommand) -> PyResult<()> {
+        py.detach(|| tx.send(cmd))
+            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))
+    }
+
     /// Clone the shared state Arc, or return "Not connected".
     pub(crate) fn shared_state(&self) -> PyResult<Arc<SharedState>> {
         self.shared.lock().unwrap().clone()
@@ -261,13 +292,18 @@ impl EClient {
         self.account_id.lock().unwrap().clone().unwrap_or_default()
     }
 
-    /// Find instrument ID for a contract, registering if needed.
-    pub(crate) fn find_or_register_instrument(&self, contract: &Contract) -> PyResult<u32> {
+    /// Find instrument ID for a contract, registering if needed. The hot
+    /// loop can take up to `REGISTRATION_TIMEOUT` to reply, so the round
+    /// trip runs with the GIL released: otherwise a slow reply stalls every
+    /// Python thread, not just this call (ibx#271).
+    pub(crate) fn find_or_register_instrument(&self, py: Python<'_>, contract: &Contract) -> PyResult<u32> {
         let tx = self.tx()?;
-        self.core.find_or_register_instrument(
-            &tx,
-            contract.con_id, &contract.symbol, &contract.exchange, &contract.sec_type,
-        ).map_err(|e| PyRuntimeError::new_err(e))
+        let con_id = contract.con_id;
+        let symbol = contract.symbol.clone();
+        let exchange = contract.exchange.clone();
+        let sec_type = contract.sec_type.clone();
+        py.detach(|| self.core.find_or_register_instrument(&tx, con_id, &symbol, &exchange, &sec_type))
+            .map_err(|e| PyRuntimeError::new_err(e))
     }
 }
 

--- a/src/python/compat/client/orders.rs
+++ b/src/python/compat/client/orders.rs
@@ -33,7 +33,7 @@ impl EClient {
             self.next_order_id.fetch_add(1, Ordering::Relaxed)
         };
 
-        let instrument = self.find_or_register_instrument(contract)?;
+        let instrument = self.find_or_register_instrument(py, contract)?;
 
         // If orderId is already tracked, this is a modification — emit Modify instead of Submit.
         let cmd = if self.core.is_order_tracked(oid) {
@@ -49,8 +49,7 @@ impl EClient {
             ClientCore::build_order_request(&api_order, oid, instrument)
                 .map_err(|e| PyRuntimeError::new_err(e))?
         };
-        tx.send(cmd)
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, cmd)?;
 
         // Track order in shared core
         let api_contract = ApiContract {
@@ -71,21 +70,20 @@ impl EClient {
 
     /// Cancel an order.
     #[pyo3(signature = (order_id, manual_order_cancel_time=""))]
-    fn cancel_order(&self, order_id: i64, manual_order_cancel_time: &str) -> PyResult<()> {
+    fn cancel_order(&self, py: Python<'_>, order_id: i64, manual_order_cancel_time: &str) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::Order(OrderRequest::Cancel { order_id: order_id as u64 }))
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::Order(OrderRequest::Cancel { order_id: order_id as u64 }))?;
         let _ = manual_order_cancel_time;
         Ok(())
     }
 
     /// Cancel all orders globally.
-    fn req_global_cancel(&self) -> PyResult<()> {
+    fn req_global_cancel(&self, py: Python<'_>) -> PyResult<()> {
         let tx = self.tx()?;
         let shared = self.shared_state()?;
         let count = shared.market.instrument_count();
         for instrument in 0..count {
-            let _ = tx.send(ControlCommand::Order(OrderRequest::CancelAll { instrument }));
+            let _ = Self::send_control(py, &tx, ControlCommand::Order(OrderRequest::CancelAll { instrument }));
         }
         Ok(())
     }

--- a/src/python/compat/client/reference.rs
+++ b/src/python/compat/client/reference.rs
@@ -14,6 +14,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, end_date_time, duration_str, bar_size_setting, what_to_show, use_rth, format_date=1, keep_up_to_date=false, chart_options=Vec::new()))]
     fn req_historical_data(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         end_date_time: &str,
@@ -32,15 +33,15 @@ impl EClient {
                 .map_err(|e| PyRuntimeError::new_err(e))?;
         }
         if what_to_show.eq_ignore_ascii_case("SCHEDULE") {
-            tx.send(ControlCommand::FetchHistoricalSchedule {
+            Self::send_control(py, &tx, ControlCommand::FetchHistoricalSchedule {
                 req_id: req_id as u32,
                 con_id: contract.con_id,
                 end_date_time: end_date_time.to_string(),
                 duration: duration_str.to_string(),
                 use_rth: use_rth != 0,
-            }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+            })?;
         } else {
-            tx.send(ControlCommand::FetchHistorical {
+            Self::send_control(py, &tx, ControlCommand::FetchHistorical {
                 req_id: req_id as u32,
                 con_id: contract.con_id,
                 symbol: contract.symbol.clone(),
@@ -50,16 +51,15 @@ impl EClient {
                 what_to_show: what_to_show.to_string(),
                 use_rth: use_rth != 0,
                 keep_up_to_date,
-            }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+            })?;
         }
         Ok(())
     }
 
     /// Cancel historical data.
-    fn cancel_historical_data(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_historical_data(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::CancelHistorical { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::CancelHistorical { req_id: req_id as u32 })?;
         Ok(())
     }
 
@@ -67,6 +67,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, what_to_show, use_rth, format_date=1))]
     fn req_head_time_stamp(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         what_to_show: &str,
@@ -74,28 +75,27 @@ impl EClient {
         format_date: i32,
     ) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchHeadTimestamp {
+        Self::send_control(py, &tx, ControlCommand::FetchHeadTimestamp {
             req_id: req_id as u32,
             con_id: contract.con_id,
             what_to_show: what_to_show.to_string(),
             use_rth: use_rth != 0,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         let _ = format_date;
         Ok(())
     }
 
     /// Cancel head timestamp request.
-    fn cancel_head_time_stamp(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_head_time_stamp(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::CancelHeadTimestamp { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::CancelHeadTimestamp { req_id: req_id as u32 })?;
         Ok(())
     }
 
     /// Request contract details.
-    fn req_contract_details(&self, req_id: i64, contract: &Contract) -> PyResult<()> {
+    fn req_contract_details(&self, py: Python<'_>, req_id: i64, contract: &Contract) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchContractDetails {
+        Self::send_control(py, &tx, ControlCommand::FetchContractDetails {
             req_id: req_id as u32,
             con_id: contract.con_id,
             symbol: contract.symbol.clone(),
@@ -113,25 +113,24 @@ impl EClient {
                 sec_id: contract.sec_id.clone(),
                 sec_id_type: contract.sec_id_type.clone(),
             },
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
     /// Request available exchanges for market depth.
-    fn req_mkt_depth_exchanges(&self) -> PyResult<()> {
+    fn req_mkt_depth_exchanges(&self, py: Python<'_>) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchMktDepthExchanges)
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::FetchMktDepthExchanges)?;
         Ok(())
     }
 
     /// Search for matching symbols.
-    fn req_matching_symbols(&self, req_id: i64, pattern: &str) -> PyResult<()> {
+    fn req_matching_symbols(&self, py: Python<'_>, req_id: i64, pattern: &str) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchMatchingSymbols {
+        Self::send_control(py, &tx, ControlCommand::FetchMatchingSymbols {
             req_id: req_id as u32,
             pattern: pattern.to_string(),
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
@@ -154,25 +153,23 @@ impl EClient {
                 .and_then(|v| v.extract::<String>(py)).unwrap_or_else(|_| "TOP_PERC_GAIN".to_string());
             let max_items = subscription.getattr(py, "numberOfRows")
                 .and_then(|v| v.extract::<u32>(py)).unwrap_or(50);
-            tx.send(ControlCommand::SubscribeScanner {
+            Self::send_control(py, &tx, ControlCommand::SubscribeScanner {
                 req_id: req_id as u32, instrument, location_code, scan_code, max_items,
-            }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))
+            })
         })
     }
 
     /// Cancel scanner subscription.
-    fn cancel_scanner_subscription(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_scanner_subscription(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::CancelScanner { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::CancelScanner { req_id: req_id as u32 })?;
         Ok(())
     }
 
     /// Request scanner parameters XML.
-    fn req_scanner_parameters(&self) -> PyResult<()> {
+    fn req_scanner_parameters(&self, py: Python<'_>) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchScannerParams)
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::FetchScannerParams)?;
         Ok(())
     }
 
@@ -180,6 +177,7 @@ impl EClient {
     #[pyo3(signature = (req_id, provider_code, article_id, news_article_options=Vec::new()))]
     fn req_news_article(
         &self,
+        py: Python<'_>,
         req_id: i64,
         provider_code: &str,
         article_id: &str,
@@ -187,11 +185,11 @@ impl EClient {
     ) -> PyResult<()> {
         let _ = news_article_options;
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchNewsArticle {
+        Self::send_control(py, &tx, ControlCommand::FetchNewsArticle {
             req_id: req_id as u32,
             provider_code: provider_code.to_string(),
             article_id: article_id.to_string(),
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
@@ -199,6 +197,7 @@ impl EClient {
     #[pyo3(signature = (req_id, con_id, provider_codes, start_date_time, end_date_time, total_results, historical_news_options=Vec::new()))]
     fn req_historical_news(
         &self,
+        py: Python<'_>,
         req_id: i64,
         con_id: i64,
         provider_codes: &str,
@@ -209,14 +208,14 @@ impl EClient {
     ) -> PyResult<()> {
         let _ = historical_news_options;
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchHistoricalNews {
+        Self::send_control(py, &tx, ControlCommand::FetchHistoricalNews {
             req_id: req_id as u32,
             con_id: con_id as u32,
             provider_codes: provider_codes.to_string(),
             start_time: start_date_time.to_string(),
             end_time: end_date_time.to_string(),
             max_results: total_results as u32,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
@@ -224,6 +223,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, report_type, fundamental_data_options=Vec::new()))]
     fn req_fundamental_data(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         report_type: &str,
@@ -231,19 +231,18 @@ impl EClient {
     ) -> PyResult<()> {
         let _ = fundamental_data_options;
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchFundamentalData {
+        Self::send_control(py, &tx, ControlCommand::FetchFundamentalData {
             req_id: req_id as u32,
             con_id: contract.con_id as u32,
             report_type: report_type.to_string(),
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
     /// Cancel fundamental data.
-    fn cancel_fundamental_data(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_fundamental_data(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::CancelFundamentalData { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::CancelFundamentalData { req_id: req_id as u32 })?;
         Ok(())
     }
 
@@ -251,6 +250,7 @@ impl EClient {
     #[pyo3(signature = (req_id, contract, start_date_time="", end_date_time="", number_of_ticks=1000, what_to_show="TRADES", use_rth=1, ignore_size=false, misc_options=Vec::new()))]
     fn req_historical_ticks(
         &self,
+        py: Python<'_>,
         req_id: i64,
         contract: &Contract,
         start_date_time: &str,
@@ -263,7 +263,7 @@ impl EClient {
     ) -> PyResult<()> {
         let tx = self.tx()?;
         let _ = (ignore_size, misc_options);
-        tx.send(ControlCommand::FetchHistoricalTicks {
+        Self::send_control(py, &tx, ControlCommand::FetchHistoricalTicks {
             req_id: req_id as u32,
             con_id: contract.con_id,
             start_date_time: start_date_time.to_string(),
@@ -271,7 +271,7 @@ impl EClient {
             number_of_ticks: number_of_ticks as u32,
             what_to_show: what_to_show.to_string(),
             use_rth: use_rth != 0,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
@@ -294,39 +294,38 @@ impl EClient {
 
     /// Request histogram data.
     #[pyo3(signature = (req_id, contract, use_rth, time_period))]
-    fn req_histogram_data(&self, req_id: i64, contract: &Contract, use_rth: bool, time_period: &str) -> PyResult<()> {
+    fn req_histogram_data(&self, py: Python<'_>, req_id: i64, contract: &Contract, use_rth: bool, time_period: &str) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchHistogramData {
+        Self::send_control(py, &tx, ControlCommand::FetchHistogramData {
             req_id: req_id as u32,
             con_id: contract.con_id as u32,
             use_rth,
             period: time_period.to_string(),
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 
     /// Cancel histogram data.
-    fn cancel_histogram_data(&self, req_id: i64) -> PyResult<()> {
+    fn cancel_histogram_data(&self, py: Python<'_>, req_id: i64) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::CancelHistogramData { req_id: req_id as u32 })
-            .map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        Self::send_control(py, &tx, ControlCommand::CancelHistogramData { req_id: req_id as u32 })?;
         Ok(())
     }
 
     /// Request historical trading schedule.
     #[pyo3(signature = (req_id, contract, end_date_time="", duration_str="1 M", use_rth=true))]
     fn req_historical_schedule(
-        &self, req_id: i64, contract: &Contract,
+        &self, py: Python<'_>, req_id: i64, contract: &Contract,
         end_date_time: &str, duration_str: &str, use_rth: bool,
     ) -> PyResult<()> {
         let tx = self.tx()?;
-        tx.send(ControlCommand::FetchHistoricalSchedule {
+        Self::send_control(py, &tx, ControlCommand::FetchHistoricalSchedule {
             req_id: req_id as u32,
             con_id: contract.con_id,
             end_date_time: end_date_time.into(),
             duration: duration_str.into(),
             use_rth,
-        }).map_err(|e| PyRuntimeError::new_err(format!("Engine stopped: {}", e)))?;
+        })?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Problem

The Python layer held the GIL across operations that block. A thread join on `disconnect()` and on `Drop`, the registration waits that can sit for up to five seconds, and every control-channel send: each one blocked with the interpreter locked, so one stalled call froze every other Python thread in the process.

## What this changes

The GIL is released around the wait and reacquired after — the blocking operation is what moves inside the detach, and nothing Python-backed crosses that boundary. Commands are built while attached, so only an owned `ControlCommand` and a channel reference travel with the closure.

The sends stay **blocking**. The channel is bounded, so a burst applies backpressure and then succeeds, which is the behaviour callers already have; what was wrong was holding the GIL while waiting, not the waiting itself.

`Drop` mints its token with `Python::try_attach` rather than `Python::attach`. Dealloc can run during interpreter shutdown, and the common `App(EWrapper, EClient)` shape means the cyclic collector rather than refcounting may be what calls it. Where the token cannot be had, the join still happens — the handle is never dropped unjoined.

`ClientCore` is untouched. It is shared with the plain Rust API, which has no GIL to release, so the fix stays on the Python side that wraps it.

## Verification

`cargo check --offline --lib --features python` is clean, and the full gate passes.

Not run: `cargo test --lib --features python` and the pytest suite, neither of which links in this tree (#381). The unblocking behaviour and the `try_attach` shutdown path are established by reading pyo3 0.29's `Ungil` bounds and `detach`/`try_attach` contracts against this repo's existing usage in `connect()` and `run()`, rather than by exercising an interpreter.

Closes #271.
