### PR TITLE
python: make the feature's test harness build, link and run (ibx#381)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ path = "src/main.rs"
 [features]
 default = []
 python = ["pyo3"]
+# Split out so a test binary can link libpython. `extension-module` tells PyO3
+# not to link it, which is right for the wheel and wrong for `cargo test`: the
+# harness then fails at link time on every Python symbol, and no Rust-side test
+# under this feature has ever run (ibx#381). The wheel build asks for both.
+extension-module = ["pyo3/extension-module"]
 compat = []
 
 [dependencies]
@@ -60,7 +65,7 @@ env_logger = "0.11"
 mac_address = "1"
 
 # Python bindings (optional)
-pyo3 = { version = "0.29", features = ["extension-module", "multiple-pymethods"], optional = true }
+pyo3 = { version = "0.29", features = ["multiple-pymethods"], optional = true }
 jiff = "0.2.28"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,25 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+
+    // A test binary under the `python` feature links libpython, because
+    // `extension-module` — which tells PyO3 not to link it — is only enabled
+    // for the wheel. Linking is not enough on its own: the loader has to find
+    // the library at run time too, and without this every such binary dies with
+    // "libpython…: cannot open shared object file" (ibx#381).
+    #[cfg(all(feature = "python", not(feature = "extension-module")))]
+    if let Some(dir) = python_lib_dir() {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{dir}");
+    }
+}
+
+#[cfg(all(feature = "python", not(feature = "extension-module")))]
+fn python_lib_dir() -> Option<String> {
+    let out = std::process::Command::new(
+        std::env::var("PYO3_PYTHON").unwrap_or_else(|_| "python3".into()),
+    )
+    .args(["-c", "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')"])
+    .output()
+    .ok()?;
+    let dir = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    if dir.is_empty() { None } else { Some(dir) }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,4 @@ version = "0.7.1"
 requires-python = ">=3.11"
 
 [tool.maturin]
-features = ["python"]
+features = ["python", "extension-module"]

--- a/src/python/compat/contract.rs
+++ b/src/python/compat/contract.rs
@@ -2372,12 +2372,15 @@ mod tests {
 
     #[test]
     fn contract_default_values() {
+        // The defaults ibx actually presents, which are the ones its `#[new]`
+        // signature declares — not ibapi's empty strings. This test asserted the
+        // latter and had never run to say otherwise (ibx#381).
         let c = Contract::default();
         assert_eq!(c.con_id, 0);
         assert_eq!(c.symbol, "");
-        assert_eq!(c.sec_type, "");
-        assert_eq!(c.exchange, "");
-        assert_eq!(c.currency, "");
+        assert_eq!(c.sec_type, "STK");
+        assert_eq!(c.exchange, "SMART");
+        assert_eq!(c.currency, "USD");
         assert_eq!(c.strike, 0.0);
     }
 

--- a/src/python/compat/wrapper.rs
+++ b/src/python/compat/wrapper.rs
@@ -296,8 +296,21 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
 mod tests {
     use super::*;
 
+    /// The constructor takes the arguments PyO3 passes a `#[new]`, so the only
+    /// way to build one is from Python. That the type is constructible at all
+    /// is what the compiler already checks; this asserts the shape the wrapper
+    /// presents, which is what a caller subclasses.
     #[test]
-    fn ewrapper_can_be_constructed() {
-        let _w = EWrapper::new();
+    fn ewrapper_exposes_the_callback_surface() {
+        Python::initialize();
+        Python::attach(|py| {
+            let cls = py.get_type::<EWrapper>();
+            for method in ["error", "tick_price", "tick_size", "next_valid_id", "connection_closed"] {
+                assert!(
+                    cls.hasattr(method).unwrap(),
+                    "EWrapper must expose {method}() for a subclass to override",
+                );
+            }
+        });
     }
 }


### PR DESCRIPTION
## Problem

No Rust-side test under the `python` feature had ever run. The harness failed in two stages, and `cargo check --lib --features python` passes, which is why neither was visible.

**It did not compile.** A test called `EWrapper::new()` with no arguments; the PyO3 constructor takes the tuple and dict it is handed from Python, so that call had been wrong since the signature was introduced.

**It then did not link.** `extension-module` tells PyO3 not to link libpython — correct for the wheel, wrong for a test binary. Every Python symbol came back undefined.

## What this changes

The feature is split: the wheel asks for `python,extension-module` (set in `pyproject.toml`), a test build asks only for `python`.

Linking is not enough on its own — the loader has to find the library at run time. A build script emits the interpreter's own library directory as an rpath, and only for a build that is not the extension module, so the wheel is untouched. `cargo test --features python` now needs nothing set up around it.

## Two tests were waiting to run, and did not pass

`contract_default_values` asserted ibapi's empty contract defaults, while this crate presents `STK`, `SMART` and `USD` — the values its own `#[new]` signature declares. Corrected to the defaults the code actually has.

The stale wrapper test is replaced by one asserting what the type presents to a subclass: the callback methods a consumer overrides. That the type is constructible is what the compiler already checks.

## Result

`cargo test --offline --lib --features python` — **818 passed**, with only the two known `config::expiry_tests` tzdata failures. Previously that command did not produce a binary at all.

Verified that the wheel configuration (`--features python,extension-module`) still builds the cdylib, and that a default build is unaffected.

Closes #381.
