### PR TITLE
orders: distinguish Rejected from Inactive once the ibapi string collapses them (ibx#250)

### DIFF
--- a/src/api/client/dispatch.rs
+++ b/src/api/client/dispatch.rs
@@ -112,7 +112,7 @@ impl EClient {
                 update.order_id as i64, status, update.filled_qty as f64,
                 update.remaining_qty as f64, 0.0, update.perm_id, update.parent_id, 0.0, 0, "", 0.0,
             );
-            self.core.update_order_status(update.order_id, status, update.filled_qty as f64, update.remaining_qty as f64);
+            self.core.update_order_status(update.order_id, update.status, update.filled_qty as f64, update.remaining_qty as f64);
         }
 
         // Cancel rejects → error
@@ -120,6 +120,12 @@ impl EClient {
             let code = if reject.reject_type == 1 { 202 } else { 10147 };
             let msg = format!("Order {} cancel/modify rejected (reason: {})", reject.order_id, reject.reason_code);
             wrapper.error(reject.order_id as i64, code, &msg, "");
+        }
+
+        // Inactive (39=I) order reasons → error (ibx#250). order_status above
+        // already reported the "Inactive" string; this carries why.
+        for (order_id, code, msg) in self.shared.orders.drain_order_inactive() {
+            wrapper.error(order_id as i64, code as i64, &msg, "");
         }
 
         // What-if → open_order(contract, order, OrderState) + order_status (iso with ibapi)

--- a/src/api/client/tests.rs
+++ b/src/api/client/tests.rs
@@ -1699,6 +1699,51 @@ fn process_msgs_dispatches_order_updates() {
     assert!(w.events.iter().any(|e| e.starts_with("order_status:45:Inactive")));
 }
 
+/// ibx#250: a parked (39=I) order's reason reaches the caller through
+/// Wrapper::error, on top of the order_status "Inactive" callback above —
+/// ibapi has no callback dedicated to "order held with reason".
+#[test]
+fn process_msgs_dispatches_inactive_reason_as_error() {
+    let (client, _rx, shared) = test_client();
+    shared.orders.push_order_inactive(46, 399, "Order held pending margin check".into());
+    let mut w = RecordingWrapper::default();
+    client.process_msgs(&mut w);
+    assert!(w.events.iter().any(|e| e == "error:46:399:Order held pending margin check"));
+}
+
+/// ibx#250 end-to-end: a genuinely-Inactive order dispatched through the real
+/// `process_msgs` path (not a direct `ClientCore` call) stays in the
+/// open-order snapshot, while a Rejected one — which stringifies to the same
+/// "Inactive" — does not resurrect into it.
+#[test]
+fn process_msgs_then_open_orders_admits_inactive_excludes_rejected() {
+    let (client, _rx, shared) = test_client();
+    let order = Order {
+        action: "BUY".into(), total_quantity: 100.0,
+        order_type: "LMT".into(), lmt_price: 150.0, ..Default::default()
+    };
+    client.place_order(82, &spy(), &order).unwrap();
+    client.place_order(83, &spy(), &order).unwrap();
+
+    shared.orders.push_order_update(OrderUpdate {
+        order_id: 82, instrument: 0, status: OrderStatus::Inactive,
+        filled_qty: 0, remaining_qty: 100, perm_id: 0, parent_id: 0, timestamp_ns: 0,
+    });
+    shared.orders.push_order_update(OrderUpdate {
+        order_id: 83, instrument: 0, status: OrderStatus::Rejected,
+        filled_qty: 0, remaining_qty: 100, perm_id: 0, parent_id: 0, timestamp_ns: 0,
+    });
+    let mut w = RecordingWrapper::default();
+    client.process_msgs(&mut w);
+
+    w.events.clear();
+    client.req_all_open_orders(&mut w);
+    assert!(w.events.iter().any(|e| e.starts_with("open_order:82:")),
+        "genuinely-inactive order must remain in the open-order snapshot after dispatch");
+    assert!(!w.events.iter().any(|e| e.starts_with("open_order:83:")),
+        "rejected order must not resurrect into the open-order snapshot after dispatch");
+}
+
 #[test]
 fn process_msgs_dispatches_cancel_reject_type_1() {
     let (client, _rx, shared) = test_client();

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -240,7 +240,8 @@ impl MarketDataState {
     }
 }
 
-/// Fills, order status updates, cancel rejects, what-if responses, and order cache.
+/// Fills, order status updates, cancel rejects, what-if responses, order
+/// cache, and inactive-order reasons.
 pub struct OrderState {
     fills: Mutex<Vec<Fill>>,
     order_updates: Mutex<Vec<OrderUpdate>>,
@@ -249,6 +250,11 @@ pub struct OrderState {
     completed_orders: Mutex<Vec<CompletedOrder>>,
     /// Enriched order info from CCP exec reports (order_id -> RichOrderInfo).
     order_cache: Mutex<HashMap<u64, RichOrderInfo>>,
+    /// Reason for a genuinely-Inactive (39=I) transition: (order_id, ibapi
+    /// error code, message). ibapi has no callback dedicated to "order
+    /// parked with reason", so this is drained into `Wrapper::error` the
+    /// same way a cancel/modify reject is (ibx#250).
+    order_inactive: Mutex<Vec<(u64, i32, String)>>,
 }
 
 impl OrderState {
@@ -260,6 +266,7 @@ impl OrderState {
             what_if_responses: Mutex::new(Vec::with_capacity(8)),
             completed_orders: Mutex::new(Vec::with_capacity(64)),
             order_cache: Mutex::new(HashMap::new()),
+            order_inactive: Mutex::new(Vec::with_capacity(8)),
         }
     }
 
@@ -275,6 +282,12 @@ impl OrderState {
         self.cancel_rejects.lock().unwrap().drain(..).collect()
     }
 
+    /// Drain reasons for genuinely-Inactive (39=I) transitions, each as
+    /// (order_id, ibapi error code, message) — see `order_inactive` (ibx#250).
+    pub fn drain_order_inactive(&self) -> Vec<(u64, i32, String)> {
+        self.order_inactive.lock().unwrap().drain(..).collect()
+    }
+
     pub fn drain_what_if_responses(&self) -> Vec<WhatIfResponse> {
         self.what_if_responses.lock().unwrap().drain(..).collect()
     }
@@ -283,14 +296,20 @@ impl OrderState {
         self.completed_orders.lock().unwrap().drain(..).collect()
     }
 
-    /// Snapshot enriched entries whose latest status is an open IB state.
-    /// Terminal entries (Filled / Cancelled / Inactive / etc.) are filtered out
-    /// so `req_open_orders` does not leak historical orders that are still cached
-    /// for `req_completed_orders` lookups.
+    /// Snapshot enriched entries that belong in the open-order book: a
+    /// genuinely open IB state, or a genuinely-Inactive (39=I) order that can
+    /// still reactivate. A rejected order also stringifies to "Inactive"
+    /// (ibapi has no Rejected string) but always carries a non-empty
+    /// `completed_status`, which is how the two are told apart — see
+    /// `is_open_or_reactivatable` (ibx#250). Terminal entries (Filled /
+    /// Cancelled / Rejected) are filtered out so `req_open_orders` does not
+    /// leak historical orders that are still cached for `req_completed_orders`
+    /// lookups.
     pub fn drain_open_orders(&self) -> Vec<(u64, RichOrderInfo)> {
         let lock = self.order_cache.lock().unwrap();
         lock.iter()
-            .filter(|(_, v)| crate::client_core::is_open_status(&v.order_state.status))
+            .filter(|(_, v)| crate::client_core::is_open_or_reactivatable(
+                &v.order_state.status, &v.order_state.completed_status))
             .map(|(&k, v)| (k, v.clone()))
             .collect()
     }
@@ -318,6 +337,10 @@ impl OrderState {
 
     #[doc(hidden)] pub fn push_cancel_reject(&self, reject: CancelReject) {
         self.cancel_rejects.lock().unwrap().push(reject);
+    }
+
+    #[doc(hidden)] pub fn push_order_inactive(&self, order_id: u64, code: i32, message: String) {
+        self.order_inactive.lock().unwrap().push((order_id, code, message));
     }
 
     #[doc(hidden)] pub fn push_what_if(&self, response: WhatIfResponse) {
@@ -873,6 +896,33 @@ mod tests {
         let q = sq.read();
         assert_eq!(q.bid, 0);
         assert_eq!(q.ask, 0);
+    }
+
+    #[test]
+    fn order_state_drain_open_orders_admits_inactive_excludes_rejected() {
+        let ss = SharedState::new();
+        ss.orders.push_order_info(90, RichOrderInfo {
+            contract: api::Contract::default(),
+            order: api::Order::default(),
+            order_state: api::OrderState { status: "Inactive".into(), ..Default::default() },
+            last_exec: api::Execution::default(),
+        });
+        ss.orders.push_order_info(91, RichOrderInfo {
+            contract: api::Contract::default(),
+            order: api::Order::default(),
+            order_state: api::OrderState {
+                status: "Inactive".into(),
+                completed_status: "No valid bid/ask".into(),
+                ..Default::default()
+            },
+            last_exec: api::Execution::default(),
+        });
+
+        let open = ss.orders.drain_open_orders();
+        assert!(open.iter().any(|(id, _)| *id == 90),
+            "genuinely-inactive order must be admitted to the open-order snapshot");
+        assert!(!open.iter().any(|(id, _)| *id == 91),
+            "rejected order (non-empty completed_status) must not resurrect");
     }
 
     #[test]

--- a/src/client_core.rs
+++ b/src/client_core.rs
@@ -257,6 +257,23 @@ pub fn is_open_status(status: &str) -> bool {
     )
 }
 
+/// True when `status`/`completed_status` describe an order that belongs in
+/// the open-order snapshot: either genuinely open per [`is_open_status`], or
+/// a genuinely-Inactive order (FIX 39=I) that can still reactivate.
+///
+/// `order_status_str` collapses both Rejected (39=8) and Inactive (39=I) to
+/// the single ibapi string "Inactive" (ibapi has no Rejected string), so
+/// widening `is_open_status` to admit "Inactive" would also readmit rejected
+/// orders into the open book — the trap this function avoids by checking
+/// `completed_status` too. It is populated only for terminal statuses
+/// (Filled/Cancelled/Rejected) and stays empty for a genuine Inactive, so an
+/// empty `completed_status` on an "Inactive" row means the order is parked,
+/// not dead (ibx#250).
+#[inline]
+pub fn is_open_or_reactivatable(status: &str, completed_status: &str) -> bool {
+    is_open_status(status) || (status == "Inactive" && completed_status.is_empty())
+}
+
 /// Convert OrderStatus enum to ibapi-compatible string.
 #[inline]
 pub fn order_status_str(status: OrderStatus) -> &'static str {
@@ -299,6 +316,13 @@ pub struct TrackedOrder {
     pub filled: f64,
     pub remaining: f64,
     pub instrument: InstrumentId,
+    /// True once this order's last transition was a genuine Rejected (FIX
+    /// 39=8). Rejected and Inactive both stringify to `status == "Inactive"`
+    /// (ibapi has no Rejected string), so that string alone cannot tell a
+    /// dead order from a parked, reactivatable one — `collect_open_orders`
+    /// uses this flag as the discriminator instead of widening
+    /// `is_open_status` (ibx#250).
+    pub rejected: bool,
 }
 
 // ── ClientCore ──
@@ -769,6 +793,7 @@ impl ClientCore {
         let remaining = order.total_quantity;
         self.open_orders.lock().unwrap().insert(order_id, TrackedOrder {
             contract, order, status: "PendingSubmit".into(), filled: 0.0, remaining, instrument,
+            rejected: false,
         });
     }
 
@@ -784,11 +809,17 @@ impl ClientCore {
         }
     }
 
-    /// Update a tracked order status from an order update event.
-    pub fn update_order_status(&self, order_id: u64, status: &str, filled: f64, remaining: f64) {
+    /// Update a tracked order status from an order update event. Takes the
+    /// pre-stringification `OrderStatus` (not the ibapi string) so a
+    /// Rejected transition can be flagged apart from a genuinely-Inactive
+    /// one: both stringify to "Inactive" (ibapi has no Rejected string), but
+    /// only a genuine Inactive is reactivatable and belongs back in the
+    /// open-order snapshot (ibx#250).
+    pub fn update_order_status(&self, order_id: u64, status: OrderStatus, filled: f64, remaining: f64) {
         let mut orders = self.open_orders.lock().unwrap();
         if let Some(o) = orders.get_mut(&order_id) {
-            o.status = status.into();
+            o.status = order_status_str(status).into();
+            o.rejected = status == OrderStatus::Rejected;
             o.filled = filled;
             o.remaining = remaining;
         }
@@ -815,11 +846,12 @@ impl ClientCore {
             }
         }
 
-        // Local tracked orders (non-terminal), enriched from secdef cache
+        // Local tracked orders (non-terminal, or genuinely-Inactive and
+        // still reactivatable — ibx#250), enriched from secdef cache
         {
             let orders = self.open_orders.lock().unwrap();
             for (&oid, o) in orders.iter() {
-                if is_open_status(&o.status) {
+                if is_open_status(&o.status) || (o.status == "Inactive" && !o.rejected) {
                     let contract = if o.contract.con_id != 0 {
                         self.get_contract(o.contract.con_id, shared).unwrap_or_else(|| o.contract.clone())
                     } else {
@@ -832,6 +864,7 @@ impl ClientCore {
                         filled: o.filled,
                         remaining: o.remaining,
                         instrument: o.instrument,
+                        rejected: o.rejected,
                     }));
                 }
             }
@@ -839,7 +872,7 @@ impl ClientCore {
 
         // Add shared-only entries not already present from local
         for (oid, info) in shared_orders {
-            if !is_open_status(&info.order_state.status) {
+            if !is_open_or_reactivatable(&info.order_state.status, &info.order_state.completed_status) {
                 continue;
             }
             if !result.iter().any(|(id, _)| *id == oid) {
@@ -855,6 +888,7 @@ impl ClientCore {
                     filled: 0.0,
                     remaining: 0.0,
                     instrument: 0,
+                    rejected: false,
                 }));
             }
         }
@@ -1633,6 +1667,79 @@ impl ClientCore {
 mod tests {
     use super::*;
     use crate::types::SmartComponent;
+    use crate::bridge::RichOrderInfo;
+    use crate::api::types::OrderState as ApiOrderState;
+
+    // ── Rejected/Inactive snapshot admission (ibx#250) ──
+
+    #[test]
+    fn is_open_or_reactivatable_admits_genuine_inactive() {
+        assert!(is_open_or_reactivatable("Inactive", ""));
+    }
+
+    #[test]
+    fn is_open_or_reactivatable_excludes_rejected_shaped_inactive() {
+        // A rejected order also stringifies to "Inactive", but always carries
+        // a non-empty completed_status — that is what must exclude it.
+        assert!(!is_open_or_reactivatable("Inactive", "No valid bid/ask"));
+    }
+
+    #[test]
+    fn is_open_or_reactivatable_still_admits_ordinary_open_status() {
+        assert!(is_open_or_reactivatable("Submitted", ""));
+    }
+
+    #[test]
+    fn is_open_or_reactivatable_still_excludes_terminal_status() {
+        assert!(!is_open_or_reactivatable("Filled", ""));
+        assert!(!is_open_or_reactivatable("Cancelled", ""));
+    }
+
+    #[test]
+    fn collect_open_orders_admits_inactive_but_excludes_rejected_locally_tracked() {
+        let core = ClientCore::new();
+        let shared = SharedState::new();
+        core.track_order(80, ApiContract::default(), ApiOrder { order_id: 80, ..Default::default() }, 0);
+        core.track_order(81, ApiContract::default(), ApiOrder { order_id: 81, ..Default::default() }, 0);
+
+        core.update_order_status(80, OrderStatus::Inactive, 0.0, 100.0);
+        core.update_order_status(81, OrderStatus::Rejected, 0.0, 100.0);
+
+        let result = core.collect_open_orders(&shared);
+        assert!(result.iter().any(|(id, _)| *id == 80),
+            "genuinely-inactive order must remain in the open-order snapshot");
+        assert!(!result.iter().any(|(id, _)| *id == 81),
+            "rejected order must not resurrect into the open-order snapshot");
+    }
+
+    #[test]
+    fn collect_open_orders_shared_only_admits_inactive_but_excludes_rejected() {
+        let core = ClientCore::new();
+        let shared = SharedState::new();
+
+        shared.orders.push_order_info(90, RichOrderInfo {
+            contract: ApiContract::default(),
+            order: ApiOrder { order_id: 90, ..Default::default() },
+            order_state: ApiOrderState { status: "Inactive".into(), ..Default::default() },
+            last_exec: Default::default(),
+        });
+        shared.orders.push_order_info(91, RichOrderInfo {
+            contract: ApiContract::default(),
+            order: ApiOrder { order_id: 91, ..Default::default() },
+            order_state: ApiOrderState {
+                status: "Inactive".into(),
+                completed_status: "No valid bid/ask".into(),
+                ..Default::default()
+            },
+            last_exec: Default::default(),
+        });
+
+        let result = core.collect_open_orders(&shared);
+        assert!(result.iter().any(|(id, _)| *id == 90),
+            "genuinely-inactive shared-only order must be admitted to the open-order snapshot");
+        assert!(!result.iter().any(|(id, _)| *id == 91),
+            "rejected shared-only order must not resurrect into the open-order snapshot");
+    }
 
     fn shared_with_components(comps: Vec<(i32, &str)>) -> SharedState {
         let s = SharedState::new();

--- a/src/engine/hot_loop/ccp.rs
+++ b/src/engine/hot_loop/ccp.rs
@@ -28,6 +28,13 @@ const SECDEF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 /// after a reconnect burst still hits the window.
 const EXEC_ID_WINDOW: usize = 1024;
 
+/// Synthetic ibapi error code for a parked (39=I) order's reason, delivered
+/// through `Wrapper::error` since ibapi has no callback dedicated to an order
+/// held with a reason. Mirrors IB's generic order-message code (399) rather
+/// than the reject code (201) — an Inactive order is not rejected, it can
+/// still reactivate (ibx#250).
+const ORDER_INACTIVE_ERROR_CODE: i32 = 399;
+
 /// Convert a FIX OrderID hex string (e.g. "00cf16ed.000225ed.69ca0941.0001") to a stable i64 permId.
 /// Uses FNV-1a hash of the first 3 dot-segments (the stable prefix) so that permId
 /// remains constant across modifications (the last segment increments on each modify).
@@ -893,6 +900,26 @@ impl CcpState {
                 };
                 shared.orders.push_order_update(update);
                 emit(event_tx, Event::OrderUpdate(update));
+
+                // A parked (39=I) order carries its reason on the same tags
+                // 58/103 as a reject, but OrderState.completedStatus stays
+                // empty for Inactive — it is not completed and may
+                // reactivate, so there is no snapshot field to carry the
+                // reason on. Route it through the same error() path a
+                // cancel/modify reject already uses instead (ibx#250).
+                if status == crate::types::OrderStatus::Inactive {
+                    let text = parsed.get(&58).map(|s| s.as_str()).unwrap_or("");
+                    let reason_code = parsed.get(&103).map(|s| s.as_str()).unwrap_or("");
+                    let reason = match (text.is_empty(), reason_code.is_empty()) {
+                        (false, false) => format!("{} (reason code {})", text, reason_code),
+                        (false, true) => text.to_string(),
+                        (true, false) => format!("reason code {}", reason_code),
+                        (true, true) => String::new(),
+                    };
+                    if !reason.is_empty() {
+                        shared.orders.push_order_inactive(clord_id, ORDER_INACTIVE_ERROR_CODE, reason);
+                    }
+                }
             }
         }
 
@@ -2208,6 +2235,55 @@ mod tests {
         ccp.handle_exec_report(&routed, &mut context, &shared, &None, "");
         assert_eq!(context.order(42).unwrap().status,
             crate::types::OrderStatus::Submitted);
+    }
+
+    // ibx#250: 39=I (Inactive) and 39=8 (Rejected) both stringify to
+    // "Inactive" downstream (client_core::order_status_str), but must not be
+    // treated the same here. A parked (39=I) order's reason is queued for
+    // delivery through Wrapper::error, and its completed_status stays empty
+    // (it is not completed and may reactivate). A rejected order's reason
+    // stays on completed_status only, and nothing is queued for it — the
+    // engine still holds the order at this point, so context still knows it
+    // as Inactive/reactivatable while a Rejected order is retired below.
+    #[test]
+    fn ord_status_inactive_reason_reaches_inactive_queue() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = exec_report_frame(&[
+            (39, "I"), (150, "0"),
+            (58, "Order held pending margin check"), (103, "0"),
+        ]);
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        assert_eq!(context.order(42).unwrap().status, crate::types::OrderStatus::Inactive);
+
+        let inactive = shared.orders.drain_order_inactive();
+        assert_eq!(inactive.len(), 1);
+        assert_eq!(inactive[0].0, 42);
+        assert_eq!(inactive[0].2, "Order held pending margin check (reason code 0)");
+
+        let info = shared.orders.get_order_info(42).unwrap();
+        assert!(info.order_state.completed_status.is_empty());
+    }
+
+    #[test]
+    fn ord_status_rejected_does_not_queue_an_inactive_reason() {
+        let (mut ccp, mut context, shared) = ord_status_test_state();
+        let frame = exec_report_frame(&[
+            (39, "8"), (150, "0"),
+            (58, "No valid bid/ask"), (103, "1"),
+        ]);
+        ccp.handle_exec_report(&frame, &mut context, &shared, &None, "");
+
+        // Rejected is terminal — the engine retires the order.
+        assert!(context.order(42).is_none());
+
+        // The reason must not leak into the Inactive-only queue...
+        assert!(shared.orders.drain_order_inactive().is_empty());
+
+        // ...it stays reachable through completed_status instead (unchanged
+        // by ibx#250 — this pins the pre-existing behavior the fix builds on).
+        let info = shared.orders.get_order_info(42).unwrap();
+        assert_eq!(info.order_state.completed_status, "No valid bid/ask");
     }
 
     // ibx#238 / ib-agent#172: in the UP portfolio snapshot the average cost is

--- a/src/python/compat/client/dispatch.rs
+++ b/src/python/compat/client/dispatch.rs
@@ -163,7 +163,7 @@ impl EClient {
                  update.remaining_qty as f64, 0.0f64, update.perm_id, update.parent_id, 0.0f64, 0i64, "", 0.0f64));
 
             // Track open orders
-            self.core.update_order_status(update.order_id, status, update.filled_qty as f64, update.remaining_qty as f64);
+            self.core.update_order_status(update.order_id, update.status, update.filled_qty as f64, update.remaining_qty as f64);
         }
 
         // Drain cancel rejects -> error
@@ -172,6 +172,11 @@ impl EClient {
             let code = if reject.reject_type == 1 { 202i64 } else { 10147i64 };
             let msg = format!("Order {} cancel/modify rejected (reason: {})", reject.order_id, reject.reason_code);
             call_wrapper!(self.wrapper, py, "error", (reject.order_id as i64, code, msg.as_str(), ""));
+        }
+
+        // Drain inactive-order reasons -> error (ibx#250)
+        for (order_id, code, msg) in shared.orders.drain_order_inactive() {
+            call_wrapper!(self.wrapper, py, "error", (order_id as i64, code as i64, msg.as_str(), ""));
         }
 
         // Poll quotes for changes -> tickPrice/tickSize


### PR DESCRIPTION
## Problem

The wire distinguishes `39=8` (Rejected) from `39=I` (Inactive), and the engine models them as distinct states — but `order_status_str` collapses both to the string `"Inactive"`, correctly, because ibapi has no Rejected string. From that point a caller cannot tell a dead order from a held one, and three consequences follow.

**The reason is dropped.** Tags 58 and 103 are parsed and logged, but reach the API only for `39=8`, through `OrderState.completed_status`. A `39=I` transition surfaces as a bare status change with the reason nowhere a caller can reach.

**The order disappears from the snapshot, and it has to.** `is_open_status` omits `"Inactive"` — and cannot simply admit it, because after stringification that value is also every rejected order. Widening it would resurrect genuinely dead orders. So a reactivatable order is hidden by a filter defending itself against the conflation above, contradicting the engine one layer down, which deliberately models Inactive as non-terminal and reactivatable.

**A replace the gateway parks looks like success.** Every client-visible surface asserts the modify succeeded while `req_open_orders` returns nothing for that order.

## What this changes

`order_status_str` is untouched — both still map to `"Inactive"`, which is the ibapi contract.

`completed_status` is the discriminator. It is already non-empty only for a terminal status and empty otherwise, and a rejection falls back to the literal `"Rejected"` when tag 58 is absent, so it is never empty for one. `is_open_or_reactivatable(status, completed_status)` admits `"Inactive"` only when it is empty. **`is_open_status` itself is not widened**, which is the trap the issue names.

`TrackedOrder` carries whether it was rejected, set at its one write choke point. That function now takes the `OrderStatus` enum rather than the already-collapsed string, so the distinction is read before it is lost and the compiler enforces the call sites.

A `39=I` transition delivers its reason through the wrapper's `error()` callback — the same path a cancel reject already uses — alongside the status change.

## Note for merging

This changes `ClientCore::update_order_status`'s signature. #362 changes the same function for an unrelated reason (an order recovered from an earlier session has no local entry to update). The two are independent but will want resolving together.

## Tests

Eleven, covering the discriminator in all four quadrants, both `collect_open_orders` admission sites, the `drain_open_orders` filter, the `TrackedOrder` write, the ccp gating condition including the Rejected/Inactive conflation trap, the reason formatting, and the dispatch plumbing.

Each production line touched was independently reverted and the intended test confirmed to fail by name.

Closes #250.
