### PR TITLE
tests: make the paper-trading compatibility suite compile again (ibx#397)

### DIFF
--- a/tests/ib_paper_compat/account.rs
+++ b/tests/ib_paper_compat/account.rs
@@ -389,6 +389,7 @@ pub(super) fn phase_enriched_order_cache(conns: Conns) -> Conns {
     control_tx.send(ControlCommand::FetchContractDetails {
         req_id: 9999, con_id: 756733, symbol: String::new(),
         sec_type: String::new(), exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).unwrap();
 
     let order_id = next_order_id();
@@ -548,6 +549,7 @@ pub(super) fn phase_enriched_open_orders(conns: Conns) -> Conns {
     control_tx.send(ControlCommand::FetchContractDetails {
         req_id: 9998, con_id: 756733, symbol: String::new(),
         sec_type: String::new(), exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).unwrap();
 
     let order_id = next_order_id();
@@ -773,6 +775,7 @@ pub(super) fn phase_enriched_exec_details(conns: Conns) -> Conns {
     control_tx.send(ControlCommand::FetchContractDetails {
         req_id: 9997, con_id: 756733, symbol: String::new(),
         sec_type: String::new(), exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).unwrap();
 
     let order_id = next_order_id();

--- a/tests/ib_paper_compat/contracts.rs
+++ b/tests/ib_paper_compat/contracts.rs
@@ -23,6 +23,7 @@ pub(super) fn phase_contract_details(conns: Conns) -> Conns {
         req_id: 1200, con_id: 756733,
         symbol: String::new(), sec_type: String::new(),
         exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).unwrap();
     let join = run_hot_loop(hot_loop);
 
@@ -76,6 +77,7 @@ pub(super) fn phase_contract_details_by_symbol(conns: Conns) -> Conns {
         req_id: 7800, con_id: 0,
         symbol: "AAPL".into(), sec_type: "STK".into(),
         exchange: "SMART".into(), currency: "USD".into(),
+        filters: Default::default(),
     }).unwrap();
     let join = run_hot_loop(hot_loop);
 
@@ -228,6 +230,7 @@ pub(super) fn phase_market_rule_id(conns: Conns) -> Conns {
         req_id: 8400, con_id: 756733,
         symbol: String::new(), sec_type: String::new(),
         exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).unwrap();
     let join = run_hot_loop(hot_loop);
 
@@ -319,6 +322,7 @@ pub(super) fn phase_contract_details_channel(conns: Conns) -> Conns {
         req_id: 1001, con_id: 756733,
         symbol: String::new(), sec_type: String::new(),
         exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).unwrap();
     let join = run_hot_loop(hot_loop);
 

--- a/tests/ib_paper_compat/main.rs
+++ b/tests/ib_paper_compat/main.rs
@@ -964,6 +964,7 @@ fn timeout_sweeps_phase_live() {
     control_tx.send(ControlCommand::FetchContractDetails {
         req_id: 6001, con_id: 756733, symbol: String::new(),
         sec_type: String::new(), exchange: String::new(), currency: String::new(),
+        filters: Default::default(),
     }).expect("send details by con_id failed");
     let (rows, end, _) = wait_details(6001, "by-conId SPY");
     assert!(rows >= 1, "by-conId lookup returned no rows");
@@ -973,6 +974,7 @@ fn timeout_sweeps_phase_live() {
     control_tx.send(ControlCommand::FetchContractDetails {
         req_id: 6002, con_id: 0, symbol: "AAPL".into(),
         sec_type: "STK".into(), exchange: String::new(), currency: "USD".into(),
+        filters: Default::default(),
     }).expect("send details by symbol failed");
     let (rows, end, row_after_end) = wait_details(6002, "by-symbol AAPL fan-out");
     assert!(rows >= 1, "by-symbol lookup returned no rows");

--- a/tests/ib_paper_compat/orders.rs
+++ b/tests/ib_paper_compat/orders.rs
@@ -493,7 +493,7 @@ pub(super) fn phase_modify_qty(conns: Conns) -> Conns {
 pub(super) fn phase_trailing_stop(conns: Conns) -> Conns {
     let oid = next_order_id();
     run_submit_cancel_phase(conns, "Phase 19: Trailing Stop Order (SPY)",
-        OrderRequest::SubmitTrailingStop { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, trail_amt: 5_00_000_000 },
+        OrderRequest::SubmitTrailingStop { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, trail_amt: 5_00_000_000, trail_stop_price: 0 },
         false)
 }
 
@@ -502,7 +502,7 @@ pub(super) fn phase_trailing_stop(conns: Conns) -> Conns {
 pub(super) fn phase_trailing_stop_limit(conns: Conns) -> Conns {
     let oid = next_order_id();
     run_submit_cancel_phase(conns, "Phase 20: Trailing Stop Limit Order (SPY)",
-        OrderRequest::SubmitTrailingStopLimit { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, lmt_offset: 1_00_000_000, trail_amt: 5_00_000_000 },
+        OrderRequest::SubmitTrailingStopLimit { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, lmt_offset: 1_00_000_000, trail_amt: 5_00_000_000, trail_stop_price: 0 },
         false)
 }
 
@@ -783,7 +783,7 @@ pub(super) fn phase_short_sell(conns: Conns) -> Conns {
 pub(super) fn phase_trailing_stop_pct(conns: Conns) -> Conns {
     let oid = next_order_id();
     run_submit_cancel_phase(conns, "Phase 36: Trailing Stop Percent Order (SPY)",
-        OrderRequest::SubmitTrailingStopPct { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, trail_pct: 100 },
+        OrderRequest::SubmitTrailingStopPct { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, trail_pct: 100, trail_stop_price: 0 },
         false)
 }
 
@@ -1338,7 +1338,7 @@ pub(super) fn phase_fractional_order(conns: Conns) -> Conns {
 pub(super) fn phase_adjustable_stop_order(conns: Conns) -> Conns {
     let oid = next_order_id();
     run_submit_cancel_phase(conns, "Phase 75: Adjustable Stop Order (SPY)",
-        OrderRequest::SubmitAdjustableStop { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, stop_price: 1_00_000_000, trigger_price: 500_00_000_000, adjusted_order_type: AdjustedOrderType::StopLimit, adjusted_stop_price: 1_50_000_000, adjusted_stop_limit_price: 1_00_000_000 },
+        OrderRequest::SubmitAdjustableStop { order_id: oid, instrument: 0, side: Side::Sell, qty: 1, stop_price: 1_00_000_000, trigger_price: 500_00_000_000, adjusted_order_type: AdjustedOrderType::StopLimit, adjusted_stop_price: 1_50_000_000, adjusted_stop_limit_price: 1_00_000_000, adjusted_trailing_amount: 0, adjustable_trailing_unit: 0 },
         false)
 }
 


### PR DESCRIPTION
## Problem

`tests/ib_paper_compat` does not build. Thirteen call sites construct request and command variants that have since gained fields, so the whole target fails to compile and every phase in it is dead — **fourteen entry points driving a hundred and fifty-four phases** against a paper account.

Nothing reported it. The suite only runs with live credentials, so ordinary development never builds it, and `cargo check` without a target name does not reach it.

It had also quietly become the baseline: work in this repo compares the suite's error set before and after a change to show nothing broke. Thirteen errors is the number being matched, which makes a broken target look like a fixed point.

## What this changes

Each site gets the value it would have had before those fields existed — default contract-details filters, no initial trailing-stop trigger, no adjustable trailing amount or unit. No phase behaviour changes.

The target now compiles clean and enumerates its fourteen tests.

## Why it matters

This is the only end-to-end coverage against a real gateway. Every wire-level claim in this repo currently rests on unit tests and reasoning, with nothing exercising a full session — which is the coverage that catches a tag emitted in the wrong position, an order the gateway rejects, or a reply the parser mishandles.

## Run against a paper account

With it building, the suite runs. All seven phases pass:

```
cancel_by_perm_id_phase_live         PASS   (ibx#191 PR B)
cross_session_recovery_phase_live    PASS   (ibx#191 PR A)
reclaim_and_symbol_search_phase_live PASS   (ibx#233 / ibx#228)
rtt_ping_phase_live                  PASS   (ibx#158)   RTT 3.78 ms
snap_to_tick_phase_live              PASS   (ibx#216)
submit_ex_bracket_child_phase_live   PASS   (ibx#224 / ibx#215)
timeout_sweeps_phase_live            PASS   (ibx#231 / ibx#227)

test result: ok. 7 passed; 0 failed; finished in 195.65s
```

So the phases still describe the server's behaviour correctly — the suite had gone stale in its call sites, not in what it asserts.

## Keeping it built

`cargo check --tests` reaches every target by name and would have caught each of these on the day the field was added. #300 adds a CI workflow; this belongs in it.

Closes #397.
