### PR TITLE
engine: park the hot loop while every transport is down (ibx#399)

### DIFF
--- a/src/engine/hot_loop/mod.rs
+++ b/src/engine/hot_loop/mod.rs
@@ -361,6 +361,17 @@ impl HotLoop {
 
             // 6. Wake any waiting consumers (e.g. Python event loop)
             self.shared.notify();
+
+            // 7. With every transport down there is no socket to poll and no
+            //    socket to be quick for, so the spin above buys nothing and
+            //    costs a core — on a laptop that is the battery and the fans,
+            //    which is how this gets noticed (ibx#399). Parking only in that
+            //    state leaves the connected path exactly as it was; a reconnect
+            //    is scheduled on a backoff measured in seconds, so a millisecond
+            //    here delays nothing, including shutdown.
+            if self.farm.disconnected && self.ccp.disconnected && self.hmds.disconnected {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
         }
     }
 
@@ -1610,6 +1621,38 @@ mod tests {
         engine.poll_once();
 
         assert!(shared.take_connection_lost());
+    }
+
+    /// A fully disconnected engine used to run the loop flat out: every poll
+    /// returns immediately with nothing, so the iteration count was bounded
+    /// only by clock speed and one core sat at 100% until the process was
+    /// killed (ibx#399).
+    ///
+    /// Counted in iterations rather than CPU time, because that is what tells a
+    /// parked loop from a spinning one on any machine. A free spin manages tens
+    /// of thousands in this window; parked it is one per millisecond.
+    #[test]
+    fn a_loop_with_every_transport_down_does_not_spin() {
+        let shared = Arc::new(SharedState::new());
+        let (tx, rx) = crossbeam_channel::bounded(1);
+        let mut engine = HotLoop::new(shared, None, None);
+        engine.set_control_rx(rx);
+        engine.farm.disconnected = true;
+        engine.ccp.disconnected = true;
+        engine.hmds.disconnected = true;
+
+        let handle = std::thread::spawn(move || {
+            engine.run();
+            engine.context.loop_iterations
+        });
+        std::thread::sleep(std::time::Duration::from_millis(60));
+        tx.send(ControlCommand::Shutdown).unwrap();
+        let iterations = handle.join().expect("the loop must exit on Shutdown");
+
+        assert!(
+            iterations < 10_000,
+            "a parked loop runs on the order of 60 iterations in 60ms; got {iterations}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The hot loop busy-polls the farm, auth and historical sockets and never yields. While a session is up that is the design: a poll that finds a tick returns it with no syscall in the way, and `core_id` exists so the spin can own a core.
- With every transport down there is nothing to poll. Each pass runs the same three polls, gets nothing, and starts again — measured at roughly 925,000 iterations a second, which is one core pinned at 100% for the length of the disconnect.
- Parking 1 ms in that state, and only that state, leaves the connected path byte for byte as it was. Nothing waits on the loop meanwhile: reconnects are already scheduled on the ibx#218 backoff in seconds, and shutdown is read once per pass.

## On the reported cause

The report puts the CPU on the reconnect scheduler retrying in a tight loop. The timestamps in its own log are two minutes apart:

```
09:48:11.537  CCP auto-reconnect skipped: no credentials
09:50:21.157  CCP auto-reconnect skipped: no credentials
```

That is the 60-second re-check in `maybe_spawn_ccp_reconnect` doing its job. The spin is the loop body itself, and it is there whether or not credentials are cached — a connected engine spins too, which is intended, and a disconnected one spins for nothing, which is not.

Closes #399.

## Test plan

- [x] `cargo test --lib` — 803 pass. The two `config::expiry_tests` failures are pre-existing on main and identical on a pristine checkout of 9367845.
- [x] `a_loop_with_every_transport_down_does_not_spin` drives `run()` with all three transports marked down, shuts it down after 60 ms and asserts the iteration count. Counting iterations rather than CPU time is what separates a parked loop from a spinning one on any machine.
- [x] Mutation: deleting the sleep takes that test from ~60 iterations to 55,554 in the same window, and it fails by name.
- [ ] Not covered: the laptop sleep/resume path the report describes. The guard is on the disconnected flags, so it does not depend on how the disconnect happened.